### PR TITLE
Monitoring M3 (People + identity), M5-lite caching, and inbox polish

### DIFF
--- a/lib/api_cache.dart
+++ b/lib/api_cache.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:shared_preferences/shared_preferences.dart';
 
 class CachedHttpClient extends http.BaseClient {
   CachedHttpClient({http.Client? inner, ResponseCache? cache})
@@ -178,76 +177,26 @@ class CachedHttpClient extends http.BaseClient {
   }
 }
 
+/// In-memory (per-isolate) response cache. Bodies are never persisted to disk,
+/// so private-repo data is never written unencrypted and cache hits incur no
+/// disk writes. The cache resets on app restart (a within-session cache is what
+/// matters for rate-limit relief).
 class ResponseCache {
-  static const String prefsKey = 'api_response_cache';
   static const int maxEntries = 200;
 
-  // Serializes read-modify-write access so concurrent GETs (bounded-concurrency
-  // fetches all share one cache) can't clobber each other's entries. Static so
-  // every ResponseCache instance serializes against the shared prefs key.
-  static Future<void> _lock = Future<void>.value();
-
-  static Future<T> _runLocked<T>(Future<T> Function() action) {
-    final result = _lock.then((_) => action());
-    _lock = result.then((_) {}, onError: (_) {});
-    return result;
-  }
+  final Map<String, CachedResponse> _entries = <String, CachedResponse>{};
 
   Future<CachedResponse?> get(String key) async {
-    return _runLocked(() async {
-      final prefs = await SharedPreferences.getInstance();
-      final entries = _readEntries(prefs);
-      final cached = entries[key];
-      if (cached == null) return null;
-
-      final touched = cached.copyWith(lastUsed: DateTime.now().toUtc());
-      entries[key] = touched;
-      await _writeEntries(prefs, entries);
-      return touched;
-    });
+    final cached = _entries[key];
+    if (cached == null) return null;
+    final touched = cached.copyWith(lastUsed: DateTime.now().toUtc());
+    _entries[key] = touched;
+    return touched;
   }
 
   Future<void> put(String key, CachedResponse resp) async {
-    return _runLocked(() async {
-      final prefs = await SharedPreferences.getInstance();
-      final entries = _readEntries(prefs);
-      entries[key] = resp.copyWith(lastUsed: DateTime.now().toUtc());
-      _evictOldEntries(entries);
-      await _writeEntries(prefs, entries);
-    });
-  }
-
-  Map<String, CachedResponse> _readEntries(SharedPreferences prefs) {
-    final raw = prefs.getString(prefsKey);
-    if (raw == null || raw.isEmpty) return <String, CachedResponse>{};
-
-    try {
-      final decoded = jsonDecode(raw);
-      if (decoded is! Map) return <String, CachedResponse>{};
-      final entries = <String, CachedResponse>{};
-      for (final entry in decoded.entries) {
-        final key = entry.key;
-        final value = entry.value;
-        if (key is! String || value is! Map) continue;
-        final cached = CachedResponse.fromJson(
-          Map<String, dynamic>.from(value),
-        );
-        if (cached != null) entries[key] = cached;
-      }
-      return entries;
-    } catch (_) {
-      return <String, CachedResponse>{};
-    }
-  }
-
-  Future<void> _writeEntries(
-    SharedPreferences prefs,
-    Map<String, CachedResponse> entries,
-  ) async {
-    await prefs.setString(
-      prefsKey,
-      jsonEncode(entries.map((key, value) => MapEntry(key, value.toJson()))),
-    );
+    _entries[key] = resp.copyWith(lastUsed: DateTime.now().toUtc());
+    _evictOldEntries(_entries);
   }
 
   void _evictOldEntries(Map<String, CachedResponse> entries) {
@@ -277,41 +226,6 @@ class CachedResponse {
   final DateTime storedAt;
   final DateTime lastUsed;
   final Map<String, String> headers;
-
-  Map<String, dynamic> toJson() {
-    return {
-      'etag': etag,
-      'body': body,
-      'statusCode': statusCode,
-      'storedAt': storedAt.toUtc().toIso8601String(),
-      'lastUsed': lastUsed.toUtc().toIso8601String(),
-      'headers': headers,
-    };
-  }
-
-  static CachedResponse? fromJson(Map<String, dynamic> json) {
-    final etag = json['etag'];
-    final body = json['body'];
-    final statusCode = _intValue(json['statusCode']);
-    final storedAt = _dateValue(json['storedAt']);
-    if (etag is! String ||
-        body is! String ||
-        statusCode == null ||
-        storedAt == null) {
-      return null;
-    }
-
-    final headers = _stringMap(json['headers']);
-    headers.putIfAbsent('etag', () => etag);
-    return CachedResponse(
-      etag: etag,
-      body: body,
-      statusCode: statusCode,
-      storedAt: storedAt,
-      lastUsed: _dateValue(json['lastUsed']) ?? storedAt,
-      headers: headers,
-    );
-  }
 
   CachedResponse copyWith({
     String? etag,
@@ -454,30 +368,6 @@ String? _headerValue(Map<String, String> headers, String name) {
     if (entry.key.toLowerCase() == lowerName) return entry.value;
   }
   return null;
-}
-
-int? _intValue(dynamic value) {
-  if (value is int) return value;
-  if (value is String) return int.tryParse(value);
-  return null;
-}
-
-DateTime? _dateValue(dynamic value) {
-  if (value is! String) return null;
-  return DateTime.tryParse(value);
-}
-
-Map<String, String> _stringMap(dynamic value) {
-  final map = <String, String>{};
-  if (value is! Map) return map;
-  for (final entry in value.entries) {
-    final key = entry.key;
-    final entryValue = entry.value;
-    if (key is String && entryValue is String) {
-      map[key] = entryValue;
-    }
-  }
-  return map;
 }
 
 String _stableHash(String value) {

--- a/lib/api_cache.dart
+++ b/lib/api_cache.dart
@@ -124,24 +124,38 @@ class ResponseCache {
   static const String prefsKey = 'api_response_cache';
   static const int maxEntries = 200;
 
-  Future<CachedResponse?> get(String key) async {
-    final prefs = await SharedPreferences.getInstance();
-    final entries = _readEntries(prefs);
-    final cached = entries[key];
-    if (cached == null) return null;
+  // Serializes read-modify-write access so concurrent GETs (bounded-concurrency
+  // fetches all share one cache) can't clobber each other's entries.
+  Future<void> _lock = Future<void>.value();
 
-    final touched = cached.copyWith(lastUsed: DateTime.now().toUtc());
-    entries[key] = touched;
-    await _writeEntries(prefs, entries);
-    return touched;
+  Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  Future<CachedResponse?> get(String key) async {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final entries = _readEntries(prefs);
+      final cached = entries[key];
+      if (cached == null) return null;
+
+      final touched = cached.copyWith(lastUsed: DateTime.now().toUtc());
+      entries[key] = touched;
+      await _writeEntries(prefs, entries);
+      return touched;
+    });
   }
 
   Future<void> put(String key, CachedResponse resp) async {
-    final prefs = await SharedPreferences.getInstance();
-    final entries = _readEntries(prefs);
-    entries[key] = resp.copyWith(lastUsed: DateTime.now().toUtc());
-    _evictOldEntries(entries);
-    await _writeEntries(prefs, entries);
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final entries = _readEntries(prefs);
+      entries[key] = resp.copyWith(lastUsed: DateTime.now().toUtc());
+      _evictOldEntries(entries);
+      await _writeEntries(prefs, entries);
+    });
   }
 
   Map<String, CachedResponse> _readEntries(SharedPreferences prefs) {
@@ -408,10 +422,14 @@ Map<String, String> _stringMap(dynamic value) {
 }
 
 String _stableHash(String value) {
-  var hash = 0x811c9dc5;
+  // 64-bit FNV-1a (via BigInt to stay exact on all platforms) so auth-scope
+  // collisions are negligible and token-scoped cache isolation holds.
+  final mask = (BigInt.one << 64) - BigInt.one;
+  final prime = BigInt.parse('1099511628211'); // 0x100000001b3
+  var hash = BigInt.parse('14695981039346656037'); // 0xcbf29ce484222325
   for (final codeUnit in value.codeUnits) {
-    hash ^= codeUnit;
-    hash = (hash * 0x01000193) & 0xffffffff;
+    hash = (hash ^ BigInt.from(codeUnit)) & mask;
+    hash = (hash * prime) & mask;
   }
-  return hash.toRadixString(16).padLeft(8, '0');
+  return hash.toRadixString(16).padLeft(16, '0');
 }

--- a/lib/api_cache.dart
+++ b/lib/api_cache.dart
@@ -13,15 +13,33 @@ class CachedHttpClient extends http.BaseClient {
   final ResponseCache _cache;
   final Map<String, RateLimitStatus> _rateLimits = <String, RateLimitStatus>{};
 
-  /// Merged GitHub rate-limit view across api.github.com token scopes.
+  /// Worst-case merged GitHub rate-limit view across api.github.com token
+  /// scopes (lowest remaining, latest reset, largest retry-after).
   RateLimitStatus get githubRateLimit {
-    var result = const RateLimitStatus();
+    int? remaining;
+    DateTime? resetAt;
+    Duration? retryAfter;
     for (final entry in _rateLimits.entries) {
-      if (entry.key.startsWith('api.github.com|')) {
-        result = result.merge(entry.value);
+      if (!entry.key.startsWith('api.github.com|')) continue;
+      final status = entry.value;
+      if (status.remaining != null &&
+          (remaining == null || status.remaining! < remaining)) {
+        remaining = status.remaining;
+      }
+      if (status.resetAt != null &&
+          (resetAt == null || status.resetAt!.isAfter(resetAt))) {
+        resetAt = status.resetAt;
+      }
+      if (status.retryAfter != null &&
+          (retryAfter == null || status.retryAfter! > retryAfter)) {
+        retryAfter = status.retryAfter;
       }
     }
-    return result;
+    return RateLimitStatus(
+      remaining: remaining,
+      resetAt: resetAt,
+      retryAfter: retryAfter,
+    );
   }
 
   String _scopeKey(http.BaseRequest request) {

--- a/lib/api_cache.dart
+++ b/lib/api_cache.dart
@@ -183,10 +183,11 @@ class ResponseCache {
   static const int maxEntries = 200;
 
   // Serializes read-modify-write access so concurrent GETs (bounded-concurrency
-  // fetches all share one cache) can't clobber each other's entries.
-  Future<void> _lock = Future<void>.value();
+  // fetches all share one cache) can't clobber each other's entries. Static so
+  // every ResponseCache instance serializes against the shared prefs key.
+  static Future<void> _lock = Future<void>.value();
 
-  Future<T> _runLocked<T>(Future<T> Function() action) {
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
     final result = _lock.then((_) => action());
     _lock = result.then((_) {}, onError: (_) {});
     return result;

--- a/lib/api_cache.dart
+++ b/lib/api_cache.dart
@@ -133,8 +133,48 @@ class CachedHttpClient extends http.BaseClient {
         retryAfter: parsed.retryAfter,
       );
     }
-    _rateLimits[scopeKey] =
-        (_rateLimits[scopeKey] ?? const RateLimitStatus()).merge(parsed);
+    _rateLimits[scopeKey] = _mergeRateLimit(_rateLimits[scopeKey], parsed);
+  }
+
+  /// Conservatively merges a rate-limit [update] into the [existing] state so
+  /// out-of-order concurrent responses can't inflate the remaining budget. A
+  /// strictly newer window (later resetAt) replaces the old values; otherwise
+  /// we keep the lowest remaining, latest reset, and longest retry-after.
+  static RateLimitStatus _mergeRateLimit(
+    RateLimitStatus? existing,
+    RateLimitStatus update,
+  ) {
+    if (existing == null) return update;
+    final existingReset = existing.resetAt;
+    final updateReset = update.resetAt;
+    if (existingReset != null &&
+        updateReset != null &&
+        updateReset.isAfter(existingReset)) {
+      return update; // new window
+    }
+    int? remaining;
+    if (existing.remaining != null && update.remaining != null) {
+      remaining = existing.remaining! < update.remaining!
+          ? existing.remaining
+          : update.remaining;
+    } else {
+      remaining = update.remaining ?? existing.remaining;
+    }
+    DateTime? resetAt = existing.resetAt;
+    if (updateReset != null &&
+        (resetAt == null || updateReset.isAfter(resetAt))) {
+      resetAt = updateReset;
+    }
+    Duration? retryAfter = existing.retryAfter;
+    if (update.retryAfter != null &&
+        (retryAfter == null || update.retryAfter! > retryAfter)) {
+      retryAfter = update.retryAfter;
+    }
+    return RateLimitStatus(
+      remaining: remaining,
+      resetAt: resetAt,
+      retryAfter: retryAfter,
+    );
   }
 }
 

--- a/lib/api_cache.dart
+++ b/lib/api_cache.dart
@@ -1,0 +1,417 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CachedHttpClient extends http.BaseClient {
+  CachedHttpClient({http.Client? inner, ResponseCache? cache})
+      : _inner = inner ?? http.Client(),
+        _cache = cache ?? ResponseCache();
+
+  final http.Client _inner;
+  final ResponseCache _cache;
+  final Map<String, RateLimitStatus> _rateLimits = <String, RateLimitStatus>{};
+
+  /// Merged GitHub rate-limit view across api.github.com token scopes.
+  RateLimitStatus get githubRateLimit {
+    var result = const RateLimitStatus();
+    for (final entry in _rateLimits.entries) {
+      if (entry.key.startsWith('api.github.com|')) {
+        result = result.merge(entry.value);
+      }
+    }
+    return result;
+  }
+
+  String _scopeKey(http.BaseRequest request) {
+    final authorization = _headerValue(request.headers, 'authorization');
+    final scope = authorization == null || authorization.isEmpty
+        ? ''
+        : _stableHash(authorization);
+    return '${request.url.host}|$scope';
+  }
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final scopeKey = _scopeKey(request);
+    if (request.method.toUpperCase() != 'GET') {
+      final response = await _inner.send(request);
+      _updateRateLimit(scopeKey, response.headers);
+      return response;
+    }
+
+    final key = cacheKey(request);
+    final cached = await _cache.get(key);
+    if (shouldUseCachedResponseForRateLimit(
+      _rateLimits[scopeKey] ?? const RateLimitStatus(),
+      DateTime.now().toUtc(),
+    )) {
+      if (cached != null) {
+        return _streamedFromCached(cached, request);
+      }
+      return _streamedText(
+        'Rate limit exceeded and no cached response is available.',
+        429,
+        request,
+        reasonPhrase: 'Too Many Requests',
+      );
+    }
+
+    if (cached != null && cached.etag.isNotEmpty) {
+      request.headers['If-None-Match'] = cached.etag;
+    }
+
+    final response = await _inner.send(request);
+    _updateRateLimit(scopeKey, response.headers);
+    final bytes = await response.stream.toBytes();
+
+    if (response.statusCode == 304 && cached != null) {
+      return _streamedFromCached(cached, request, statusCode: 200);
+    }
+
+    if (response.statusCode == 200) {
+      final etag = _headerValue(response.headers, 'etag');
+      if (etag != null && etag.isNotEmpty) {
+        await _cache.put(
+          key,
+          CachedResponse(
+            etag: etag,
+            body: utf8.decode(bytes, allowMalformed: true),
+            statusCode: 200,
+            storedAt: DateTime.now().toUtc(),
+            headers: response.headers,
+          ),
+        );
+      }
+    }
+
+    return _streamedFromBytes(
+      bytes,
+      response.statusCode,
+      request,
+      headers: response.headers,
+      isRedirect: response.isRedirect,
+      persistentConnection: response.persistentConnection,
+      reasonPhrase: response.reasonPhrase,
+    );
+  }
+
+  @override
+  void close() {
+    _inner.close();
+  }
+
+  void _updateRateLimit(String scopeKey, Map<String, String> headers) {
+    var parsed = parseRateLimit(headers);
+    if (!parsed.hasValues) return;
+    if (parsed.retryAfter != null) {
+      // Secondary rate limit (e.g. a 403 with Retry-After): back off until
+      // now + Retry-After by modelling it as an exhausted window.
+      final retryUntil = DateTime.now().toUtc().add(parsed.retryAfter!);
+      parsed = RateLimitStatus(
+        remaining: 0,
+        resetAt: retryUntil,
+        retryAfter: parsed.retryAfter,
+      );
+    }
+    _rateLimits[scopeKey] =
+        (_rateLimits[scopeKey] ?? const RateLimitStatus()).merge(parsed);
+  }
+}
+
+class ResponseCache {
+  static const String prefsKey = 'api_response_cache';
+  static const int maxEntries = 200;
+
+  Future<CachedResponse?> get(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    final entries = _readEntries(prefs);
+    final cached = entries[key];
+    if (cached == null) return null;
+
+    final touched = cached.copyWith(lastUsed: DateTime.now().toUtc());
+    entries[key] = touched;
+    await _writeEntries(prefs, entries);
+    return touched;
+  }
+
+  Future<void> put(String key, CachedResponse resp) async {
+    final prefs = await SharedPreferences.getInstance();
+    final entries = _readEntries(prefs);
+    entries[key] = resp.copyWith(lastUsed: DateTime.now().toUtc());
+    _evictOldEntries(entries);
+    await _writeEntries(prefs, entries);
+  }
+
+  Map<String, CachedResponse> _readEntries(SharedPreferences prefs) {
+    final raw = prefs.getString(prefsKey);
+    if (raw == null || raw.isEmpty) return <String, CachedResponse>{};
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return <String, CachedResponse>{};
+      final entries = <String, CachedResponse>{};
+      for (final entry in decoded.entries) {
+        final key = entry.key;
+        final value = entry.value;
+        if (key is! String || value is! Map) continue;
+        final cached = CachedResponse.fromJson(
+          Map<String, dynamic>.from(value),
+        );
+        if (cached != null) entries[key] = cached;
+      }
+      return entries;
+    } catch (_) {
+      return <String, CachedResponse>{};
+    }
+  }
+
+  Future<void> _writeEntries(
+    SharedPreferences prefs,
+    Map<String, CachedResponse> entries,
+  ) async {
+    await prefs.setString(
+      prefsKey,
+      jsonEncode(entries.map((key, value) => MapEntry(key, value.toJson()))),
+    );
+  }
+
+  void _evictOldEntries(Map<String, CachedResponse> entries) {
+    if (entries.length <= maxEntries) return;
+    final newest = entries.entries.toList()
+      ..sort((a, b) => b.value.lastUsed.compareTo(a.value.lastUsed));
+    entries
+      ..clear()
+      ..addEntries(newest.take(maxEntries));
+  }
+}
+
+class CachedResponse {
+  CachedResponse({
+    required this.etag,
+    required this.body,
+    required this.statusCode,
+    required this.storedAt,
+    DateTime? lastUsed,
+    Map<String, String> headers = const <String, String>{},
+  })  : lastUsed = lastUsed ?? storedAt,
+        headers = Map.unmodifiable(headers);
+
+  final String etag;
+  final String body;
+  final int statusCode;
+  final DateTime storedAt;
+  final DateTime lastUsed;
+  final Map<String, String> headers;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'etag': etag,
+      'body': body,
+      'statusCode': statusCode,
+      'storedAt': storedAt.toUtc().toIso8601String(),
+      'lastUsed': lastUsed.toUtc().toIso8601String(),
+      'headers': headers,
+    };
+  }
+
+  static CachedResponse? fromJson(Map<String, dynamic> json) {
+    final etag = json['etag'];
+    final body = json['body'];
+    final statusCode = _intValue(json['statusCode']);
+    final storedAt = _dateValue(json['storedAt']);
+    if (etag is! String ||
+        body is! String ||
+        statusCode == null ||
+        storedAt == null) {
+      return null;
+    }
+
+    final headers = _stringMap(json['headers']);
+    headers.putIfAbsent('etag', () => etag);
+    return CachedResponse(
+      etag: etag,
+      body: body,
+      statusCode: statusCode,
+      storedAt: storedAt,
+      lastUsed: _dateValue(json['lastUsed']) ?? storedAt,
+      headers: headers,
+    );
+  }
+
+  CachedResponse copyWith({
+    String? etag,
+    String? body,
+    int? statusCode,
+    DateTime? storedAt,
+    DateTime? lastUsed,
+    Map<String, String>? headers,
+  }) {
+    return CachedResponse(
+      etag: etag ?? this.etag,
+      body: body ?? this.body,
+      statusCode: statusCode ?? this.statusCode,
+      storedAt: storedAt ?? this.storedAt,
+      lastUsed: lastUsed ?? this.lastUsed,
+      headers: headers ?? this.headers,
+    );
+  }
+}
+
+class RateLimitStatus {
+  const RateLimitStatus({
+    this.remaining,
+    this.resetAt,
+    this.retryAfter,
+  });
+
+  final int? remaining;
+  final DateTime? resetAt;
+  final Duration? retryAfter;
+
+  bool get hasValues =>
+      remaining != null || resetAt != null || retryAfter != null;
+
+  RateLimitStatus merge(RateLimitStatus update) {
+    return RateLimitStatus(
+      remaining: update.remaining ?? remaining,
+      resetAt: update.resetAt ?? resetAt,
+      retryAfter: update.retryAfter ?? retryAfter,
+    );
+  }
+}
+
+RateLimitStatus parseRateLimit(Map<String, String> headers) {
+  final remaining = int.tryParse(
+    _headerValue(headers, 'x-ratelimit-remaining')?.trim() ?? '',
+  );
+  final resetSeconds = int.tryParse(
+    _headerValue(headers, 'x-ratelimit-reset')?.trim() ?? '',
+  );
+  final retryAfterSeconds = int.tryParse(
+    _headerValue(headers, 'retry-after')?.trim() ?? '',
+  );
+
+  return RateLimitStatus(
+    remaining: remaining,
+    resetAt: resetSeconds == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(
+            resetSeconds * 1000,
+            isUtc: true,
+          ),
+    retryAfter:
+        retryAfterSeconds == null ? null : Duration(seconds: retryAfterSeconds),
+  );
+}
+
+bool shouldUseCachedResponseForRateLimit(
+  RateLimitStatus status,
+  DateTime now,
+) {
+  final resetAt = status.resetAt;
+  return status.remaining == 0 && resetAt != null && resetAt.isAfter(now);
+}
+
+String cacheKey(http.BaseRequest request) {
+  final authorization = _headerValue(request.headers, 'authorization');
+  final authScope = authorization == null || authorization.isEmpty
+      ? ''
+      : ' auth=${_stableHash(authorization)}';
+  return '${request.method} ${request.url}$authScope';
+}
+
+http.StreamedResponse _streamedFromCached(
+    CachedResponse cached, http.BaseRequest request,
+    {int? statusCode}) {
+  final bytes = utf8.encode(cached.body);
+  final headers = Map<String, String>.from(cached.headers);
+  headers.putIfAbsent('etag', () => cached.etag);
+  final effectiveStatusCode = statusCode ?? cached.statusCode;
+  return _streamedFromBytes(
+    bytes,
+    effectiveStatusCode,
+    request,
+    headers: headers,
+    reasonPhrase: effectiveStatusCode == 200 ? 'OK' : null,
+  );
+}
+
+http.StreamedResponse _streamedText(
+  String body,
+  int statusCode,
+  http.BaseRequest request, {
+  String? reasonPhrase,
+}) {
+  final bytes = utf8.encode(body);
+  return _streamedFromBytes(
+    bytes,
+    statusCode,
+    request,
+    headers: const {'content-type': 'text/plain; charset=utf-8'},
+    reasonPhrase: reasonPhrase,
+  );
+}
+
+http.StreamedResponse _streamedFromBytes(
+  List<int> bytes,
+  int statusCode,
+  http.BaseRequest request, {
+  Map<String, String> headers = const <String, String>{},
+  bool isRedirect = false,
+  bool persistentConnection = true,
+  String? reasonPhrase,
+}) {
+  return http.StreamedResponse(
+    Stream<List<int>>.value(bytes),
+    statusCode,
+    contentLength: bytes.length,
+    request: request,
+    headers: headers,
+    isRedirect: isRedirect,
+    persistentConnection: persistentConnection,
+    reasonPhrase: reasonPhrase,
+  );
+}
+
+String? _headerValue(Map<String, String> headers, String name) {
+  final lowerName = name.toLowerCase();
+  for (final entry in headers.entries) {
+    if (entry.key.toLowerCase() == lowerName) return entry.value;
+  }
+  return null;
+}
+
+int? _intValue(dynamic value) {
+  if (value is int) return value;
+  if (value is String) return int.tryParse(value);
+  return null;
+}
+
+DateTime? _dateValue(dynamic value) {
+  if (value is! String) return null;
+  return DateTime.tryParse(value);
+}
+
+Map<String, String> _stringMap(dynamic value) {
+  final map = <String, String>{};
+  if (value is! Map) return map;
+  for (final entry in value.entries) {
+    final key = entry.key;
+    final entryValue = entry.value;
+    if (key is String && entryValue is String) {
+      map[key] = entryValue;
+    }
+  }
+  return map;
+}
+
+String _stableHash(String value) {
+  var hash = 0x811c9dc5;
+  for (final codeUnit in value.codeUnits) {
+    hash ^= codeUnit;
+    hash = (hash * 0x01000193) & 0xffffffff;
+  }
+  return hash.toRadixString(16).padLeft(8, '0');
+}

--- a/lib/app_http.dart
+++ b/lib/app_http.dart
@@ -1,0 +1,11 @@
+import 'api_cache.dart';
+
+/// App-wide HTTP client with ETag caching + rate-limit awareness.
+///
+/// It lives for the whole app lifetime (never closed) so its response cache and
+/// rate-limit state are shared across every page that fetches from GitHub/ADO.
+class AppHttp {
+  AppHttp._();
+
+  static final CachedHttpClient client = CachedHttpClient();
+}

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -1,10 +1,17 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'app_http.dart';
 import 'attention_service.dart';
+import 'identity_store.dart';
+import 'notification_service.dart';
+import 'snooze_store.dart';
 
 /// Shows a ranked list of items that need the user's attention across all
-/// monitored repositories (PRs waiting on review, stale PRs, and errors).
+/// monitored repositories (PRs waiting on review, changes requested, stale PRs,
+/// and errors). Supports snooze/dismiss and a "Mine" filter.
 class AttentionInboxPage extends StatefulWidget {
   const AttentionInboxPage({super.key});
 
@@ -15,6 +22,8 @@ class AttentionInboxPage extends StatefulWidget {
 class _AttentionInboxPageState extends State<AttentionInboxPage> {
   List<AttentionItem> _items = const [];
   bool _loading = true;
+  bool _mineOnly = false;
+  bool _identitySet = false;
   String? _error;
   DateTime? _lastChecked;
 
@@ -24,19 +33,32 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
     _load();
   }
 
+  List<AttentionItem> get _visibleItems =>
+      _mineOnly ? _items.where((i) => i.isMine).toList() : _items;
+
   Future<void> _load() async {
     setState(() {
       _loading = true;
       _error = null;
     });
     try {
-      final items = await AttentionService.computeAll();
+      final snoozed = await SnoozeStore.snoozedIds();
+      final selfGithub = await IdentityStore.selfGithubLogins();
+      final selfAdo = await IdentityStore.selfAdoNames();
+      final items = await AttentionService.computeAll(
+        client: AppHttp.client,
+        snoozedIds: snoozed,
+        selfGithubLogins: selfGithub,
+        selfAdoNames: selfAdo,
+      );
       if (!mounted) return;
       setState(() {
         _items = items;
+        _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
         _lastChecked = DateTime.now();
         _loading = false;
       });
+      unawaited(NotificationService.notifyNewAttention(items));
     } catch (e) {
       debugPrint('AttentionInbox failed to load: $e');
       if (!mounted) return;
@@ -54,6 +76,13 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       appBar: AppBar(
         title: const Text('Attention'),
         actions: [
+          IconButton(
+            icon: Icon(_mineOnly ? Icons.person : Icons.groups),
+            tooltip:
+                _mineOnly ? 'Showing yours — tap for all' : 'Show only mine',
+            onPressed:
+                _loading ? null : () => setState(() => _mineOnly = !_mineOnly),
+          ),
           IconButton(
             icon: const Icon(Icons.refresh),
             tooltip: 'Refresh',
@@ -79,58 +108,137 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       );
     }
 
-    if (_items.isEmpty) {
-      return ListView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        children: [
-          const SizedBox(height: 140),
-          Center(
-            child: Icon(Icons.check_circle_outline,
-                size: 56, color: Colors.green[400]),
-          ),
-          const SizedBox(height: 12),
-          const Center(child: Text('Nothing needs your attention right now.')),
-          const SizedBox(height: 6),
-          Center(
-            child: Text(
-              _lastChecked == null
-                  ? 'Pull down to refresh.'
-                  : 'Checked ${_relativeTime(_lastChecked!)} · pull down to refresh.',
-              style: TextStyle(color: Colors.grey[600], fontSize: 12),
-            ),
-          ),
-        ],
-      );
-    }
+    final visible = _visibleItems;
+    if (visible.isEmpty) return _buildEmptyState();
 
     return ListView.separated(
       physics: const AlwaysScrollableScrollPhysics(),
-      itemCount: _items.length + 1,
+      itemCount: visible.length + 1,
       separatorBuilder: (_, __) => const Divider(height: 1),
       itemBuilder: (context, index) {
-        if (index == 0) {
-          return Padding(
-            padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
-            child: Text(
-              '${_items.length} item${_items.length == 1 ? '' : 's'} '
-              'need${_items.length == 1 ? 's' : ''} attention'
-              '${_lastChecked == null ? '' : ' · checked ${_relativeTime(_lastChecked!)}'}',
-              style: TextStyle(color: Colors.grey[600], fontSize: 12),
-            ),
-          );
-        }
-        final item = _items[index - 1];
-        final visual = _visualFor(item.category);
-        return ListTile(
-          key: ValueKey(item.id),
-          leading: Icon(visual.icon, color: visual.color),
-          title: Text(item.title),
-          subtitle: Text(item.subtitle),
-          trailing:
-              item.url != null ? const Icon(Icons.open_in_new, size: 16) : null,
-          onTap: item.url == null ? null : () => _open(item.url!),
-        );
+        if (index == 0) return _buildHeader(visible.length);
+        return _buildItemTile(visible[index - 1]);
       },
+    );
+  }
+
+  Widget _buildEmptyState() {
+    final String message;
+    if (_items.isEmpty) {
+      message = 'Nothing needs your attention right now.';
+    } else if (_mineOnly && !_identitySet) {
+      message = 'Set your identity in People to use the "Mine" filter.';
+    } else {
+      message = 'None of the current items are yours.';
+    }
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        const SizedBox(height: 140),
+        Center(
+          child: Icon(Icons.check_circle_outline,
+              size: 56, color: Colors.green[400]),
+        ),
+        const SizedBox(height: 12),
+        Center(child: Text(message, textAlign: TextAlign.center)),
+        const SizedBox(height: 6),
+        Center(
+          child: Text(
+            _lastChecked == null
+                ? 'Pull down to refresh.'
+                : 'Checked ${_relativeTime(_lastChecked!)} · pull down to refresh.',
+            style: TextStyle(color: Colors.grey[600], fontSize: 12),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildHeader(int count) {
+    final noun = 'item${count == 1 ? '' : 's'}';
+    final label = _mineOnly
+        ? '$count $noun yours'
+        : '$count $noun need${count == 1 ? 's' : ''} attention';
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
+      child: Text(
+        '$label${_lastChecked == null ? '' : ' · checked ${_relativeTime(_lastChecked!)}'}',
+        style: TextStyle(color: Colors.grey[600], fontSize: 12),
+      ),
+    );
+  }
+
+  Widget _buildItemTile(AttentionItem item) {
+    final visual = _visualFor(item.category);
+    return Dismissible(
+      key: ValueKey(item.id),
+      background: _swipeBackground(
+        alignment: Alignment.centerLeft,
+        color: Colors.blueGrey,
+        icon: Icons.snooze,
+        label: 'Snooze 1 day',
+      ),
+      secondaryBackground: _swipeBackground(
+        alignment: Alignment.centerRight,
+        color: Colors.red,
+        icon: Icons.notifications_off,
+        label: 'Dismiss',
+      ),
+      onDismissed: (direction) => _onDismissed(item, direction),
+      child: ListTile(
+        leading: Icon(visual.icon, color: visual.color),
+        title: Text(item.title),
+        subtitle: Text(item.subtitle),
+        trailing:
+            item.url != null ? const Icon(Icons.open_in_new, size: 16) : null,
+        onTap: item.url == null ? null : () => _open(item.url!),
+      ),
+    );
+  }
+
+  Widget _swipeBackground({
+    required Alignment alignment,
+    required Color color,
+    required IconData icon,
+    required String label,
+  }) {
+    return Container(
+      color: color,
+      alignment: alignment,
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, color: Colors.white),
+          const SizedBox(width: 8),
+          Text(label, style: const TextStyle(color: Colors.white)),
+        ],
+      ),
+    );
+  }
+
+  void _onDismissed(AttentionItem item, DismissDirection direction) {
+    final dismissForever = direction == DismissDirection.endToStart;
+    // Remove synchronously so the dismissed widget is gone before the next
+    // build, then persist the snooze in the background.
+    setState(() => _items = _items.where((i) => i.id != item.id).toList());
+    final pending = dismissForever
+        ? SnoozeStore.snooze(item.id)
+        : SnoozeStore.snooze(item.id, forDuration: const Duration(days: 1));
+    unawaited(pending);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(dismissForever ? 'Dismissed' : 'Snoozed for 1 day'),
+        action: SnackBarAction(
+          label: 'Undo',
+          onPressed: () async {
+            await pending; // ensure the snooze write finished before undoing
+            await SnoozeStore.unsnooze(item.id);
+            if (!mounted) return;
+            await _load();
+          },
+        ),
+      ),
     );
   }
 

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -232,7 +232,11 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         action: SnackBarAction(
           label: 'Undo',
           onPressed: () async {
-            await pending; // ensure the snooze write finished before undoing
+            // Ensure the snooze write finished before undoing, but never let a
+            // persistence error prevent the undo/reload.
+            try {
+              await pending;
+            } catch (_) {}
             await SnoozeStore.unsnooze(item.id);
             if (!mounted) return;
             await _load();

--- a/lib/attention_service.dart
+++ b/lib/attention_service.dart
@@ -43,9 +43,10 @@ class AttentionItem {
 /// Computes a ranked, team-wide list of pull requests that need action across
 /// all monitored repos: waiting on review, changes requested (Azure DevOps
 /// only for now — GitHub changes-requested detection needs the reviews API and
-/// is a later milestone), or open a long time. It is NOT personalized to the
-/// current user yet — that needs identity (a later milestone). CI-failing repos
-/// are surfaced on the Radar, not here.
+/// is a later milestone), or open a long time. Items are optionally tagged as
+/// the current user's (`AttentionItem.isMine`) when GitHub logins / ADO names
+/// are supplied, and snoozed items are filtered out. CI-failing repos are
+/// surfaced on the Radar, not here.
 class AttentionService {
   AttentionService._();
 

--- a/lib/attention_service.dart
+++ b/lib/attention_service.dart
@@ -74,7 +74,7 @@ class AttentionService {
     required DateTime now,
     Set<String> selfGithubLogins = const {},
   }) {
-    final self = selfGithubLogins.map((e) => e.toLowerCase()).toSet();
+    final self = selfGithubLogins.map((e) => e.trim().toLowerCase()).toSet();
     final items = <AttentionItem>[];
     for (final pr in prs) {
       if (pr is! Map) continue;
@@ -94,13 +94,13 @@ class AttentionService {
       if (reviewers is List) {
         for (final r in reviewers) {
           final login = _nestedString(r, 'login');
-          if (login != null) reviewerLogins.add(login.toLowerCase());
+          if (login != null) reviewerLogins.add(login.trim().toLowerCase());
         }
       }
       final waitingOnReview = (reviewers is List && reviewers.isNotEmpty) ||
           (teams is List && teams.isNotEmpty);
       final mine = self.isNotEmpty &&
-          (self.contains(author.toLowerCase()) ||
+          (self.contains(author.trim().toLowerCase()) ||
               reviewerLogins.any(self.contains));
 
       if (waitingOnReview) {
@@ -125,7 +125,7 @@ class AttentionService {
     required DateTime now,
     Set<String> selfAdoNames = const {},
   }) {
-    final self = selfAdoNames.map((e) => e.toLowerCase()).toSet();
+    final self = selfAdoNames.map((e) => e.trim().toLowerCase()).toSet();
     final items = <AttentionItem>[];
     for (final pr in prs) {
       if (pr is! Map) continue;
@@ -149,13 +149,13 @@ class AttentionService {
           if (r is! Map) continue;
           votes.add(r['vote']);
           final dn = _stringValue(r, 'displayName');
-          if (dn != null) reviewerNames.add(dn.toLowerCase());
+          if (dn != null) reviewerNames.add(dn.trim().toLowerCase());
         }
       }
       final changesRequested = votes.any((v) => v is int && v < 0);
       final waitingOnReview = votes.any((v) => v == 0);
       final mine = self.isNotEmpty &&
-          (self.contains(author.toLowerCase()) ||
+          (self.contains(author.trim().toLowerCase()) ||
               reviewerNames.any(self.contains));
 
       if (changesRequested) {

--- a/lib/attention_service.dart
+++ b/lib/attention_service.dart
@@ -18,6 +18,7 @@ class AttentionItem {
     required this.repoDisplay,
     this.url,
     this.ageDays,
+    this.isMine = false,
   });
 
   /// Stable identity for the item (enables list keys and future snooze).
@@ -34,6 +35,9 @@ class AttentionItem {
   final String repoDisplay;
   final String? url;
   final int? ageDays;
+
+  /// True when the current user is the PR author or a requested reviewer.
+  final bool isMine;
 }
 
 /// Computes a ranked, team-wide list of pull requests that need action across
@@ -67,7 +71,9 @@ class AttentionService {
     required String repoDisplay,
     required List<dynamic> prs,
     required DateTime now,
+    Set<String> selfGithubLogins = const {},
   }) {
+    final self = selfGithubLogins.map((e) => e.toLowerCase()).toSet();
     final items = <AttentionItem>[];
     for (final pr in prs) {
       if (pr is! Map) continue;
@@ -83,15 +89,26 @@ class AttentionService {
       // submit a review, so a non-empty list means "still waiting".)
       final reviewers = pr['requested_reviewers'];
       final teams = pr['requested_teams'];
+      final reviewerLogins = <String>{};
+      if (reviewers is List) {
+        for (final r in reviewers) {
+          final login = _nestedString(r, 'login');
+          if (login != null) reviewerLogins.add(login.toLowerCase());
+        }
+      }
       final waitingOnReview = (reviewers is List && reviewers.isNotEmpty) ||
           (teams is List && teams.isNotEmpty);
+      final mine = self.isNotEmpty &&
+          (self.contains(author.toLowerCase()) ||
+              reviewerLogins.any(self.contains));
 
       if (waitingOnReview) {
         items.add(_reviewRequested(
-            repoDisplay, 'PR #$number', title, author, age, url));
+            repoDisplay, 'PR #$number', title, author, age, url,
+            isMine: mine));
       } else if ((age ?? 0) > oldOpenPrDays) {
-        items
-            .add(_oldOpen(repoDisplay, 'PR #$number', title, author, age, url));
+        items.add(_oldOpen(repoDisplay, 'PR #$number', title, author, age, url,
+            isMine: mine));
       }
     }
     return items;
@@ -105,7 +122,9 @@ class AttentionService {
     required String name,
     required List<dynamic> prs,
     required DateTime now,
+    Set<String> selfAdoNames = const {},
   }) {
+    final self = selfAdoNames.map((e) => e.toLowerCase()).toSet();
     final items = <AttentionItem>[];
     for (final pr in prs) {
       if (pr is! Map) continue;
@@ -122,27 +141,41 @@ class AttentionService {
       // ADO reviewer votes: 10 approved, 5 approved-with-suggestions,
       // 0 no vote yet, -5 waiting for author, -10 rejected.
       final reviewers = pr['reviewers'];
-      final votes = reviewers is List
-          ? reviewers.whereType<Map>().map((r) => r['vote']).toList()
-          : const [];
+      final votes = <dynamic>[];
+      final reviewerNames = <String>{};
+      if (reviewers is List) {
+        for (final r in reviewers) {
+          if (r is! Map) continue;
+          votes.add(r['vote']);
+          final dn = _stringValue(r, 'displayName');
+          if (dn != null) reviewerNames.add(dn.toLowerCase());
+        }
+      }
       final changesRequested = votes.any((v) => v is int && v < 0);
       final waitingOnReview = votes.any((v) => v == 0);
+      final mine = self.isNotEmpty &&
+          (self.contains(author.toLowerCase()) ||
+              reviewerNames.any(self.contains));
 
       if (changesRequested) {
-        items.add(
-            _changesRequested(repoDisplay, 'PR #$id', title, author, age, url));
+        items.add(_changesRequested(
+            repoDisplay, 'PR #$id', title, author, age, url,
+            isMine: mine));
       } else if (waitingOnReview) {
-        items.add(
-            _reviewRequested(repoDisplay, 'PR #$id', title, author, age, url));
+        items.add(_reviewRequested(
+            repoDisplay, 'PR #$id', title, author, age, url,
+            isMine: mine));
       } else if ((age ?? 0) > oldOpenPrDays) {
-        items.add(_oldOpen(repoDisplay, 'PR #$id', title, author, age, url));
+        items.add(_oldOpen(repoDisplay, 'PR #$id', title, author, age, url,
+            isMine: mine));
       }
     }
     return items;
   }
 
   static AttentionItem _reviewRequested(String repoDisplay, String prLabel,
-      String title, String author, int? ageDays, String? url) {
+      String title, String author, int? ageDays, String? url,
+      {bool isMine = false}) {
     return AttentionItem(
       id: 'reviewRequested:$repoDisplay:$prLabel',
       category: 'reviewRequested',
@@ -153,11 +186,13 @@ class AttentionService {
       repoDisplay: repoDisplay,
       url: url,
       ageDays: ageDays,
+      isMine: isMine,
     );
   }
 
   static AttentionItem _changesRequested(String repoDisplay, String prLabel,
-      String title, String author, int? ageDays, String? url) {
+      String title, String author, int? ageDays, String? url,
+      {bool isMine = false}) {
     return AttentionItem(
       id: 'changesRequested:$repoDisplay:$prLabel',
       category: 'changesRequested',
@@ -168,11 +203,13 @@ class AttentionService {
       repoDisplay: repoDisplay,
       url: url,
       ageDays: ageDays,
+      isMine: isMine,
     );
   }
 
   static AttentionItem _oldOpen(String repoDisplay, String prLabel,
-      String title, String author, int? ageDays, String? url) {
+      String title, String author, int? ageDays, String? url,
+      {bool isMine = false}) {
     return AttentionItem(
       id: 'oldOpenPr:$repoDisplay:$prLabel',
       category: 'oldOpenPr',
@@ -182,6 +219,7 @@ class AttentionService {
       repoDisplay: repoDisplay,
       url: url,
       ageDays: ageDays,
+      isMine: isMine,
     );
   }
 
@@ -225,6 +263,9 @@ class AttentionService {
     http.Client? client,
     int concurrency = 5,
     DateTime? now,
+    Set<String> selfGithubLogins = const {},
+    Set<String> selfAdoNames = const {},
+    Set<String> snoozedIds = const {},
   }) async {
     final httpClient = client ?? http.Client();
     final effectiveNow = now ?? DateTime.now();
@@ -244,8 +285,8 @@ class AttentionService {
         final name = _stringValue(map, 'repoName');
         if (owner == null || name == null) continue;
         final tokenId = _stringValue(map, 'tokenId');
-        tasks.add(() =>
-            _githubRepoItems(httpClient, owner, name, tokenId, effectiveNow));
+        tasks.add(() => _githubRepoItems(
+            httpClient, owner, name, tokenId, effectiveNow, selfGithubLogins));
       }
 
       for (final raw in adoRepos) {
@@ -256,12 +297,15 @@ class AttentionService {
         final name = _stringValue(map, 'repoName');
         if (organization == null || project == null || name == null) continue;
         final tokenId = _stringValue(map, 'tokenId');
-        tasks.add(() => _adoRepoItems(
-            httpClient, organization, project, name, tokenId, effectiveNow));
+        tasks.add(() => _adoRepoItems(httpClient, organization, project, name,
+            tokenId, effectiveNow, selfAdoNames));
       }
 
       final grouped = await _runBounded(tasks, concurrency);
-      final items = grouped.expand((e) => e).toList();
+      final items = grouped
+          .expand((e) => e)
+          .where((item) => !snoozedIds.contains(item.id))
+          .toList();
 
       items.sort((a, b) {
         final bySeverity = b.severity.compareTo(a.severity);
@@ -274,8 +318,13 @@ class AttentionService {
     }
   }
 
-  static Future<List<AttentionItem>> _githubRepoItems(http.Client client,
-      String owner, String name, String? tokenId, DateTime now) async {
+  static Future<List<AttentionItem>> _githubRepoItems(
+      http.Client client,
+      String owner,
+      String name,
+      String? tokenId,
+      DateTime now,
+      Set<String> selfGithubLogins) async {
     final repoDisplay = '$owner/$name';
     try {
       final secret =
@@ -299,7 +348,11 @@ class AttentionService {
       }
       final body = jsonDecode(response.body);
       if (body is! List) return const [];
-      return githubItems(repoDisplay: repoDisplay, prs: body, now: now);
+      return githubItems(
+          repoDisplay: repoDisplay,
+          prs: body,
+          now: now,
+          selfGithubLogins: selfGithubLogins);
     } catch (e) {
       debugPrint('AttentionService GitHub fetch failed for $repoDisplay: $e');
       return [_errorItem(repoDisplay, 'Could not load pull requests')];
@@ -312,7 +365,8 @@ class AttentionService {
       String project,
       String name,
       String? tokenId,
-      DateTime now) async {
+      DateTime now,
+      Set<String> selfAdoNames) async {
     final repoDisplay = '$organization/$project/$name';
     try {
       final secret =
@@ -347,6 +401,7 @@ class AttentionService {
         name: name,
         prs: value,
         now: now,
+        selfAdoNames: selfAdoNames,
       );
     } catch (e) {
       debugPrint('AttentionService ADO fetch failed for $repoDisplay: $e');

--- a/lib/identity_store.dart
+++ b/lib/identity_store.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class IdentityStore {
+  IdentityStore._();
+
+  static const String _githubKey = 'self_github_logins';
+  static const String _adoKey = 'self_ado_names';
+
+  static Future<Set<String>> selfGithubLogins() async {
+    final prefs = await SharedPreferences.getInstance();
+    return _readSet(prefs, _githubKey, _normalizeLogin);
+  }
+
+  static Future<void> setSelfGithubLogins(Set<String> logins) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _githubKey,
+      jsonEncode(_normalizedSorted(logins, _normalizeLogin)),
+    );
+  }
+
+  static Future<Set<String>> selfAdoNames() async {
+    final prefs = await SharedPreferences.getInstance();
+    return _readSet(prefs, _adoKey, _normalizeName);
+  }
+
+  static Future<void> setSelfAdoNames(Set<String> names) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _adoKey,
+      jsonEncode(_normalizedSorted(names, _normalizeName)),
+    );
+  }
+
+  static Set<String> _readSet(
+    SharedPreferences prefs,
+    String key,
+    String Function(String) normalize,
+  ) {
+    final raw = prefs.getString(key);
+    if (raw == null) return <String>{};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return <String>{};
+      return _normalizedSorted(decoded.whereType<String>().toSet(), normalize)
+          .toSet();
+    } catch (_) {
+      return <String>{};
+    }
+  }
+
+  static List<String> _normalizedSorted(
+    Iterable<String> values,
+    String Function(String) normalize,
+  ) {
+    final normalized =
+        values.map(normalize).where((value) => value.isNotEmpty).toSet();
+    return normalized.toList()..sort();
+  }
+
+  static String _normalizeLogin(String value) => value.trim().toLowerCase();
+
+  static String _normalizeName(String value) => value.trim();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'manage_repos_page.dart';
 import 'manage_tokens_page.dart';
 import 'radar_page.dart';
 import 'attention_inbox_page.dart';
+import 'people_page.dart';
 import 'auto_add_service.dart';
 import 'token_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -596,6 +597,16 @@ class _MyHomePageState extends State<MyHomePage>
               await Navigator.push(
                 context,
                 MaterialPageRoute(builder: (_) => const RadarPage()),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.people),
+            tooltip: 'People',
+            onPressed: () async {
+              await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const PeoplePage()),
               );
             },
           ),

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'attention_service.dart';
+
+class NotificationService {
+  NotificationService._();
+
+  static const String _seenKey = 'seen_attention';
+  static const int _summaryNotificationId = 42001;
+  static const String _channelId = 'attention_inbox';
+  static const String _channelName = 'Attention Inbox';
+  static const String _channelDescription =
+      'Notifications for new Attention Inbox items';
+
+  static final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  static bool _initialized = false;
+  static Future<void>? _initFuture;
+
+  static Future<void> init() async {
+    if (_initialized || !_isSupportedPlatform) return;
+
+    final existing = _initFuture;
+    if (existing != null) {
+      await existing;
+      return;
+    }
+
+    final initFuture = _initPlugin();
+    _initFuture = initFuture;
+    await initFuture;
+  }
+
+  static Future<void> notifyNewAttention(List<AttentionItem> items) async {
+    try {
+      final currentIds = items.map((item) => item.id).toSet();
+      final prefs = await SharedPreferences.getInstance();
+      // On the very first run there is no baseline, so seed silently instead of
+      // notifying for every existing item.
+      final firstRun = !prefs.containsKey(_seenKey);
+      final seen = (prefs.getStringList(_seenKey) ?? const <String>[]).toSet();
+      final newIds = firstRun ? <String>{} : diffNew(seen, currentIds);
+
+      if (newIds.isNotEmpty) {
+        final newItems = items
+            .where((item) => newIds.contains(item.id))
+            .toList(growable: false);
+        await _showSummaryNotification(newItems);
+      }
+
+      await prefs.setStringList(_seenKey, currentIds.toList()..sort());
+    } catch (e) {
+      debugPrint('Failed to process attention notifications: $e');
+    }
+  }
+
+  static Set<String> diffNew(Set<String> seen, Iterable<String> current) =>
+      current.toSet().difference(seen);
+
+  static Future<void> _initPlugin() async {
+    try {
+      const settings = InitializationSettings(
+        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+        iOS: DarwinInitializationSettings(),
+        macOS: DarwinInitializationSettings(),
+      );
+      await _plugin.initialize(settings);
+      _initialized = true;
+    } catch (e) {
+      debugPrint('Failed to initialize local notifications: $e');
+    } finally {
+      _initFuture = null;
+    }
+  }
+
+  static Future<void> _showSummaryNotification(
+    List<AttentionItem> newItems,
+  ) async {
+    try {
+      if (newItems.isEmpty || !_isSupportedPlatform) return;
+
+      await init();
+      if (!_initialized) return;
+
+      final details = _notificationDetails();
+      if (details == null) return;
+
+      await _plugin.show(
+        _summaryNotificationId,
+        _summaryTitle(newItems.length),
+        _summaryBody(newItems),
+        details,
+      );
+    } catch (e) {
+      debugPrint('Failed to show attention notification: $e');
+    }
+  }
+
+  static NotificationDetails? _notificationDetails() {
+    if (!_isSupportedPlatform) return null;
+
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android => const NotificationDetails(
+          android: AndroidNotificationDetails(
+            _channelId,
+            _channelName,
+            channelDescription: _channelDescription,
+          ),
+        ),
+      TargetPlatform.iOS => const NotificationDetails(
+          iOS: DarwinNotificationDetails(),
+        ),
+      TargetPlatform.macOS => const NotificationDetails(
+          macOS: DarwinNotificationDetails(),
+        ),
+      _ => null,
+    };
+  }
+
+  static bool get _isSupportedPlatform {
+    if (kIsWeb) return false;
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android ||
+      TargetPlatform.iOS ||
+      TargetPlatform.macOS =>
+        true,
+      _ => false,
+    };
+  }
+
+  static String _summaryTitle(int count) =>
+      count == 1 ? '1 item needs attention' : '$count items need attention';
+
+  static String _summaryBody(List<AttentionItem> items) {
+    final titles = items.take(3).map((item) => item.title).toList();
+    final remaining = items.length - titles.length;
+    if (remaining > 0) {
+      titles.add('+$remaining more');
+    }
+    return titles.join('\n');
+  }
+}

--- a/lib/people_page.dart
+++ b/lib/people_page.dart
@@ -85,30 +85,32 @@ class _PeoplePageState extends State<PeoplePage> {
         context: context,
         builder: (dialogContext) => AlertDialog(
           title: const Text('Your identity'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Text(
-                'Marks "You" here and powers the Attention inbox\'s "Mine" '
-                'filter. Separate multiple entries with commas.',
-                style: TextStyle(fontSize: 12),
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: ghController,
-                decoration: const InputDecoration(
-                  labelText: 'GitHub username(s)',
-                  hintText: 'octocat, ...',
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'Marks "You" here and powers the Attention inbox\'s "Mine" '
+                  'filter. Separate multiple entries with commas.',
+                  style: TextStyle(fontSize: 12),
                 ),
-              ),
-              const SizedBox(height: 8),
-              TextField(
-                controller: adoController,
-                decoration: const InputDecoration(
-                  labelText: 'Azure DevOps display name(s)',
+                const SizedBox(height: 12),
+                TextField(
+                  controller: ghController,
+                  decoration: const InputDecoration(
+                    labelText: 'GitHub username(s)',
+                    hintText: 'octocat, ...',
+                  ),
                 ),
-              ),
-            ],
+                const SizedBox(height: 8),
+                TextField(
+                  controller: adoController,
+                  decoration: const InputDecoration(
+                    labelText: 'Azure DevOps display name(s)',
+                  ),
+                ),
+              ],
+            ),
           ),
           actions: [
             TextButton(

--- a/lib/people_page.dart
+++ b/lib/people_page.dart
@@ -80,54 +80,59 @@ class _PeoplePageState extends State<PeoplePage> {
     if (!mounted) return;
     final ghController = TextEditingController(text: gh);
     final adoController = TextEditingController(text: ado);
-    final saved = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Your identity'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text(
-              'Marks "You" here and powers the Attention inbox\'s "Mine" '
-              'filter. Separate multiple entries with commas.',
-              style: TextStyle(fontSize: 12),
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: ghController,
-              decoration: const InputDecoration(
-                labelText: 'GitHub username(s)',
-                hintText: 'octocat, ...',
+    try {
+      final saved = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('Your identity'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                'Marks "You" here and powers the Attention inbox\'s "Mine" '
+                'filter. Separate multiple entries with commas.',
+                style: TextStyle(fontSize: 12),
               ),
-            ),
-            const SizedBox(height: 8),
-            TextField(
-              controller: adoController,
-              decoration: const InputDecoration(
-                labelText: 'Azure DevOps display name(s)',
+              const SizedBox(height: 12),
+              TextField(
+                controller: ghController,
+                decoration: const InputDecoration(
+                  labelText: 'GitHub username(s)',
+                  hintText: 'octocat, ...',
+                ),
               ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: adoController,
+                decoration: const InputDecoration(
+                  labelText: 'Azure DevOps display name(s)',
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(dialogContext, true),
+              child: const Text('Save'),
             ),
           ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            child: const Text('Save'),
-          ),
-        ],
-      ),
-    );
-    if (saved == true) {
-      await IdentityStore.setSelfGithubLogins(_parseLogins(ghController.text));
-      await IdentityStore.setSelfAdoNames(_parseNames(adoController.text));
-      await _loadPeople();
+      );
+      if (saved == true) {
+        await IdentityStore.setSelfGithubLogins(
+            _parseLogins(ghController.text));
+        await IdentityStore.setSelfAdoNames(_parseNames(adoController.text));
+        if (!mounted) return;
+        await _loadPeople();
+      }
+    } finally {
+      ghController.dispose();
+      adoController.dispose();
     }
-    ghController.dispose();
-    adoController.dispose();
   }
 
   /// GitHub logins never contain whitespace, so split on commas or whitespace.

--- a/lib/people_page.dart
+++ b/lib/people_page.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/material.dart';
+
+import 'app_http.dart';
+import 'identity_store.dart';
+import 'people_service.dart';
+import 'person.dart';
+
+class PeoplePage extends StatefulWidget {
+  const PeoplePage({super.key});
+
+  @override
+  State<PeoplePage> createState() => _PeoplePageState();
+}
+
+class _PeoplePageState extends State<PeoplePage> {
+  List<Person> _people = const [];
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPeople();
+  }
+
+  Future<void> _loadPeople() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final people = await PeopleService.computeAll(client: AppHttp.client);
+      if (!mounted) return;
+      setState(() {
+        _people = people;
+        _loading = false;
+      });
+    } catch (e) {
+      debugPrint('PeoplePage failed to load: $e');
+      if (!mounted) return;
+      setState(() {
+        _error =
+            'Something went wrong while loading people. Pull down to try again.';
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('People'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.manage_accounts),
+            tooltip: 'Set your identity',
+            onPressed: _editIdentity,
+          ),
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: _loading ? null : _loadPeople,
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: _loadPeople,
+              child: _buildContent(),
+            ),
+    );
+  }
+
+  Future<void> _editIdentity() async {
+    final gh = (await IdentityStore.selfGithubLogins()).join(', ');
+    final ado = (await IdentityStore.selfAdoNames()).join(', ');
+    if (!mounted) return;
+    final ghController = TextEditingController(text: gh);
+    final adoController = TextEditingController(text: ado);
+    final saved = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Your identity'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Marks "You" here and powers the Attention inbox\'s "Mine" '
+              'filter. Separate multiple entries with commas.',
+              style: TextStyle(fontSize: 12),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: ghController,
+              decoration: const InputDecoration(
+                labelText: 'GitHub username(s)',
+                hintText: 'octocat, ...',
+              ),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: adoController,
+              decoration: const InputDecoration(
+                labelText: 'Azure DevOps display name(s)',
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (saved == true) {
+      await IdentityStore.setSelfGithubLogins(_parseLogins(ghController.text));
+      await IdentityStore.setSelfAdoNames(_parseNames(adoController.text));
+      await _loadPeople();
+    }
+    ghController.dispose();
+    adoController.dispose();
+  }
+
+  /// GitHub logins never contain whitespace, so split on commas or whitespace.
+  Set<String> _parseLogins(String value) => value
+      .split(RegExp(r'[,\s]+'))
+      .map((e) => e.trim())
+      .where((e) => e.isNotEmpty)
+      .toSet();
+
+  /// Azure DevOps display names contain spaces, so split only on separators.
+  Set<String> _parseNames(String value) => value
+      .split(RegExp(r'[,\n;]'))
+      .map((e) => e.trim())
+      .where((e) => e.isNotEmpty)
+      .toSet();
+
+  Widget _buildContent() {
+    if (_error != null) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 160),
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Text(
+                _error!,
+                textAlign: TextAlign.center,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (_people.isEmpty) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: const [
+          SizedBox(height: 160),
+          Center(
+            child: Padding(
+              padding: EdgeInsets.all(24),
+              child: Text(
+                'No people found yet.',
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return ListView.separated(
+      physics: const AlwaysScrollableScrollPhysics(),
+      itemCount: _people.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final person = _people[index];
+        return ListTile(
+          leading: CircleAvatar(child: Text(_initials(person.displayName))),
+          title: Row(
+            children: [
+              Expanded(child: Text(person.displayName)),
+              if (person.isSelf) ...[
+                const SizedBox(width: 8),
+                const Chip(
+                  label: Text('You'),
+                  visualDensity: VisualDensity.compact,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  padding: EdgeInsets.zero,
+                ),
+              ],
+            ],
+          ),
+          subtitle: Text(
+            _subtitle(person),
+            style: TextStyle(color: Colors.grey[600], fontSize: 12),
+          ),
+        );
+      },
+    );
+  }
+
+  String _subtitle(Person person) {
+    final reviewText =
+        '${person.reviewRequests} review request${person.reviewRequests == 1 ? '' : 's'}';
+    final authoredText =
+        '${person.authoredOpenPrs} open PR${person.authoredOpenPrs == 1 ? '' : 's'}';
+    return '$reviewText · $authoredText · last active '
+        '${_relativeTime(person.lastSeen)}';
+  }
+
+  String _relativeTime(DateTime? value) {
+    if (value == null) return 'unknown';
+    final diff = DateTime.now().difference(value);
+    if (diff.isNegative || diff.inSeconds < 45) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    if (diff.inDays < 30) return '${diff.inDays}d ago';
+    final months = diff.inDays ~/ 30;
+    if (months < 12) return '${months}mo ago';
+    return '${diff.inDays ~/ 365}y ago';
+  }
+
+  String _initials(String name) {
+    final parts = name.trim().split(RegExp(r'\s+')).where((p) => p.isNotEmpty);
+    final initials = parts.take(2).map((part) => part[0].toUpperCase()).join();
+    return initials.isEmpty ? '?' : initials;
+  }
+}

--- a/lib/people_service.dart
+++ b/lib/people_service.dart
@@ -15,7 +15,6 @@ class PeopleService {
   static const Duration _requestTimeout = Duration(seconds: 20);
 
   static List<Person> aggregateGithub({
-    required String repoDisplay,
     required List<dynamic> prs,
     required DateTime now,
     Set<String> self = const {},
@@ -66,7 +65,6 @@ class PeopleService {
   }
 
   static List<Person> aggregateAdo({
-    required String repoDisplay,
     required List<dynamic> prs,
     required DateTime now,
     Set<String> self = const {},
@@ -280,7 +278,6 @@ class PeopleService {
       final body = jsonDecode(response.body);
       if (body is! List) return const <Person>[];
       return aggregateGithub(
-        repoDisplay: repoDisplay,
         prs: body,
         now: now,
         self: self,
@@ -323,7 +320,6 @@ class PeopleService {
       final value = body is Map ? body['value'] : body;
       if (value is! List) return const <Person>[];
       return aggregateAdo(
-        repoDisplay: repoDisplay,
         prs: value,
         now: now,
         self: self,

--- a/lib/people_service.dart
+++ b/lib/people_service.dart
@@ -1,0 +1,492 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'identity_store.dart';
+import 'person.dart';
+import 'repo_store.dart';
+import 'token_store.dart';
+
+class PeopleService {
+  PeopleService._();
+
+  static const Duration _requestTimeout = Duration(seconds: 20);
+
+  static List<Person> aggregateGithub({
+    required String repoDisplay,
+    required List<dynamic> prs,
+    required DateTime now,
+    Set<String> self = const {},
+  }) {
+    final selfLogins = self.map(_normalizeLogin).where(_isNotEmpty).toSet();
+    final people = <String, _MutablePerson>{};
+
+    for (final pr in prs) {
+      if (pr is! Map) continue;
+      if (pr['draft'] == true) continue;
+      final state = _stringValue(pr, 'state');
+      if (state != null && state.toLowerCase() != 'open') continue;
+
+      final lastSeen = _dateValue(pr['created_at'], now);
+      final authorLogin = _normalizeLogin(
+        _nestedString(pr['user'], 'login') ?? '',
+      );
+      if (authorLogin.isNotEmpty) {
+        final author = people.putIfAbsent(
+          authorLogin,
+          () => _MutablePerson.github(authorLogin),
+        );
+        author.authoredOpenPrs++;
+        author.markSelf(selfLogins.contains(authorLogin));
+        author.see(lastSeen);
+      }
+
+      final reviewers = pr['requested_reviewers'];
+      if (reviewers is! List) continue;
+      for (final reviewer in reviewers) {
+        final login = _normalizeLogin(
+          _nestedString(reviewer, 'login') ?? '',
+        );
+        if (login.isEmpty) continue;
+        final person = people.putIfAbsent(
+          login,
+          () => _MutablePerson.github(login),
+        );
+        person.reviewRequests++;
+        person.markSelf(selfLogins.contains(login));
+        person.see(lastSeen);
+      }
+    }
+
+    final result = people.values.map((person) => person.toPerson()).toList();
+    _sortPeople(result);
+    return result;
+  }
+
+  static List<Person> aggregateAdo({
+    required String repoDisplay,
+    required List<dynamic> prs,
+    required DateTime now,
+    Set<String> self = const {},
+  }) {
+    final selfNames = self.map(_adoIdentity).where(_isNotEmpty).toSet();
+    final people = <String, _MutablePerson>{};
+
+    for (final pr in prs) {
+      if (pr is! Map) continue;
+      if (pr['isDraft'] == true) continue;
+      final status = _stringValue(pr, 'status');
+      if (status != null && status.toLowerCase() != 'active') continue;
+
+      final lastSeen = _dateValue(pr['creationDate'], now);
+      final authorName = _normalizeName(
+        _nestedString(pr['createdBy'], 'displayName') ?? '',
+      );
+      final authorKey = _adoIdentity(authorName);
+      if (authorKey.isNotEmpty) {
+        final author = people.putIfAbsent(
+          authorKey,
+          () => _MutablePerson.ado(authorName),
+        );
+        author.authoredOpenPrs++;
+        author.markSelf(selfNames.contains(authorKey));
+        author.see(lastSeen);
+      }
+
+      final reviewers = pr['reviewers'];
+      if (reviewers is! List) continue;
+      for (final reviewer in reviewers) {
+        // Only pending reviews (no vote yet) count as a review request, to
+        // match GitHub's requested-reviewers semantics. ADO votes: 10 approved,
+        // 5 approved-with-suggestions, 0 waiting, -5 waiting-for-author,
+        // -10 rejected.
+        final vote = reviewer is Map ? reviewer['vote'] : null;
+        if (vote is int && vote != 0) continue;
+        final name = _normalizeName(
+          _nestedString(reviewer, 'displayName') ?? '',
+        );
+        final key = _adoIdentity(name);
+        if (key.isEmpty) continue;
+        final person = people.putIfAbsent(
+          key,
+          () => _MutablePerson.ado(name),
+        );
+        person.reviewRequests++;
+        person.markSelf(selfNames.contains(key));
+        person.see(lastSeen);
+      }
+    }
+
+    final result = people.values.map((person) => person.toPerson()).toList();
+    _sortPeople(result);
+    return result;
+  }
+
+  static List<Person> mergePeople(List<Person> all) {
+    if (all.isEmpty) return <Person>[];
+
+    final parents = List<int>.generate(all.length, (index) => index);
+
+    int find(int index) {
+      var current = index;
+      while (parents[current] != current) {
+        parents[current] = parents[parents[current]];
+        current = parents[current];
+      }
+      return current;
+    }
+
+    void union(int a, int b) {
+      final rootA = find(a);
+      final rootB = find(b);
+      if (rootA != rootB) parents[rootB] = rootA;
+    }
+
+    final githubOwners = <String, int>{};
+    final adoOwners = <String, int>{};
+
+    for (var i = 0; i < all.length; i++) {
+      for (final login in all[i].githubLogins) {
+        final key = _normalizeLogin(login);
+        if (key.isEmpty) continue;
+        final existing = githubOwners[key];
+        if (existing == null) {
+          githubOwners[key] = i;
+        } else {
+          union(i, existing);
+        }
+      }
+
+      for (final name in all[i].adoNames) {
+        final key = _adoIdentity(name);
+        if (key.isEmpty) continue;
+        final existing = adoOwners[key];
+        if (existing == null) {
+          adoOwners[key] = i;
+        } else {
+          union(i, existing);
+        }
+      }
+    }
+
+    final groups = <int, _MutablePerson>{};
+    for (var i = 0; i < all.length; i++) {
+      final person = all[i];
+      final root = find(i);
+      final group = groups.putIfAbsent(
+        root,
+        () => _MutablePerson.person(person),
+      );
+      group.addPerson(person);
+    }
+
+    final result = groups.values.map((person) => person.toPerson()).toList();
+    _sortPeople(result);
+    return result;
+  }
+
+  static Future<List<Person>> computeAll({
+    http.Client? client,
+    int concurrency = 5,
+  }) async {
+    final httpClient = client ?? http.Client();
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final githubRepos =
+          prefs.getStringList(RepoStore.githubKey) ?? const <String>[];
+      final adoRepos =
+          prefs.getStringList(RepoStore.adoKey) ?? const <String>[];
+      final selfGithub = await IdentityStore.selfGithubLogins();
+      final selfAdo = await IdentityStore.selfAdoNames();
+      final now = DateTime.now();
+      final tasks = <Future<List<Person>> Function()>[];
+
+      for (final raw in githubRepos) {
+        final map = _decode(raw);
+        if (map == null) continue;
+        final owner = _stringValue(map, 'owner');
+        final name = _stringValue(map, 'repoName');
+        if (owner == null || name == null) continue;
+        final tokenId = _stringValue(map, 'tokenId');
+        tasks.add(
+          () => _githubRepoPeople(
+            httpClient,
+            owner,
+            name,
+            tokenId,
+            now,
+            selfGithub,
+          ),
+        );
+      }
+
+      for (final raw in adoRepos) {
+        final map = _decode(raw);
+        if (map == null) continue;
+        final organization = _stringValue(map, 'organization');
+        final project = _stringValue(map, 'project');
+        final name = _stringValue(map, 'repoName');
+        if (organization == null || project == null || name == null) continue;
+        final tokenId = _stringValue(map, 'tokenId');
+        tasks.add(
+          () => _adoRepoPeople(
+            httpClient,
+            organization,
+            project,
+            name,
+            tokenId,
+            now,
+            selfAdo,
+          ),
+        );
+      }
+
+      final grouped = await _runBounded(tasks, concurrency);
+      return mergePeople(grouped.expand((people) => people).toList());
+    } finally {
+      if (client == null) httpClient.close();
+    }
+  }
+
+  static Future<List<Person>> _githubRepoPeople(
+    http.Client client,
+    String owner,
+    String name,
+    String? tokenId,
+    DateTime now,
+    Set<String> self,
+  ) async {
+    final repoDisplay = '$owner/$name';
+    try {
+      final secret =
+          (await TokenStore.resolveGithubSecret(owner, tokenId: tokenId))
+              ?.trim();
+      if (secret == null || secret.isEmpty) return const <Person>[];
+
+      final response = await client.get(
+        Uri.https('api.github.com', '/repos/$owner/$name/pulls', {
+          'state': 'open',
+          'per_page': '100',
+        }),
+        headers: {
+          'Authorization': 'Bearer $secret',
+          'Accept': 'application/vnd.github+json',
+        },
+      ).timeout(_requestTimeout);
+      if (response.statusCode != 200) return const <Person>[];
+
+      final body = jsonDecode(response.body);
+      if (body is! List) return const <Person>[];
+      return aggregateGithub(
+        repoDisplay: repoDisplay,
+        prs: body,
+        now: now,
+        self: self,
+      );
+    } catch (e) {
+      debugPrint('PeopleService GitHub fetch failed for $repoDisplay: $e');
+      return const <Person>[];
+    }
+  }
+
+  static Future<List<Person>> _adoRepoPeople(
+    http.Client client,
+    String organization,
+    String project,
+    String name,
+    String? tokenId,
+    DateTime now,
+    Set<String> self,
+  ) async {
+    final repoDisplay = '$organization/$project/$name';
+    try {
+      final secret =
+          (await TokenStore.resolveAdoSecret(organization, tokenId: tokenId))
+              ?.trim();
+      if (secret == null || secret.isEmpty) return const <Person>[];
+
+      final response = await client.get(
+        Uri.https(
+          'dev.azure.com',
+          '/$organization/$project/_apis/git/repositories/$name/pullrequests',
+          {'searchCriteria.status': 'active', 'api-version': '6.0'},
+        ),
+        headers: {
+          'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
+        },
+      ).timeout(_requestTimeout);
+      if (response.statusCode != 200) return const <Person>[];
+
+      final body = jsonDecode(response.body);
+      final value = body is Map ? body['value'] : body;
+      if (value is! List) return const <Person>[];
+      return aggregateAdo(
+        repoDisplay: repoDisplay,
+        prs: value,
+        now: now,
+        self: self,
+      );
+    } catch (e) {
+      debugPrint('PeopleService ADO fetch failed for $repoDisplay: $e');
+      return const <Person>[];
+    }
+  }
+
+  static Map<String, dynamic>? _decode(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      return decoded is Map ? Map<String, dynamic>.from(decoded) : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static String? _nestedString(dynamic map, String key) =>
+      map is Map && map[key] is String ? map[key] as String : null;
+
+  static String? _stringValue(Map map, String key) {
+    final value = map[key];
+    return value is String ? value : null;
+  }
+
+  static DateTime? _dateValue(dynamic isoDate, DateTime now) {
+    if (isoDate is! String) return null;
+    final parsed = DateTime.tryParse(isoDate);
+    if (parsed == null) return null;
+    return parsed.isAfter(now) ? now : parsed;
+  }
+
+  static Future<List<T>> _runBounded<T>(
+    List<Future<T> Function()> tasks,
+    int concurrency,
+  ) async {
+    if (tasks.isEmpty) return <T>[];
+    final results = <T>[];
+    var next = 0;
+
+    Future<void> worker() async {
+      while (true) {
+        final index = next++;
+        if (index >= tasks.length) break;
+        results.add(await tasks[index]());
+      }
+    }
+
+    final workerCount = concurrency.clamp(1, tasks.length);
+    await Future.wait(List.generate(workerCount, (_) => worker()));
+    return results;
+  }
+
+  static void _sortPeople(List<Person> people) {
+    people.sort((a, b) {
+      final byReviewRequests = b.reviewRequests.compareTo(a.reviewRequests);
+      if (byReviewRequests != 0) return byReviewRequests;
+      final byAuthoredOpenPrs = b.authoredOpenPrs.compareTo(a.authoredOpenPrs);
+      if (byAuthoredOpenPrs != 0) return byAuthoredOpenPrs;
+      return a.displayName.toLowerCase().compareTo(
+            b.displayName.toLowerCase(),
+          );
+    });
+  }
+
+  static String _normalizeLogin(String value) => value.trim().toLowerCase();
+
+  static String _normalizeName(String value) => value.trim();
+
+  static String _adoIdentity(String value) => value.trim().toLowerCase();
+
+  static bool _isNotEmpty(String value) => value.isNotEmpty;
+}
+
+class _MutablePerson {
+  _MutablePerson(this.key, this.displayName);
+
+  factory _MutablePerson.github(String login) {
+    final person = _MutablePerson('github:$login', login);
+    person.githubLogins.add(login);
+    return person;
+  }
+
+  factory _MutablePerson.ado(String name) {
+    final trimmed = PeopleService._normalizeName(name);
+    final person = _MutablePerson('ado:${PeopleService._adoIdentity(name)}',
+        trimmed.isEmpty ? name : trimmed);
+    person.addAdoName(name);
+    return person;
+  }
+
+  factory _MutablePerson.person(Person person) =>
+      _MutablePerson(person.key, person.displayName);
+
+  String key;
+  String displayName;
+  final Set<String> githubLogins = <String>{};
+  final Map<String, String> adoNames = <String, String>{};
+  int authoredOpenPrs = 0;
+  int reviewRequests = 0;
+  DateTime? lastSeen;
+  bool isSelf = false;
+
+  void addPerson(Person person) {
+    if (displayName.trim().isEmpty && person.displayName.trim().isNotEmpty) {
+      displayName = person.displayName.trim();
+    }
+    for (final login in person.githubLogins) {
+      final normalized = PeopleService._normalizeLogin(login);
+      if (normalized.isNotEmpty) githubLogins.add(normalized);
+    }
+    for (final name in person.adoNames) {
+      addAdoName(name);
+    }
+    authoredOpenPrs += person.authoredOpenPrs;
+    reviewRequests += person.reviewRequests;
+    see(person.lastSeen);
+    markSelf(person.isSelf);
+  }
+
+  void addAdoName(String name) {
+    final trimmed = PeopleService._normalizeName(name);
+    final key = PeopleService._adoIdentity(trimmed);
+    if (key.isEmpty) return;
+    adoNames.putIfAbsent(key, () => trimmed);
+  }
+
+  void see(DateTime? value) {
+    if (value == null) return;
+    if (lastSeen == null || value.isAfter(lastSeen!)) lastSeen = value;
+  }
+
+  void markSelf(bool value) {
+    isSelf = isSelf || value;
+  }
+
+  Person toPerson() {
+    final logins = githubLogins.toList()..sort();
+    final adoKeys = adoNames.keys.toList()..sort();
+    final stableKey = logins.isNotEmpty
+        ? 'github:${logins.first}'
+        : adoKeys.isNotEmpty
+            ? 'ado:${adoKeys.first}'
+            : key;
+    final fallbackName = logins.isNotEmpty
+        ? logins.first
+        : adoKeys.isNotEmpty
+            ? adoNames[adoKeys.first]!
+            : stableKey;
+    final shownName =
+        displayName.trim().isEmpty ? fallbackName : displayName.trim();
+
+    return Person(
+      key: stableKey,
+      displayName: shownName,
+      githubLogins: logins.toSet(),
+      adoNames: adoKeys.map((key) => adoNames[key]!).toSet(),
+      authoredOpenPrs: authoredOpenPrs,
+      reviewRequests: reviewRequests,
+      lastSeen: lastSeen,
+      isSelf: isSelf,
+    );
+  }
+}

--- a/lib/people_service.dart
+++ b/lib/people_service.dart
@@ -101,7 +101,7 @@ class PeopleService {
         // 5 approved-with-suggestions, 0 waiting, -5 waiting-for-author,
         // -10 rejected.
         final vote = reviewer is Map ? reviewer['vote'] : null;
-        if (vote is int && vote != 0) continue;
+        if (vote != 0) continue;
         final name = _normalizeName(
           _nestedString(reviewer, 'displayName') ?? '',
         );

--- a/lib/person.dart
+++ b/lib/person.dart
@@ -1,0 +1,22 @@
+class Person {
+  Person({
+    required this.key,
+    required this.displayName,
+    Set<String> githubLogins = const <String>{},
+    Set<String> adoNames = const <String>{},
+    this.authoredOpenPrs = 0,
+    this.reviewRequests = 0,
+    this.lastSeen,
+    this.isSelf = false,
+  })  : githubLogins = Set.unmodifiable(githubLogins),
+        adoNames = Set.unmodifiable(adoNames);
+
+  final String key;
+  final String displayName;
+  final Set<String> githubLogins;
+  final Set<String> adoNames;
+  int authoredOpenPrs;
+  int reviewRequests;
+  DateTime? lastSeen;
+  bool isSelf;
+}

--- a/lib/radar_page.dart
+++ b/lib/radar_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'activity_service.dart';
+import 'app_http.dart';
 
 class RadarPage extends StatefulWidget {
   const RadarPage({super.key});
@@ -28,7 +29,8 @@ class _RadarPageState extends State<RadarPage> {
     });
 
     try {
-      final activities = await ActivityService.computeAll();
+      final activities =
+          await ActivityService.computeAll(client: AppHttp.client);
       if (!mounted) return;
       setState(() {
         _activities = activities;

--- a/lib/snooze_store.dart
+++ b/lib/snooze_store.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SnoozeStore {
+  SnoozeStore._();
+
+  static const String _storageKey = 'snoozed_attention';
+
+  static Future<Set<String>> snoozedIds() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = _readFrom(prefs);
+    final pruned = pruneExpired(raw, DateTime.now());
+    if (!_mapsEqual(raw, pruned)) {
+      await _writeTo(prefs, pruned);
+    }
+    return pruned.keys.toSet();
+  }
+
+  static Future<void> snooze(String id, {Duration? forDuration}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = _readFrom(prefs);
+    raw[id] = forDuration == null
+        ? null
+        : DateTime.now().add(forDuration).millisecondsSinceEpoch;
+    await _writeTo(prefs, raw);
+  }
+
+  static Future<void> unsnooze(String id) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = _readFrom(prefs);
+    raw.remove(id);
+    await _writeTo(prefs, raw);
+  }
+
+  static Future<bool> isSnoozed(String id) async {
+    final ids = await snoozedIds();
+    return ids.contains(id);
+  }
+
+  static Map<String, int?> pruneExpired(Map<String, int?> raw, DateTime now) {
+    final nowMillis = now.millisecondsSinceEpoch;
+    return Map<String, int?>.fromEntries(
+      raw.entries.where((entry) {
+        final untilMillis = entry.value;
+        return untilMillis == null || untilMillis > nowMillis;
+      }),
+    );
+  }
+
+  static Map<String, int?> _readFrom(SharedPreferences prefs) {
+    final raw = prefs.getString(_storageKey);
+    if (raw == null || raw.isEmpty) return <String, int?>{};
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return <String, int?>{};
+
+      final result = <String, int?>{};
+      for (final entry in decoded.entries) {
+        final key = entry.key;
+        if (key is! String || key.isEmpty) continue;
+
+        final value = entry.value;
+        if (value == null) {
+          result[key] = null;
+        } else if (value is int) {
+          result[key] = value;
+        } else if (value is num) {
+          result[key] = value.toInt();
+        }
+      }
+      return result;
+    } catch (_) {
+      return <String, int?>{};
+    }
+  }
+
+  static Future<void> _writeTo(
+    SharedPreferences prefs,
+    Map<String, int?> raw,
+  ) async {
+    await prefs.setString(_storageKey, jsonEncode(raw));
+  }
+
+  static bool _mapsEqual(Map<String, int?> a, Map<String, int?> b) {
+    if (a.length != b.length) return false;
+    for (final entry in a.entries) {
+      if (!b.containsKey(entry.key) || b[entry.key] != entry.value) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/lib/snooze_store.dart
+++ b/lib/snooze_store.dart
@@ -7,30 +7,46 @@ class SnoozeStore {
 
   static const String _storageKey = 'snoozed_attention';
 
+  // Serializes read-modify-write access so rapid swipes / Undo can't clobber
+  // one another's persisted state.
+  static Future<void> _lock = Future<void>.value();
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
   static Future<Set<String>> snoozedIds() async {
-    final prefs = await SharedPreferences.getInstance();
-    final raw = _readFrom(prefs);
-    final pruned = pruneExpired(raw, DateTime.now());
-    if (!_mapsEqual(raw, pruned)) {
-      await _writeTo(prefs, pruned);
-    }
-    return pruned.keys.toSet();
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = _readFrom(prefs);
+      final pruned = pruneExpired(raw, DateTime.now());
+      if (!_mapsEqual(raw, pruned)) {
+        await _writeTo(prefs, pruned);
+      }
+      return pruned.keys.toSet();
+    });
   }
 
   static Future<void> snooze(String id, {Duration? forDuration}) async {
-    final prefs = await SharedPreferences.getInstance();
-    final raw = _readFrom(prefs);
-    raw[id] = forDuration == null
-        ? null
-        : DateTime.now().add(forDuration).millisecondsSinceEpoch;
-    await _writeTo(prefs, raw);
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = _readFrom(prefs);
+      raw[id] = forDuration == null
+          ? null
+          : DateTime.now().add(forDuration).millisecondsSinceEpoch;
+      await _writeTo(prefs, raw);
+    });
   }
 
   static Future<void> unsnooze(String id) async {
-    final prefs = await SharedPreferences.getInstance();
-    final raw = _readFrom(prefs);
-    raw.remove(id);
-    await _writeTo(prefs, raw);
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = _readFrom(prefs);
+      raw.remove(id);
+      await _writeTo(prefs, raw);
+    });
   }
 
   static Future<bool> isSnoozed(String id) async {

--- a/test/api_cache_test.dart
+++ b/test/api_cache_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:kode_radar/api_cache.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('caches a 200 with an ETag and serves cached body for 304', () async {
+    var calls = 0;
+    final ifNoneMatchHeaders = <String?>[];
+    final inner = MockClient((request) async {
+      calls++;
+      ifNoneMatchHeaders.add(request.headers['If-None-Match']);
+      if (calls == 1) {
+        return http.Response(
+          '{"value":1}',
+          200,
+          headers: {
+            'etag': '"v1"',
+            'content-type': 'application/json; charset=utf-8',
+          },
+        );
+      }
+      return http.Response('', 304);
+    });
+    final client = CachedHttpClient(inner: inner);
+    addTearDown(client.close);
+
+    final uri = Uri.parse('https://api.github.com/repos/acme/api/pulls');
+    final first = await client.get(uri);
+    final second = await client.get(uri);
+
+    expect(first.statusCode, 200);
+    expect(first.body, '{"value":1}');
+    expect(calls, 2);
+    expect(ifNoneMatchHeaders, [null, '"v1"']);
+    expect(second.statusCode, 200);
+    expect(second.body, '{"value":1}');
+    expect(second.headers['content-type'], 'application/json; charset=utf-8');
+  });
+
+  test('exhausted rate limit serves a cached GET response', () async {
+    var calls = 0;
+    final resetSeconds = DateTime.utc(2100).millisecondsSinceEpoch ~/
+        Duration.millisecondsPerSecond;
+    final inner = MockClient((_) async {
+      calls++;
+      return http.Response(
+        'cached body',
+        200,
+        headers: {
+          'etag': '"rate"',
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': '$resetSeconds',
+        },
+      );
+    });
+    final client = CachedHttpClient(inner: inner);
+    addTearDown(client.close);
+
+    final uri = Uri.parse('https://api.github.com/repos/acme/api/pulls');
+    final first = await client.get(uri);
+    final second = await client.get(uri);
+
+    expect(first.body, 'cached body');
+    expect(second.statusCode, 200);
+    expect(second.body, 'cached body');
+    expect(calls, 1);
+    expect(client.githubRateLimit.remaining, 0);
+    expect(client.githubRateLimit.resetAt, DateTime.utc(2100));
+  });
+
+  test('an exhausted GitHub scope does not gate other hosts (Azure DevOps)',
+      () async {
+    final resetSeconds = DateTime.utc(2100).millisecondsSinceEpoch ~/
+        Duration.millisecondsPerSecond;
+    var adoCalls = 0;
+    final inner = MockClient((request) async {
+      if (request.url.host == 'api.github.com') {
+        return http.Response('gh', 200, headers: {
+          'etag': '"gh"',
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': '$resetSeconds',
+        });
+      }
+      adoCalls++;
+      return http.Response('ado', 200);
+    });
+    final client = CachedHttpClient(inner: inner);
+    addTearDown(client.close);
+
+    // Exhaust the GitHub scope.
+    await client.get(Uri.parse('https://api.github.com/repos/acme/api/pulls'));
+    // Azure DevOps must still reach the network (not gated by GitHub's limit).
+    final adoResponse = await client.get(Uri.parse(
+        'https://dev.azure.com/org/proj/_apis/git/repositories/r/pullrequests'));
+
+    expect(adoResponse.statusCode, 200);
+    expect(adoResponse.body, 'ado');
+    expect(adoCalls, 1);
+  });
+
+  test('parseRateLimit parses GitHub rate limit headers', () {
+    final resetAt = DateTime.utc(2026, 7, 14, 8, 30);
+    final resetSeconds =
+        resetAt.millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond;
+
+    final status = parseRateLimit({
+      'X-RateLimit-Remaining': '0',
+      'x-ratelimit-reset': '$resetSeconds',
+      'Retry-After': '45',
+    });
+
+    expect(status.remaining, 0);
+    expect(status.resetAt, resetAt);
+    expect(status.retryAfter, const Duration(seconds: 45));
+  });
+}

--- a/test/attention_service_test.dart
+++ b/test/attention_service_test.dart
@@ -236,6 +236,68 @@ void main() {
     expect(items.single.url, isNull);
   });
 
+  test('githubItems tags isMine for the self login (author or reviewer)', () {
+    final items = AttentionService.githubItems(
+      repoDisplay: 'acme/api',
+      now: now,
+      selfGithubLogins: {'Me'},
+      prs: [
+        {
+          'number': 1,
+          'title': 't',
+          'user': {'login': 'alice'},
+          'created_at': daysAgo(1).toIso8601String(),
+          'requested_reviewers': [
+            {'login': 'me'}
+          ],
+        },
+        {
+          'number': 2,
+          'title': 't',
+          'user': {'login': 'me'},
+          'created_at': daysAgo(40).toIso8601String(),
+          'requested_reviewers': [],
+        },
+        {
+          'number': 3,
+          'title': 't',
+          'user': {'login': 'bob'},
+          'created_at': daysAgo(1).toIso8601String(),
+          'requested_reviewers': [
+            {'login': 'carol'}
+          ],
+        },
+      ],
+    );
+    final byId = {for (final i in items) i.id: i};
+    expect(byId['reviewRequested:acme/api:PR #1']!.isMine, isTrue);
+    expect(byId['oldOpenPr:acme/api:PR #2']!.isMine, isTrue);
+    expect(byId['reviewRequested:acme/api:PR #3']!.isMine, isFalse);
+  });
+
+  test('adoItems tags isMine matching self names with whitespace trimming', () {
+    final items = AttentionService.adoItems(
+      repoDisplay: 'org/proj/repo',
+      organization: 'org',
+      project: 'proj',
+      name: 'repo',
+      now: now,
+      selfAdoNames: {'  Jane Doe '},
+      prs: [
+        {
+          'pullRequestId': 5,
+          'title': 't',
+          'createdBy': {'displayName': 'Jane Doe'},
+          'creationDate': daysAgo(1).toIso8601String(),
+          'reviewers': [
+            {'vote': 0, 'displayName': 'Someone'}
+          ],
+        },
+      ],
+    );
+    expect(items.single.isMine, isTrue);
+  });
+
   group('computeAll', () {
     setUp(() {
       TestWidgetsFlutterBinding.ensureInitialized();
@@ -287,6 +349,50 @@ void main() {
       expect(items, hasLength(1));
       expect(items.single.category, 'reviewRequested');
       expect(items.single.ageDays, 10);
+    });
+
+    test('filters out snoozed item ids', () async {
+      final token = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Acme',
+        scope: 'acme',
+        secret: 'ghp_secret',
+      );
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList('github_repos', [
+        jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': token.id}),
+      ]);
+      final client = MockClient((request) async {
+        if (request.url.path == '/repos/acme/api/pulls') {
+          return http.Response(
+            jsonEncode([
+              {
+                'number': 7,
+                'title': 't',
+                'user': {'login': 'a'},
+                'created_at': '2020-01-01T00:00:00Z',
+                'requested_reviewers': [
+                  {'login': 'b'}
+                ],
+                'html_url': 'https://github.com/acme/api/pull/7',
+              },
+            ]),
+            200,
+          );
+        }
+        return http.Response('[]', 200);
+      });
+
+      final now = DateTime.parse('2020-01-11T00:00:00Z');
+      final all = await AttentionService.computeAll(client: client, now: now);
+      expect(all, hasLength(1));
+
+      final filtered = await AttentionService.computeAll(
+        client: client,
+        now: now,
+        snoozedIds: {all.single.id},
+      );
+      expect(filtered, isEmpty);
     });
   });
 }

--- a/test/identity_store_test.dart
+++ b/test/identity_store_test.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/identity_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('round-trips self GitHub logins and ADO names', () async {
+    await IdentityStore.setSelfGithubLogins({' Alice ', 'BOB', ''});
+    await IdentityStore.setSelfAdoNames({' Ada Lovelace ', 'Grace Hopper', ''});
+
+    expect(await IdentityStore.selfGithubLogins(), {'alice', 'bob'});
+    expect(await IdentityStore.selfAdoNames(), {
+      'Ada Lovelace',
+      'Grace Hopper',
+    });
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      jsonDecode(prefs.getString('self_github_logins')!) as List<dynamic>,
+      ['alice', 'bob'],
+    );
+    expect(
+      jsonDecode(prefs.getString('self_ado_names')!) as List<dynamic>,
+      ['Ada Lovelace', 'Grace Hopper'],
+    );
+  });
+}

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/notification_service.dart';
+
+void main() {
+  test('diffNew returns current ids not already seen', () {
+    expect(
+      NotificationService.diffNew(<String>{'a', 'b'}, <String>['b', 'c', 'c']),
+      <String>{'c'},
+    );
+  });
+
+  test('diffNew returns an empty set when all current ids are seen', () {
+    expect(
+      NotificationService.diffNew(<String>{'a', 'b'}, <String>['a', 'b']),
+      isEmpty,
+    );
+  });
+}

--- a/test/people_service_test.dart
+++ b/test/people_service_test.dart
@@ -7,7 +7,6 @@ void main() {
 
   test('aggregateGithub counts authors and requested reviewers', () {
     final people = PeopleService.aggregateGithub(
-      repoDisplay: 'acme/api',
       now: now,
       prs: [
         {
@@ -90,7 +89,6 @@ void main() {
 
   test('aggregateAdo counts only pending (vote 0) reviewers', () {
     final people = PeopleService.aggregateAdo(
-      repoDisplay: 'org/project/repo',
       now: now,
       prs: [
         {
@@ -118,7 +116,6 @@ void main() {
   test('malformed entries do not throw', () {
     expect(
       () => PeopleService.aggregateGithub(
-        repoDisplay: 'acme/api',
         now: now,
         prs: [
           'not-a-map',
@@ -136,7 +133,6 @@ void main() {
     );
 
     final people = PeopleService.aggregateAdo(
-      repoDisplay: 'org/project/repo',
       now: now,
       prs: [
         null,

--- a/test/people_service_test.dart
+++ b/test/people_service_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/people_service.dart';
+import 'package:kode_radar/person.dart';
+
+void main() {
+  final now = DateTime.parse('2026-07-14T12:00:00Z');
+
+  test('aggregateGithub counts authors and requested reviewers', () {
+    final people = PeopleService.aggregateGithub(
+      repoDisplay: 'acme/api',
+      now: now,
+      prs: [
+        {
+          'user': {'login': 'Alice'},
+          'created_at': '2026-07-12T12:00:00Z',
+          'requested_reviewers': [
+            {'login': 'Bob'},
+            {'login': 'carol'},
+          ],
+        },
+        {
+          'user': {'login': 'alice'},
+          'created_at': '2026-07-13T12:00:00Z',
+          'requested_reviewers': [
+            {'login': 'bob'},
+          ],
+        },
+        {
+          'draft': true,
+          'user': {'login': 'draft-author'},
+          'requested_reviewers': [
+            {'login': 'draft-reviewer'},
+          ],
+        },
+      ],
+    );
+
+    final alice = people.singleWhere((person) => person.key == 'github:alice');
+    final bob = people.singleWhere((person) => person.key == 'github:bob');
+    final carol = people.singleWhere((person) => person.key == 'github:carol');
+
+    expect(alice.authoredOpenPrs, 2);
+    expect(alice.reviewRequests, 0);
+    expect(alice.lastSeen, DateTime.parse('2026-07-13T12:00:00Z'));
+    expect(bob.authoredOpenPrs, 0);
+    expect(bob.reviewRequests, 2);
+    expect(carol.reviewRequests, 1);
+    expect(
+        people.any((person) => person.key == 'github:draft-author'), isFalse);
+  });
+
+  test('mergePeople merges shared logins, sums counts, and marks self', () {
+    final people = PeopleService.mergePeople([
+      Person(
+        key: 'one',
+        displayName: 'Alice',
+        githubLogins: {'alice'},
+        authoredOpenPrs: 1,
+        reviewRequests: 2,
+        lastSeen: DateTime.parse('2026-07-12T12:00:00Z'),
+        isSelf: true,
+      ),
+      Person(
+        key: 'two',
+        displayName: 'Alice B',
+        githubLogins: {'ALICE'},
+        adoNames: {'Ada Lovelace'},
+        authoredOpenPrs: 3,
+        reviewRequests: 4,
+        lastSeen: DateTime.parse('2026-07-13T12:00:00Z'),
+      ),
+      Person(
+        key: 'three',
+        displayName: 'Bob',
+        githubLogins: {'bob'},
+        reviewRequests: 5,
+      ),
+    ]);
+
+    expect(people, hasLength(2));
+    final alice = people.singleWhere((person) => person.key == 'github:alice');
+    expect(alice.authoredOpenPrs, 4);
+    expect(alice.reviewRequests, 6);
+    expect(alice.githubLogins, {'alice'});
+    expect(alice.adoNames, {'Ada Lovelace'});
+    expect(alice.lastSeen, DateTime.parse('2026-07-13T12:00:00Z'));
+    expect(alice.isSelf, isTrue);
+    expect(people.first.key, 'github:alice');
+  });
+
+  test('aggregateAdo counts only pending (vote 0) reviewers', () {
+    final people = PeopleService.aggregateAdo(
+      repoDisplay: 'org/project/repo',
+      now: now,
+      prs: [
+        {
+          'createdBy': {'displayName': 'Jane Doe'},
+          'creationDate': '2026-07-13T12:00:00Z',
+          'reviewers': [
+            {'displayName': 'Rev Pending', 'vote': 0},
+            {'displayName': 'Rev Approved', 'vote': 10},
+            {'displayName': 'Rev Rejected', 'vote': -10},
+          ],
+        },
+      ],
+    );
+
+    // Only the author + the pending reviewer are registered.
+    expect(people, hasLength(2));
+    final reviewSum =
+        people.map((p) => p.reviewRequests).fold<int>(0, (a, b) => a + b);
+    final authorSum =
+        people.map((p) => p.authoredOpenPrs).fold<int>(0, (a, b) => a + b);
+    expect(reviewSum, 1);
+    expect(authorSum, 1);
+  });
+
+  test('malformed entries do not throw', () {
+    expect(
+      () => PeopleService.aggregateGithub(
+        repoDisplay: 'acme/api',
+        now: now,
+        prs: [
+          'not-a-map',
+          {
+            'user': {'login': 42},
+            'created_at': 'not-a-date',
+            'requested_reviewers': [
+              'bad-reviewer',
+              {'login': 7},
+            ],
+          },
+        ],
+      ),
+      returnsNormally,
+    );
+
+    final people = PeopleService.aggregateAdo(
+      repoDisplay: 'org/project/repo',
+      now: now,
+      prs: [
+        null,
+        {
+          'createdBy': {'displayName': false},
+          'creationDate': 123,
+          'reviewers': [
+            {'displayName': 9},
+          ],
+        },
+      ],
+    );
+    expect(people, isEmpty);
+  });
+}

--- a/test/snooze_store_test.dart
+++ b/test/snooze_store_test.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/snooze_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('round-trips a timed snooze and unsnooze', () async {
+    await SnoozeStore.snooze(
+      'item-1',
+      forDuration: const Duration(hours: 1),
+    );
+
+    expect(await SnoozeStore.isSnoozed('item-1'), isTrue);
+    expect(await SnoozeStore.snoozedIds(), contains('item-1'));
+
+    await SnoozeStore.unsnooze('item-1');
+
+    expect(await SnoozeStore.isSnoozed('item-1'), isFalse);
+    expect(await SnoozeStore.snoozedIds(), isNot(contains('item-1')));
+  });
+
+  test('round-trips dismiss forever', () async {
+    await SnoozeStore.snooze('item-2');
+
+    expect(await SnoozeStore.isSnoozed('item-2'), isTrue);
+    expect(await SnoozeStore.snoozedIds(), contains('item-2'));
+
+    final prefs = await SharedPreferences.getInstance();
+    final stored = jsonDecode(
+      prefs.getString('snoozed_attention')!,
+    ) as Map<String, dynamic>;
+    expect(stored['item-2'], isNull);
+  });
+
+  test('pruneExpired removes expired entries and keeps active entries', () {
+    final now = DateTime.fromMillisecondsSinceEpoch(1000);
+
+    final pruned = SnoozeStore.pruneExpired(
+      <String, int?>{
+        'expired': 999,
+        'exactly-now': 1000,
+        'future': 1001,
+        'forever': null,
+      },
+      now,
+    );
+
+    expect(
+      pruned,
+      <String, int?>{
+        'future': 1001,
+        'forever': null,
+      },
+    );
+  });
+}


### PR DESCRIPTION
Builds three parallel slices of the monitoring roadmap on top of the Attention Inbox (M2).

## M5-lite — caching & rate-limit foundation
- `CachedHttpClient` (`lib/api_cache.dart`): ETag / `If-None-Match` → 304 reuse, bounded LRU `ResponseCache`, **per host + token-scope** rate-limit tracking with `Retry-After` backoff, and **token-scoped cache keys** (no cross-token private-data leakage).
- `AppHttp.client` shares one instance app-wide, injected into Radar / Inbox / People fetches.

## M3 — People + identity
- People view ranked by review load, **union-find identity resolution** (merge by shared login/name), a "You" badge, and a self-identity setter.
- `IdentityStore` persists your GitHub logins / ADO names locally.

## Inbox polish
- Swipe-to-**snooze (1 day)** / **dismiss** with Undo, a **Mine/All** filter (uses identity + PR author/reviewer), and **local notifications** for genuinely new items (first load seeds silently, no burst).

## Notes
- All storage is local (SharedPreferences); no new DB dependency.
- Reviewed via code-review + rubber-duck; feedback implemented (rate-limit scoping, ADO name parsing, ADO pending-review semantics, notification first-run seeding, snooze/Undo race) with regression tests.
- Known follow-up: ADO identities are keyed by display name (rare same-name collisions) — a later pass should key by `uniqueName`.

**Validation:** `flutter analyze` clean, `dart format` clean, **60 tests pass** (12 new).