### PR TITLE
chore: upgrade Flutter to 3.44.6 and update dependencies

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.6'
           channel: 'stable'
           cache: true
 
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.6'
           channel: 'stable'
           cache: true
 
@@ -135,7 +135,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.6'
           channel: 'stable'
           cache: true
 
@@ -178,7 +178,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.6'
           channel: 'stable'
           cache: true
 
@@ -229,7 +229,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.6'
           channel: 'stable'
           cache: true
 
@@ -272,7 +272,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.6'
           channel: 'stable'
           cache: true
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Add the INTERNET permission -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Required to show notifications on Android 13+ (API 33+) -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <application
         android:label="kode_radar"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.kode_radar">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Add the INTERNET permission -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.5.2" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "1.9.25" apply false
 }
 

--- a/lib/activity_service.dart
+++ b/lib/activity_service.dart
@@ -129,8 +129,12 @@ class ActivityService {
 
     final result = _lowerString(build['result']);
     if (result == 'succeeded') return 'success';
-    if (const {'failed', 'canceled', 'cancelled', 'partiallysucceeded'}
-        .contains(result)) {
+    if (const {
+      'failed',
+      'canceled',
+      'cancelled',
+      'partiallysucceeded',
+    }.contains(result)) {
       return 'failure';
     }
 
@@ -158,8 +162,9 @@ class ActivityService {
     // Attention weighting: failing CI and long-stuck PRs raise the score so
     // repos that need a human bubble up, not just busy ones.
     final ciBonus = ciStatus == 'failure' ? 5 : 0;
-    final staleBonus =
-        (oldestOpenPrAgeDays != null && oldestOpenPrAgeDays > 14) ? 3 : 0;
+    final staleBonus = (oldestOpenPrAgeDays != null && oldestOpenPrAgeDays > 14)
+        ? 3
+        : 0;
     return openPrCount +
         (needsReviewCount * 2) +
         recencyBonus +
@@ -193,8 +198,9 @@ class ActivityService {
       if (item is! Map) continue;
       final reviewers = item['reviewers'];
       if (reviewers is List &&
-          reviewers.any((reviewer) =>
-              reviewer is Map && _intValue(reviewer['vote']) == 0)) {
+          reviewers.any(
+            (reviewer) => reviewer is Map && _intValue(reviewer['vote']) == 0,
+          )) {
         count++;
       }
     }
@@ -359,10 +365,7 @@ class ActivityService {
               Uri.https(
                 'dev.azure.com',
                 '/$organization/$project/_apis/git/repositories/$name/pullrequests',
-                {
-                  'searchCriteria.status': 'active',
-                  'api-version': '6.0',
-                },
+                {'searchCriteria.status': 'active', 'api-version': '6.0'},
               ),
               headers: headers,
             )
@@ -485,8 +488,10 @@ class ActivityService {
           final tokenId = _stringValue(decoded, 'tokenId');
           tasks.add(() async {
             try {
-              final secret =
-                  await TokenStore.resolveGithubSecret(owner, tokenId: tokenId);
+              final secret = await TokenStore.resolveGithubSecret(
+                owner,
+                tokenId: tokenId,
+              );
               return await computeForGithub(
                 owner: owner,
                 name: name,
@@ -518,8 +523,11 @@ class ActivityService {
           if (organization == null || project == null || name == null) {
             continue;
           }
-          final repoKey =
-              RepoDiscoveryService.adoKey(organization, project, name);
+          final repoKey = RepoDiscoveryService.adoKey(
+            organization,
+            project,
+            name,
+          );
           final tokenId = _stringValue(decoded, 'tokenId');
           tasks.add(() async {
             try {
@@ -560,8 +568,8 @@ class ActivityService {
         final byScore = b.activityScore.compareTo(a.activityScore);
         if (byScore != 0) return byScore;
         return a.displayName.toLowerCase().compareTo(
-              b.displayName.toLowerCase(),
-            );
+          b.displayName.toLowerCase(),
+        );
       });
       return activities;
     } finally {

--- a/lib/add_edit_token_page.dart
+++ b/lib/add_edit_token_page.dart
@@ -84,9 +84,9 @@ class _AddEditTokenPageState extends State<AddEditTokenPage> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to save token: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Failed to save token: $e')));
       return;
     }
     if (!mounted) return;
@@ -112,9 +112,9 @@ class _AddEditTokenPageState extends State<AddEditTokenPage> {
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     } else if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not open $url')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not open $url')));
     }
   }
 
@@ -253,31 +253,33 @@ class _AddEditTokenPageState extends State<AddEditTokenPage> {
                 ),
               ),
               const SizedBox(height: 12),
-              Builder(builder: (context) {
-                final scopeEmpty = _scopeController.text.trim().isEmpty;
-                final adoNeedsScope =
-                    _provider == TokenStore.providerAdo && scopeEmpty;
-                return CheckboxListTile(
-                  contentPadding: EdgeInsets.zero,
-                  controlAffinity: ListTileControlAffinity.leading,
-                  value: _autoAdd,
-                  onChanged: adoNeedsScope
-                      ? null
-                      : (value) => setState(() => _autoAdd = value ?? false),
-                  title: const Text('Automatically add new repositories'),
-                  subtitle: Text(
-                    adoNeedsScope
-                        ? 'Enter an organization scope above to enable auto-add '
-                            'for Azure DevOps.'
-                        : isGithub
-                            ? 'Periodically adds repos this token can see'
+              Builder(
+                builder: (context) {
+                  final scopeEmpty = _scopeController.text.trim().isEmpty;
+                  final adoNeedsScope =
+                      _provider == TokenStore.providerAdo && scopeEmpty;
+                  return CheckboxListTile(
+                    contentPadding: EdgeInsets.zero,
+                    controlAffinity: ListTileControlAffinity.leading,
+                    value: _autoAdd,
+                    onChanged: adoNeedsScope
+                        ? null
+                        : (value) => setState(() => _autoAdd = value ?? false),
+                    title: const Text('Automatically add new repositories'),
+                    subtitle: Text(
+                      adoNeedsScope
+                          ? 'Enter an organization scope above to enable auto-add '
+                                'for Azure DevOps.'
+                          : isGithub
+                          ? 'Periodically adds repos this token can see'
                                 '${scopeEmpty ? ' (all accessible repos)' : ' in "${_scopeController.text.trim()}"'}. '
                                 'A removed repo will be re-added while this is on.'
-                            : 'Periodically adds repos in the organization above. '
+                          : 'Periodically adds repos in the organization above. '
                                 'A removed repo will be re-added while this is on.',
-                  ),
-                );
-              }),
+                    ),
+                  );
+                },
+              ),
               const SizedBox(height: 24),
               Center(
                 child: ElevatedButton(

--- a/lib/api_cache.dart
+++ b/lib/api_cache.dart
@@ -5,8 +5,8 @@ import 'package:http/http.dart' as http;
 
 class CachedHttpClient extends http.BaseClient {
   CachedHttpClient({http.Client? inner, ResponseCache? cache})
-      : _inner = inner ?? http.Client(),
-        _cache = cache ?? ResponseCache();
+    : _inner = inner ?? http.Client(),
+      _cache = cache ?? ResponseCache();
 
   final http.Client _inner;
   final ResponseCache _cache;
@@ -217,8 +217,8 @@ class CachedResponse {
     required this.storedAt,
     DateTime? lastUsed,
     Map<String, String> headers = const <String, String>{},
-  })  : lastUsed = lastUsed ?? storedAt,
-        headers = Map.unmodifiable(headers);
+  }) : lastUsed = lastUsed ?? storedAt,
+       headers = Map.unmodifiable(headers);
 
   final String etag;
   final String body;
@@ -247,11 +247,7 @@ class CachedResponse {
 }
 
 class RateLimitStatus {
-  const RateLimitStatus({
-    this.remaining,
-    this.resetAt,
-    this.retryAfter,
-  });
+  const RateLimitStatus({this.remaining, this.resetAt, this.retryAfter});
 
   final int? remaining;
   final DateTime? resetAt;
@@ -284,19 +280,14 @@ RateLimitStatus parseRateLimit(Map<String, String> headers) {
     remaining: remaining,
     resetAt: resetSeconds == null
         ? null
-        : DateTime.fromMillisecondsSinceEpoch(
-            resetSeconds * 1000,
-            isUtc: true,
-          ),
-    retryAfter:
-        retryAfterSeconds == null ? null : Duration(seconds: retryAfterSeconds),
+        : DateTime.fromMillisecondsSinceEpoch(resetSeconds * 1000, isUtc: true),
+    retryAfter: retryAfterSeconds == null
+        ? null
+        : Duration(seconds: retryAfterSeconds),
   );
 }
 
-bool shouldUseCachedResponseForRateLimit(
-  RateLimitStatus status,
-  DateTime now,
-) {
+bool shouldUseCachedResponseForRateLimit(RateLimitStatus status, DateTime now) {
   final resetAt = status.resetAt;
   return status.remaining == 0 && resetAt != null && resetAt.isAfter(now);
 }
@@ -310,8 +301,10 @@ String cacheKey(http.BaseRequest request) {
 }
 
 http.StreamedResponse _streamedFromCached(
-    CachedResponse cached, http.BaseRequest request,
-    {int? statusCode}) {
+  CachedResponse cached,
+  http.BaseRequest request, {
+  int? statusCode,
+}) {
   final bytes = utf8.encode(cached.body);
   final headers = Map<String, String>.from(cached.headers);
   headers.putIfAbsent('etag', () => cached.etag);

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -78,10 +78,12 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         actions: [
           IconButton(
             icon: Icon(_mineOnly ? Icons.person : Icons.groups),
-            tooltip:
-                _mineOnly ? 'Showing yours — tap for all' : 'Show only mine',
-            onPressed:
-                _loading ? null : () => setState(() => _mineOnly = !_mineOnly),
+            tooltip: _mineOnly
+                ? 'Showing yours — tap for all'
+                : 'Show only mine',
+            onPressed: _loading
+                ? null
+                : () => setState(() => _mineOnly = !_mineOnly),
           ),
           IconButton(
             icon: const Icon(Icons.refresh),
@@ -103,7 +105,8 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         children: [
           const SizedBox(height: 160),
           Center(
-              child: Text(_error!, style: const TextStyle(color: Colors.red))),
+            child: Text(_error!, style: const TextStyle(color: Colors.red)),
+          ),
         ],
       );
     }
@@ -114,7 +117,7 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
     return ListView.separated(
       physics: const AlwaysScrollableScrollPhysics(),
       itemCount: visible.length + 1,
-      separatorBuilder: (_, __) => const Divider(height: 1),
+      separatorBuilder: (_, _) => const Divider(height: 1),
       itemBuilder: (context, index) {
         if (index == 0) return _buildHeader(visible.length);
         return _buildItemTile(visible[index - 1]);
@@ -136,8 +139,11 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       children: [
         const SizedBox(height: 140),
         Center(
-          child: Icon(Icons.check_circle_outline,
-              size: 56, color: Colors.green[400]),
+          child: Icon(
+            Icons.check_circle_outline,
+            size: 56,
+            color: Colors.green[400],
+          ),
         ),
         const SizedBox(height: 12),
         Center(child: Text(message, textAlign: TextAlign.center)),
@@ -189,8 +195,9 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         leading: Icon(visual.icon, color: visual.color),
         title: Text(item.title),
         subtitle: Text(item.subtitle),
-        trailing:
-            item.url != null ? const Icon(Icons.open_in_new, size: 16) : null,
+        trailing: item.url != null
+            ? const Icon(Icons.open_in_new, size: 16)
+            : null,
         onTap: item.url == null ? null : () => _open(item.url!),
       ),
     );
@@ -288,8 +295,8 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
   }
 
   void _showOpenError(String url) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Could not open $url')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Could not open $url')));
   }
 }

--- a/lib/attention_service.dart
+++ b/lib/attention_service.dart
@@ -97,19 +97,38 @@ class AttentionService {
           if (login != null) reviewerLogins.add(login.trim().toLowerCase());
         }
       }
-      final waitingOnReview = (reviewers is List && reviewers.isNotEmpty) ||
+      final waitingOnReview =
+          (reviewers is List && reviewers.isNotEmpty) ||
           (teams is List && teams.isNotEmpty);
-      final mine = self.isNotEmpty &&
+      final mine =
+          self.isNotEmpty &&
           (self.contains(author.trim().toLowerCase()) ||
               reviewerLogins.any(self.contains));
 
       if (waitingOnReview) {
-        items.add(_reviewRequested(
-            repoDisplay, 'PR #$number', title, author, age, url,
-            isMine: mine));
+        items.add(
+          _reviewRequested(
+            repoDisplay,
+            'PR #$number',
+            title,
+            author,
+            age,
+            url,
+            isMine: mine,
+          ),
+        );
       } else if ((age ?? 0) > oldOpenPrDays) {
-        items.add(_oldOpen(repoDisplay, 'PR #$number', title, author, age, url,
-            isMine: mine));
+        items.add(
+          _oldOpen(
+            repoDisplay,
+            'PR #$number',
+            title,
+            author,
+            age,
+            url,
+            isMine: mine,
+          ),
+        );
       }
     }
     return items;
@@ -137,7 +156,7 @@ class AttentionService {
       final url = id == null
           ? null
           : 'https://dev.azure.com/$organization/$project/_git/$name/'
-              'pullrequest/$id';
+                'pullrequest/$id';
 
       // ADO reviewer votes: 10 approved, 5 approved-with-suggestions,
       // 0 no vote yet, -5 waiting for author, -10 rejected.
@@ -154,29 +173,61 @@ class AttentionService {
       }
       final changesRequested = votes.any((v) => v is int && v < 0);
       final waitingOnReview = votes.any((v) => v == 0);
-      final mine = self.isNotEmpty &&
+      final mine =
+          self.isNotEmpty &&
           (self.contains(author.trim().toLowerCase()) ||
               reviewerNames.any(self.contains));
 
       if (changesRequested) {
-        items.add(_changesRequested(
-            repoDisplay, 'PR #$id', title, author, age, url,
-            isMine: mine));
+        items.add(
+          _changesRequested(
+            repoDisplay,
+            'PR #$id',
+            title,
+            author,
+            age,
+            url,
+            isMine: mine,
+          ),
+        );
       } else if (waitingOnReview) {
-        items.add(_reviewRequested(
-            repoDisplay, 'PR #$id', title, author, age, url,
-            isMine: mine));
+        items.add(
+          _reviewRequested(
+            repoDisplay,
+            'PR #$id',
+            title,
+            author,
+            age,
+            url,
+            isMine: mine,
+          ),
+        );
       } else if ((age ?? 0) > oldOpenPrDays) {
-        items.add(_oldOpen(repoDisplay, 'PR #$id', title, author, age, url,
-            isMine: mine));
+        items.add(
+          _oldOpen(
+            repoDisplay,
+            'PR #$id',
+            title,
+            author,
+            age,
+            url,
+            isMine: mine,
+          ),
+        );
       }
     }
     return items;
   }
 
-  static AttentionItem _reviewRequested(String repoDisplay, String prLabel,
-      String title, String author, int? ageDays, String? url,
-      {bool isMine = false}) {
+  static AttentionItem _reviewRequested(
+    String repoDisplay,
+    String prLabel,
+    String title,
+    String author,
+    int? ageDays,
+    String? url, {
+    bool isMine = false,
+  }) {
     return AttentionItem(
       id: 'reviewRequested:$repoDisplay:$prLabel',
       category: 'reviewRequested',
@@ -191,9 +242,15 @@ class AttentionService {
     );
   }
 
-  static AttentionItem _changesRequested(String repoDisplay, String prLabel,
-      String title, String author, int? ageDays, String? url,
-      {bool isMine = false}) {
+  static AttentionItem _changesRequested(
+    String repoDisplay,
+    String prLabel,
+    String title,
+    String author,
+    int? ageDays,
+    String? url, {
+    bool isMine = false,
+  }) {
     return AttentionItem(
       id: 'changesRequested:$repoDisplay:$prLabel',
       category: 'changesRequested',
@@ -208,9 +265,15 @@ class AttentionService {
     );
   }
 
-  static AttentionItem _oldOpen(String repoDisplay, String prLabel,
-      String title, String author, int? ageDays, String? url,
-      {bool isMine = false}) {
+  static AttentionItem _oldOpen(
+    String repoDisplay,
+    String prLabel,
+    String title,
+    String author,
+    int? ageDays,
+    String? url, {
+    bool isMine = false,
+  }) {
     return AttentionItem(
       id: 'oldOpenPr:$repoDisplay:$prLabel',
       category: 'oldOpenPr',
@@ -286,8 +349,16 @@ class AttentionService {
         final name = _stringValue(map, 'repoName');
         if (owner == null || name == null) continue;
         final tokenId = _stringValue(map, 'tokenId');
-        tasks.add(() => _githubRepoItems(
-            httpClient, owner, name, tokenId, effectiveNow, selfGithubLogins));
+        tasks.add(
+          () => _githubRepoItems(
+            httpClient,
+            owner,
+            name,
+            tokenId,
+            effectiveNow,
+            selfGithubLogins,
+          ),
+        );
       }
 
       for (final raw in adoRepos) {
@@ -298,8 +369,17 @@ class AttentionService {
         final name = _stringValue(map, 'repoName');
         if (organization == null || project == null || name == null) continue;
         final tokenId = _stringValue(map, 'tokenId');
-        tasks.add(() => _adoRepoItems(httpClient, organization, project, name,
-            tokenId, effectiveNow, selfAdoNames));
+        tasks.add(
+          () => _adoRepoItems(
+            httpClient,
+            organization,
+            project,
+            name,
+            tokenId,
+            effectiveNow,
+            selfAdoNames,
+          ),
+        );
       }
 
       final grouped = await _runBounded(tasks, concurrency);
@@ -320,40 +400,47 @@ class AttentionService {
   }
 
   static Future<List<AttentionItem>> _githubRepoItems(
-      http.Client client,
-      String owner,
-      String name,
-      String? tokenId,
-      DateTime now,
-      Set<String> selfGithubLogins) async {
+    http.Client client,
+    String owner,
+    String name,
+    String? tokenId,
+    DateTime now,
+    Set<String> selfGithubLogins,
+  ) async {
     final repoDisplay = '$owner/$name';
     try {
-      final secret =
-          (await TokenStore.resolveGithubSecret(owner, tokenId: tokenId))
-              ?.trim();
+      final secret = (await TokenStore.resolveGithubSecret(
+        owner,
+        tokenId: tokenId,
+      ))?.trim();
       if (secret == null || secret.isEmpty) {
         return [_errorItem(repoDisplay, 'No token set')];
       }
-      final response = await client.get(
-        Uri.https('api.github.com', '/repos/$owner/$name/pulls',
-            {'state': 'open', 'per_page': '100'}),
-        headers: {
-          'Authorization': 'Bearer $secret',
-          'Accept': 'application/vnd.github+json',
-        },
-      ).timeout(_requestTimeout);
+      final response = await client
+          .get(
+            Uri.https('api.github.com', '/repos/$owner/$name/pulls', {
+              'state': 'open',
+              'per_page': '100',
+            }),
+            headers: {
+              'Authorization': 'Bearer $secret',
+              'Accept': 'application/vnd.github+json',
+            },
+          )
+          .timeout(_requestTimeout);
       if (response.statusCode != 200) {
         return [
-          _errorItem(repoDisplay, 'GitHub returned ${response.statusCode}')
+          _errorItem(repoDisplay, 'GitHub returned ${response.statusCode}'),
         ];
       }
       final body = jsonDecode(response.body);
       if (body is! List) return const [];
       return githubItems(
-          repoDisplay: repoDisplay,
-          prs: body,
-          now: now,
-          selfGithubLogins: selfGithubLogins);
+        repoDisplay: repoDisplay,
+        prs: body,
+        now: now,
+        selfGithubLogins: selfGithubLogins,
+      );
     } catch (e) {
       debugPrint('AttentionService GitHub fetch failed for $repoDisplay: $e');
       return [_errorItem(repoDisplay, 'Could not load pull requests')];
@@ -361,35 +448,41 @@ class AttentionService {
   }
 
   static Future<List<AttentionItem>> _adoRepoItems(
-      http.Client client,
-      String organization,
-      String project,
-      String name,
-      String? tokenId,
-      DateTime now,
-      Set<String> selfAdoNames) async {
+    http.Client client,
+    String organization,
+    String project,
+    String name,
+    String? tokenId,
+    DateTime now,
+    Set<String> selfAdoNames,
+  ) async {
     final repoDisplay = '$organization/$project/$name';
     try {
-      final secret =
-          (await TokenStore.resolveAdoSecret(organization, tokenId: tokenId))
-              ?.trim();
+      final secret = (await TokenStore.resolveAdoSecret(
+        organization,
+        tokenId: tokenId,
+      ))?.trim();
       if (secret == null || secret.isEmpty) {
         return [_errorItem(repoDisplay, 'No token set')];
       }
-      final response = await client.get(
-        Uri.https(
-          'dev.azure.com',
-          '/$organization/$project/_apis/git/repositories/$name/pullrequests',
-          {'searchCriteria.status': 'active', 'api-version': '6.0'},
-        ),
-        headers: {
-          'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
-        },
-      ).timeout(_requestTimeout);
+      final response = await client
+          .get(
+            Uri.https(
+              'dev.azure.com',
+              '/$organization/$project/_apis/git/repositories/$name/pullrequests',
+              {'searchCriteria.status': 'active', 'api-version': '6.0'},
+            ),
+            headers: {
+              'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
+            },
+          )
+          .timeout(_requestTimeout);
       if (response.statusCode != 200) {
         return [
           _errorItem(
-              repoDisplay, 'Azure DevOps returned ${response.statusCode}')
+            repoDisplay,
+            'Azure DevOps returned ${response.statusCode}',
+          ),
         ];
       }
       final body = jsonDecode(response.body);

--- a/lib/auto_add_service.dart
+++ b/lib/auto_add_service.dart
@@ -16,8 +16,9 @@ class AutoAddService {
   ///
   /// Provide [client] to reuse a connection (and in tests).
   static Future<int> run({http.Client? client}) async {
-    final autoTokens =
-        (await TokenStore.getTokens()).where((t) => t.autoAdd).toList();
+    final autoTokens = (await TokenStore.getTokens())
+        .where((t) => t.autoAdd)
+        .toList();
     if (autoTokens.isEmpty) return 0;
 
     // Process scoped tokens before default (unscoped) ones so a scoped token
@@ -71,10 +72,12 @@ class AutoAddService {
     // repo is never re-added and no UI change is clobbered.
     return RepoStore.runLocked(() async {
       final prefs = await SharedPreferences.getInstance();
-      final github =
-          List<String>.of(prefs.getStringList(RepoStore.githubKey) ?? const []);
-      final ado =
-          List<String>.of(prefs.getStringList(RepoStore.adoKey) ?? const []);
+      final github = List<String>.of(
+        prefs.getStringList(RepoStore.githubKey) ?? const [],
+      );
+      final ado = List<String>.of(
+        prefs.getStringList(RepoStore.adoKey) ?? const [],
+      );
       final ignored = IgnoreStore.readFrom(prefs);
       final existing = _existingKeys(github, ado);
       var added = 0;
@@ -105,15 +108,24 @@ class AutoAddService {
     for (final raw in githubRepos) {
       try {
         final map = Map<String, String>.from(jsonDecode(raw) as Map);
-        keys.add(RepoDiscoveryService.githubKey(
-            map['owner'] ?? '', map['repoName'] ?? ''));
+        keys.add(
+          RepoDiscoveryService.githubKey(
+            map['owner'] ?? '',
+            map['repoName'] ?? '',
+          ),
+        );
       } catch (_) {}
     }
     for (final raw in adoRepos) {
       try {
         final map = Map<String, String>.from(jsonDecode(raw) as Map);
-        keys.add(RepoDiscoveryService.adoKey(map['organization'] ?? '',
-            map['project'] ?? '', map['repoName'] ?? ''));
+        keys.add(
+          RepoDiscoveryService.adoKey(
+            map['organization'] ?? '',
+            map['project'] ?? '',
+            map['repoName'] ?? '',
+          ),
+        );
       } catch (_) {}
     }
     return keys;

--- a/lib/identity_store.dart
+++ b/lib/identity_store.dart
@@ -44,8 +44,10 @@ class IdentityStore {
     try {
       final decoded = jsonDecode(raw);
       if (decoded is! List) return <String>{};
-      return _normalizedSorted(decoded.whereType<String>().toSet(), normalize)
-          .toSet();
+      return _normalizedSorted(
+        decoded.whereType<String>().toSet(),
+        normalize,
+      ).toSet();
     } catch (_) {
       return <String>{};
     }
@@ -55,8 +57,10 @@ class IdentityStore {
     Iterable<String> values,
     String Function(String) normalize,
   ) {
-    final normalized =
-        values.map(normalize).where((value) => value.isNotEmpty).toSet();
+    final normalized = values
+        .map(normalize)
+        .where((value) => value.isNotEmpty)
+        .toSet();
     return normalized.toList()..sort();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,12 @@ void main() async {
     macOS: initializationSettingsDarwin,
   );
   await _notificationsPlugin.initialize(settings: initializationSettings);
+  // Android 13+ (API 33+) requires the runtime POST_NOTIFICATIONS grant.
+  await _notificationsPlugin
+      .resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin
+      >()
+      ?.requestNotificationsPermission();
 
   if (_isDesktopPlatform) {
     await windowManager.ensureInitialized(); // Initialize window manager

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,10 +32,10 @@ void main() async {
       AndroidInitializationSettings('@mipmap/ic_launcher');
   const DarwinInitializationSettings initializationSettingsDarwin =
       DarwinInitializationSettings(
-    requestAlertPermission: true,
-    requestBadgePermission: true,
-    requestSoundPermission: true,
-  );
+        requestAlertPermission: true,
+        requestBadgePermission: true,
+        requestSoundPermission: true,
+      );
   const InitializationSettings initializationSettings = InitializationSettings(
     android: initializationSettingsAndroid,
     iOS: initializationSettingsDarwin,
@@ -69,7 +69,8 @@ void main() async {
     if (e is SocketException) {
       if (kDebugMode) {
         print(
-            'SocketException: Check if the ports are already in use or if permissions are missing.');
+          'SocketException: Check if the ports are already in use or if permissions are missing.',
+        );
       }
     }
   }
@@ -82,10 +83,14 @@ bool get _isDesktopPlatform =>
 
 Future<void> _initializeSystemTray() async {
   await trayManager.setIcon('assets/app_icon.png'); // Set the tray icon
-  trayManager.setContextMenu(Menu(items: [
-    MenuItem(key: 'show', label: 'Show App'),
-    MenuItem(key: 'exit', label: 'Exit'),
-  ]));
+  trayManager.setContextMenu(
+    Menu(
+      items: [
+        MenuItem(key: 'show', label: 'Show App'),
+        MenuItem(key: 'exit', label: 'Exit'),
+      ],
+    ),
+  );
 
   trayManager.addListener(_TrayManagerListener());
 }
@@ -256,7 +261,12 @@ class _MyHomePageState extends State<MyHomePage>
           if (owner == null || repoName == null) continue;
           final repoKey = 'GitHub: $owner/$repoName';
           await _fetchGithubData(
-              owner, repoName, repoKey, newData, repoMap['tokenId']);
+            owner,
+            repoName,
+            repoKey,
+            newData,
+            repoMap['tokenId'],
+          );
         } catch (e) {
           // Skip a malformed entry rather than aborting the whole refresh.
           if (kDebugMode) {
@@ -275,8 +285,14 @@ class _MyHomePageState extends State<MyHomePage>
             continue;
           }
           final repoKey = 'ADO: $organization/$project/$repoName';
-          await _fetchAdoData(organization, project, repoName, repoKey, newData,
-              repoMap['tokenId']);
+          await _fetchAdoData(
+            organization,
+            project,
+            repoName,
+            repoKey,
+            newData,
+            repoMap['tokenId'],
+          );
         } catch (e) {
           if (kDebugMode) {
             print('Skipping malformed ado_repos entry: $e');
@@ -288,8 +304,9 @@ class _MyHomePageState extends State<MyHomePage>
         setState(() {
           if (initialLoad || !_isDataEqual(_data, newData)) {
             _previousData.clear();
-            _previousData
-                .addAll(_data); // Save the current data as previous data
+            _previousData.addAll(
+              _data,
+            ); // Save the current data as previous data
             _data.clear();
             _data.addAll(newData); // only if it has changed
           }
@@ -304,8 +321,13 @@ class _MyHomePageState extends State<MyHomePage>
     }
   }
 
-  Future<void> _fetchGithubData(String owner, String repoName, String repoKey,
-      Map<String, Map<String, List<String>>> newData, String? tokenId) async {
+  Future<void> _fetchGithubData(
+    String owner,
+    String repoName,
+    String repoKey,
+    Map<String, Map<String, List<String>>> newData,
+    String? tokenId,
+  ) async {
     final token = await TokenStore.resolveGithubSecret(owner, tokenId: tokenId);
     await _fetchData(
       repoKey,
@@ -314,25 +336,26 @@ class _MyHomePageState extends State<MyHomePage>
       (data) async {
         final bool isBaselined = _baselinedRepos.contains(repoKey);
         final List<String> prNotifications = [];
-        return Future.value(data.map((pr) {
-          final title = pr['title'] as String? ?? 'No Title';
-          final number = pr['number'] as int? ?? 0;
-          final user = pr['user']?['login'] as String? ?? 'Unknown User';
-          final comments = pr['comments'] as int? ?? 0;
+        return Future.value(
+          data.map((pr) {
+            final title = pr['title'] as String? ?? 'No Title';
+            final number = pr['number'] as int? ?? 0;
+            final user = pr['user']?['login'] as String? ?? 'Unknown User';
+            final comments = pr['comments'] as int? ?? 0;
 
-          final notificationKey = 'GitHub:$repoKey:PR#$number';
-          if (!_notifiedItems.contains(notificationKey)) {
-            // Only notify once the repo has been baselined; the first fetch of
-            // a newly-added repo records existing PRs silently.
-            if (isBaselined) {
-              prNotifications.add('New PR #$number by $user: $title');
+            final notificationKey = 'GitHub:$repoKey:PR#$number';
+            if (!_notifiedItems.contains(notificationKey)) {
+              // Only notify once the repo has been baselined; the first fetch of
+              // a newly-added repo records existing PRs silently.
+              if (isBaselined) {
+                prNotifications.add('New PR #$number by $user: $title');
+              }
+              _notifiedItems.add(notificationKey); // Mark as notified
             }
-            _notifiedItems.add(notificationKey); // Mark as notified
-          }
 
-          return 'PR #$number by $user: $title ($comments comments)';
-        }).toList())
-            .then((prList) {
+            return 'PR #$number by $user: $title ($comments comments)';
+          }).toList(),
+        ).then((prList) {
           if (!isBaselined) {
             _baselinedRepos.add(repoKey);
             _saveBaselinedRepos();
@@ -353,11 +376,14 @@ class _MyHomePageState extends State<MyHomePage>
       repoKey,
       'Releases',
       Uri.parse('https://api.github.com/repos/$owner/$repoName/releases'),
-      (data) async => Future.value(data.map((release) {
-        final name = release['name'] as String? ??
-            'Unnamed Release'; // Safely access the name
-        return name;
-      }).toList()),
+      (data) async => Future.value(
+        data.map((release) {
+          final name =
+              release['name'] as String? ??
+              'Unnamed Release'; // Safely access the name
+          return name;
+        }).toList(),
+      ),
       true, // GitHub
       newData,
       token,
@@ -365,41 +391,47 @@ class _MyHomePageState extends State<MyHomePage>
   }
 
   Future<void> _fetchAdoData(
-      String organization,
-      String project,
-      String repoName,
-      String repoKey,
-      Map<String, Map<String, List<String>>> newData,
-      String? tokenId) async {
-    final token =
-        await TokenStore.resolveAdoSecret(organization, tokenId: tokenId);
+    String organization,
+    String project,
+    String repoName,
+    String repoKey,
+    Map<String, Map<String, List<String>>> newData,
+    String? tokenId,
+  ) async {
+    final token = await TokenStore.resolveAdoSecret(
+      organization,
+      tokenId: tokenId,
+    );
     await _fetchData(
       repoKey,
       'PRs',
       Uri.parse(
-          'https://dev.azure.com/$organization/$project/_apis/git/repositories/$repoName/pullrequests?api-version=6.0'),
+        'https://dev.azure.com/$organization/$project/_apis/git/repositories/$repoName/pullrequests?api-version=6.0',
+      ),
       (data) async {
         final bool isBaselined = _baselinedRepos.contains(repoKey);
         final List<String> prNotifications = [];
-        return Future.value(data.map((pr) {
-          final title = pr['title'] as String? ?? 'No Title';
-          final id = pr['pullRequestId'] as int? ?? 0;
-          final creator =
-              pr['createdBy']?['displayName'] as String? ?? 'Unknown Creator';
-          final status = pr['status'] as String? ?? 'Unknown Status';
+        return Future.value(
+          data.map((pr) {
+            final title = pr['title'] as String? ?? 'No Title';
+            final id = pr['pullRequestId'] as int? ?? 0;
+            final creator =
+                pr['createdBy']?['displayName'] as String? ?? 'Unknown Creator';
+            final status = pr['status'] as String? ?? 'Unknown Status';
 
-          final notificationKey = 'ADO:$repoKey:PR#$id';
-          if (!_notifiedItems.contains(notificationKey)) {
-            if (isBaselined) {
-              prNotifications
-                  .add('New PR #$id by $creator: $title (Status: $status)');
+            final notificationKey = 'ADO:$repoKey:PR#$id';
+            if (!_notifiedItems.contains(notificationKey)) {
+              if (isBaselined) {
+                prNotifications.add(
+                  'New PR #$id by $creator: $title (Status: $status)',
+                );
+              }
+              _notifiedItems.add(notificationKey); // Mark as notified
             }
-            _notifiedItems.add(notificationKey); // Mark as notified
-          }
 
-          return 'PR #$id by $creator: $title (Status: $status)';
-        }).toList())
-            .then((prList) {
+            return 'PR #$id by $creator: $title (Status: $status)';
+          }).toList(),
+        ).then((prList) {
           if (!isBaselined) {
             _baselinedRepos.add(repoKey);
             _saveBaselinedRepos();
@@ -420,22 +452,30 @@ class _MyHomePageState extends State<MyHomePage>
       repoKey,
       'Builds',
       Uri.parse(
-          'https://dev.azure.com/$organization/$project/_apis/build/builds?api-version=6.0'),
+        'https://dev.azure.com/$organization/$project/_apis/build/builds?api-version=6.0',
+      ),
       (data) async {
-        return await Future.wait(data.map((build) async {
-          final name =
-              build['definition']['name'] as String? ?? 'Unnamed Build';
-          final requestedBy =
-              build['requestedBy']?['displayName'] as String? ?? 'Unknown User';
-          final buildId = build['id'] as int?;
-          if (buildId != null) {
-            final stages =
-                await _fetchBuildStages(organization, project, buildId, token);
-            final stagesText = stages.map((stage) => '- $stage').join('\n');
-            return '$name (Triggered by: $requestedBy)\nStages:\n$stagesText';
-          }
-          return '$name (Triggered by: $requestedBy)';
-        }).toList());
+        return await Future.wait(
+          data.map((build) async {
+            final name =
+                build['definition']['name'] as String? ?? 'Unnamed Build';
+            final requestedBy =
+                build['requestedBy']?['displayName'] as String? ??
+                'Unknown User';
+            final buildId = build['id'] as int?;
+            if (buildId != null) {
+              final stages = await _fetchBuildStages(
+                organization,
+                project,
+                buildId,
+                token,
+              );
+              final stagesText = stages.map((stage) => '- $stage').join('\n');
+              return '$name (Triggered by: $requestedBy)\nStages:\n$stagesText';
+            }
+            return '$name (Triggered by: $requestedBy)';
+          }).toList(),
+        );
       },
       false, // ADO
       newData,
@@ -445,12 +485,16 @@ class _MyHomePageState extends State<MyHomePage>
       repoKey,
       'Pipelines',
       Uri.parse(
-          'https://dev.azure.com/$organization/$project/_apis/pipelines?api-version=6.0'),
-      (data) async => Future.value(data.map((pipeline) {
-        final name = pipeline['name'] as String? ??
-            'Unnamed Pipeline'; // Safely access the pipeline name
-        return name;
-      }).toList()),
+        'https://dev.azure.com/$organization/$project/_apis/pipelines?api-version=6.0',
+      ),
+      (data) async => Future.value(
+        data.map((pipeline) {
+          final name =
+              pipeline['name'] as String? ??
+              'Unnamed Pipeline'; // Safely access the pipeline name
+          return name;
+        }).toList(),
+      ),
       false, // ADO
       newData,
       token,
@@ -458,13 +502,18 @@ class _MyHomePageState extends State<MyHomePage>
   }
 
   Future<List<String>> _fetchBuildStages(
-      String organization, String project, int buildId, String? token) async {
+    String organization,
+    String project,
+    int buildId,
+    String? token,
+  ) async {
     if (token == null || token.isEmpty) return ['Token not set.'];
 
     try {
       final response = await http.get(
         Uri.parse(
-            'https://dev.azure.com/$organization/$project/_apis/build/builds/$buildId/timeline?api-version=6.0'),
+          'https://dev.azure.com/$organization/$project/_apis/build/builds/$buildId/timeline?api-version=6.0',
+        ),
         headers: {
           'Authorization': 'Basic ${base64Encode(utf8.encode(':$token'))}',
         },
@@ -475,12 +524,14 @@ class _MyHomePageState extends State<MyHomePage>
         final List<dynamic> records = responseBody['records'] ?? [];
         return records
             .where(
-                (record) => record['type'] == 'Task') // Filter for task records
+              (record) => record['type'] == 'Task',
+            ) // Filter for task records
             .map((record) {
-          final name = record['name'] as String? ?? 'Unnamed Task';
-          final result = record['result'] as String? ?? 'unknown';
-          return '$name: $result';
-        }).toList();
+              final name = record['name'] as String? ?? 'Unnamed Task';
+              final result = record['result'] as String? ?? 'unknown';
+              return '$name: $result';
+            })
+            .toList();
       } else {
         return ['Failed to fetch stages (Status: ${response.statusCode})'];
       }
@@ -494,14 +545,14 @@ class _MyHomePageState extends State<MyHomePage>
     String category,
     Uri url,
     Future<List<String>> Function(List<dynamic>)
-        parseData, // Ensure parseData is consistently async
+    parseData, // Ensure parseData is consistently async
     bool isGithub,
     Map<String, Map<String, List<String>>> newData,
     String? token,
   ) async {
     if (token == null || token.isEmpty) {
       newData[category]![repoKey] = [
-        'Token not set. Add or assign a token via "Manage tokens".'
+        'Token not set. Add or assign a token via "Manage tokens".',
       ];
       return;
     }
@@ -529,11 +580,11 @@ class _MyHomePageState extends State<MyHomePage>
         newData[category]![repoKey] = parsedData;
       } else if (response.statusCode == 203) {
         newData[category]![repoKey] = [
-          'Non-authoritative response received (Status: 203). Please check your permissions or token.'
+          'Non-authoritative response received (Status: 203). Please check your permissions or token.',
         ];
       } else {
         newData[category]![repoKey] = [
-          'Failed to fetch data (Status: ${response.statusCode})'
+          'Failed to fetch data (Status: ${response.statusCode})',
         ];
       }
     } catch (e) {
@@ -541,29 +592,31 @@ class _MyHomePageState extends State<MyHomePage>
     }
   }
 
-  bool _isDataEqual(Map<String, Map<String, List<String>>> oldData,
-      Map<String, Map<String, List<String>>> newData) {
+  bool _isDataEqual(
+    Map<String, Map<String, List<String>>> oldData,
+    Map<String, Map<String, List<String>>> newData,
+  ) {
     return const DeepCollectionEquality().equals(oldData, newData);
   }
 
   Future<void> _showNotification(String title, String body) async {
     const AndroidNotificationDetails androidPlatformChannelSpecifics =
         AndroidNotificationDetails(
-      'pr_notifications', // Channel ID
-      'PR Notifications', // Channel name
-      channelDescription: 'Notifications for new PRs and comments',
-      importance: Importance.high,
-      priority: Priority.high,
-      timeoutAfter: 30000, // Notification stays visible for 30 seconds
-    );
+          'pr_notifications', // Channel ID
+          'PR Notifications', // Channel name
+          channelDescription: 'Notifications for new PRs and comments',
+          importance: Importance.high,
+          priority: Priority.high,
+          timeoutAfter: 30000, // Notification stays visible for 30 seconds
+        );
 
     const DarwinNotificationDetails darwinPlatformChannelSpecifics =
         DarwinNotificationDetails(
-      presentAlert: true, // Ensure the alert is presented
-      presentSound: true, // Ensure the sound is presented
-      interruptionLevel:
-          InterruptionLevel.active, // Critical level for visibility
-    );
+          presentAlert: true, // Ensure the alert is presented
+          presentSound: true, // Ensure the sound is presented
+          interruptionLevel:
+              InterruptionLevel.active, // Critical level for visibility
+        );
 
     const NotificationDetails platformChannelSpecifics = NotificationDetails(
       android: androidPlatformChannelSpecifics,
@@ -633,7 +686,8 @@ class _MyHomePageState extends State<MyHomePage>
       ),
       body: _isLoading
           ? const Center(
-              child: CircularProgressIndicator()) // Show a loading indicator
+              child: CircularProgressIndicator(),
+            ) // Show a loading indicator
           : TabBarView(
               controller: _tabController,
               children: _data.keys.map((category) {
@@ -686,10 +740,7 @@ class _MyHomePageState extends State<MyHomePage>
   /// added/edited/removed repositories are reflected without waiting for the
   /// next poll cycle.
   Future<void> _openRepoPage(Widget page) async {
-    await Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => page),
-    );
+    await Navigator.push(context, MaterialPageRoute(builder: (_) => page));
     if (mounted) {
       _loadRepos(initialLoad: false);
     }
@@ -713,7 +764,8 @@ class _MyHomePageState extends State<MyHomePage>
         final repoKey = data.keys.elementAt(index);
         return ExpansionTile(
           title: Text(repoKey),
-          children: data[repoKey]?.map((item) {
+          children:
+              data[repoKey]?.map((item) {
                 if (repoKey.startsWith('ADO:') && item.contains('Stages:')) {
                   final parts = item.split('\nStages:\n');
                   final buildInfo = parts[0];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,7 +41,7 @@ void main() async {
     iOS: initializationSettingsDarwin,
     macOS: initializationSettingsDarwin,
   );
-  await _notificationsPlugin.initialize(initializationSettings);
+  await _notificationsPlugin.initialize(settings: initializationSettings);
 
   if (_isDesktopPlatform) {
     await windowManager.ensureInitialized(); // Initialize window manager
@@ -570,7 +570,12 @@ class _MyHomePageState extends State<MyHomePage>
       iOS: darwinPlatformChannelSpecifics,
       macOS: darwinPlatformChannelSpecifics,
     );
-    await _notificationsPlugin.show(0, title, body, platformChannelSpecifics);
+    await _notificationsPlugin.show(
+      id: 0,
+      title: title,
+      body: body,
+      notificationDetails: platformChannelSpecifics,
+    );
   }
 
   @override

--- a/lib/manage_ignored_page.dart
+++ b/lib/manage_ignored_page.dart
@@ -71,9 +71,9 @@ class _ManageIgnoredPageState extends State<ManageIgnoredPage> {
     await IgnoreStore.remove(key);
     await _load();
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Un-ignored "$label".')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Un-ignored "$label".')));
   }
 
   @override

--- a/lib/manage_repos_page.dart
+++ b/lib/manage_repos_page.dart
@@ -79,11 +79,15 @@ class _ManageReposPageState extends State<ManageReposPage> {
   /// Atomically removes a repo AND adds its key to the ignore list under the
   /// shared lock, so an in-flight auto-add pass can't re-add it in between.
   Future<void> _removeAndIgnore(
-      String storageKey, int index, String ignoreKey) async {
+    String storageKey,
+    int index,
+    String ignoreKey,
+  ) async {
     await RepoStore.runLocked(() async {
       final prefs = await SharedPreferences.getInstance();
-      final repos =
-          List<String>.of(prefs.getStringList(storageKey) ?? const []);
+      final repos = List<String>.of(
+        prefs.getStringList(storageKey) ?? const [],
+      );
       if (index >= 0 && index < repos.length) {
         repos.removeAt(index);
       }
@@ -150,8 +154,9 @@ class _ManageReposPageState extends State<ManageReposPage> {
             if (canIgnore)
               TextButton(
                 style: TextButton.styleFrom(foregroundColor: Colors.red),
-                onPressed: () => Navigator.of(dialogContext)
-                    .pop(_DeleteChoice.removeAndIgnore),
+                onPressed: () => Navigator.of(
+                  dialogContext,
+                ).pop(_DeleteChoice.removeAndIgnore),
                 child: const Text('Remove & ignore'),
               ),
           ],
@@ -235,7 +240,8 @@ class _ManageReposPageState extends State<ManageReposPage> {
                   await Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => const RegisterGithubRepoPage()),
+                      builder: (_) => const RegisterGithubRepoPage(),
+                    ),
                   );
                   await _loadRepos();
                 },
@@ -248,7 +254,8 @@ class _ManageReposPageState extends State<ManageReposPage> {
                   await Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => const RegisterAdoRepoPage()),
+                      builder: (_) => const RegisterAdoRepoPage(),
+                    ),
                   );
                   await _loadRepos();
                 },
@@ -290,7 +297,8 @@ class _ManageReposPageState extends State<ManageReposPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-              'Added $added ${added == 1 ? 'repository' : 'repositories'}.'),
+            'Added $added ${added == 1 ? 'repository' : 'repositories'}.',
+          ),
         ),
       );
     }

--- a/lib/manage_tokens_page.dart
+++ b/lib/manage_tokens_page.dart
@@ -81,9 +81,9 @@ class _ManageTokensPageState extends State<ManageTokensPage> {
     await TokenStore.deleteToken(token.id);
     await _load();
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Removed "${token.label}".')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Removed "${token.label}".')));
   }
 
   @override
@@ -121,10 +121,12 @@ class _ManageTokensPageState extends State<ManageTokensPage> {
       );
     }
 
-    final github =
-        _tokens.where((t) => t.provider == TokenStore.providerGithub).toList();
-    final ado =
-        _tokens.where((t) => t.provider == TokenStore.providerAdo).toList();
+    final github = _tokens
+        .where((t) => t.provider == TokenStore.providerGithub)
+        .toList();
+    final ado = _tokens
+        .where((t) => t.provider == TokenStore.providerAdo)
+        .toList();
 
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 8),

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -104,18 +104,18 @@ class NotificationService {
 
     return switch (defaultTargetPlatform) {
       TargetPlatform.android => const NotificationDetails(
-          android: AndroidNotificationDetails(
-            _channelId,
-            _channelName,
-            channelDescription: _channelDescription,
-          ),
+        android: AndroidNotificationDetails(
+          _channelId,
+          _channelName,
+          channelDescription: _channelDescription,
         ),
+      ),
       TargetPlatform.iOS => const NotificationDetails(
-          iOS: DarwinNotificationDetails(),
-        ),
+        iOS: DarwinNotificationDetails(),
+      ),
       TargetPlatform.macOS => const NotificationDetails(
-          macOS: DarwinNotificationDetails(),
-        ),
+        macOS: DarwinNotificationDetails(),
+      ),
       _ => null,
     };
   }
@@ -125,8 +125,7 @@ class NotificationService {
     return switch (defaultTargetPlatform) {
       TargetPlatform.android ||
       TargetPlatform.iOS ||
-      TargetPlatform.macOS =>
-        true,
+      TargetPlatform.macOS => true,
       _ => false,
     };
   }

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -67,7 +67,7 @@ class NotificationService {
         iOS: DarwinInitializationSettings(),
         macOS: DarwinInitializationSettings(),
       );
-      await _plugin.initialize(settings);
+      await _plugin.initialize(settings: settings);
       _initialized = true;
     } catch (e) {
       debugPrint('Failed to initialize local notifications: $e');
@@ -89,10 +89,10 @@ class NotificationService {
       if (details == null) return;
 
       await _plugin.show(
-        _summaryNotificationId,
-        _summaryTitle(newItems.length),
-        _summaryBody(newItems),
-        details,
+        id: _summaryNotificationId,
+        title: _summaryTitle(newItems.length),
+        body: _summaryBody(newItems),
+        notificationDetails: details,
       );
     } catch (e) {
       debugPrint('Failed to show attention notification: $e');

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -68,6 +68,12 @@ class NotificationService {
         macOS: DarwinInitializationSettings(),
       );
       await _plugin.initialize(settings: settings);
+      // Android 13+ (API 33+) requires the runtime POST_NOTIFICATIONS grant.
+      await _plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >()
+          ?.requestNotificationsPermission();
       _initialized = true;
     } catch (e) {
       debugPrint('Failed to initialize local notifications: $e');

--- a/lib/people_page.dart
+++ b/lib/people_page.dart
@@ -67,10 +67,7 @@ class _PeoplePageState extends State<PeoplePage> {
       ),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
-          : RefreshIndicator(
-              onRefresh: _loadPeople,
-              child: _buildContent(),
-            ),
+          : RefreshIndicator(onRefresh: _loadPeople, child: _buildContent()),
     );
   }
 
@@ -126,7 +123,8 @@ class _PeoplePageState extends State<PeoplePage> {
       );
       if (saved == true) {
         await IdentityStore.setSelfGithubLogins(
-            _parseLogins(ghController.text));
+          _parseLogins(ghController.text),
+        );
         await IdentityStore.setSelfAdoNames(_parseNames(adoController.text));
         if (!mounted) return;
         await _loadPeople();
@@ -179,10 +177,7 @@ class _PeoplePageState extends State<PeoplePage> {
           Center(
             child: Padding(
               padding: EdgeInsets.all(24),
-              child: Text(
-                'No people found yet.',
-                textAlign: TextAlign.center,
-              ),
+              child: Text('No people found yet.', textAlign: TextAlign.center),
             ),
           ),
         ],
@@ -192,7 +187,7 @@ class _PeoplePageState extends State<PeoplePage> {
     return ListView.separated(
       physics: const AlwaysScrollableScrollPhysics(),
       itemCount: _people.length,
-      separatorBuilder: (_, __) => const Divider(height: 1),
+      separatorBuilder: (_, _) => const Divider(height: 1),
       itemBuilder: (context, index) {
         final person = _people[index];
         return ListTile(

--- a/lib/people_service.dart
+++ b/lib/people_service.dart
@@ -45,9 +45,7 @@ class PeopleService {
       final reviewers = pr['requested_reviewers'];
       if (reviewers is! List) continue;
       for (final reviewer in reviewers) {
-        final login = _normalizeLogin(
-          _nestedString(reviewer, 'login') ?? '',
-        );
+        final login = _normalizeLogin(_nestedString(reviewer, 'login') ?? '');
         if (login.isEmpty) continue;
         final person = people.putIfAbsent(
           login,
@@ -107,10 +105,7 @@ class PeopleService {
         );
         final key = _adoIdentity(name);
         if (key.isEmpty) continue;
-        final person = people.putIfAbsent(
-          key,
-          () => _MutablePerson.ado(name),
-        );
+        final person = people.putIfAbsent(key, () => _MutablePerson.ado(name));
         person.reviewRequests++;
         person.markSelf(selfNames.contains(key));
         person.see(lastSeen);
@@ -258,30 +253,29 @@ class PeopleService {
   ) async {
     final repoDisplay = '$owner/$name';
     try {
-      final secret =
-          (await TokenStore.resolveGithubSecret(owner, tokenId: tokenId))
-              ?.trim();
+      final secret = (await TokenStore.resolveGithubSecret(
+        owner,
+        tokenId: tokenId,
+      ))?.trim();
       if (secret == null || secret.isEmpty) return const <Person>[];
 
-      final response = await client.get(
-        Uri.https('api.github.com', '/repos/$owner/$name/pulls', {
-          'state': 'open',
-          'per_page': '100',
-        }),
-        headers: {
-          'Authorization': 'Bearer $secret',
-          'Accept': 'application/vnd.github+json',
-        },
-      ).timeout(_requestTimeout);
+      final response = await client
+          .get(
+            Uri.https('api.github.com', '/repos/$owner/$name/pulls', {
+              'state': 'open',
+              'per_page': '100',
+            }),
+            headers: {
+              'Authorization': 'Bearer $secret',
+              'Accept': 'application/vnd.github+json',
+            },
+          )
+          .timeout(_requestTimeout);
       if (response.statusCode != 200) return const <Person>[];
 
       final body = jsonDecode(response.body);
       if (body is! List) return const <Person>[];
-      return aggregateGithub(
-        prs: body,
-        now: now,
-        self: self,
-      );
+      return aggregateGithub(prs: body, now: now, self: self);
     } catch (e) {
       debugPrint('PeopleService GitHub fetch failed for $repoDisplay: $e');
       return const <Person>[];
@@ -299,31 +293,30 @@ class PeopleService {
   ) async {
     final repoDisplay = '$organization/$project/$name';
     try {
-      final secret =
-          (await TokenStore.resolveAdoSecret(organization, tokenId: tokenId))
-              ?.trim();
+      final secret = (await TokenStore.resolveAdoSecret(
+        organization,
+        tokenId: tokenId,
+      ))?.trim();
       if (secret == null || secret.isEmpty) return const <Person>[];
 
-      final response = await client.get(
-        Uri.https(
-          'dev.azure.com',
-          '/$organization/$project/_apis/git/repositories/$name/pullrequests',
-          {'searchCriteria.status': 'active', 'api-version': '6.0'},
-        ),
-        headers: {
-          'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
-        },
-      ).timeout(_requestTimeout);
+      final response = await client
+          .get(
+            Uri.https(
+              'dev.azure.com',
+              '/$organization/$project/_apis/git/repositories/$name/pullrequests',
+              {'searchCriteria.status': 'active', 'api-version': '6.0'},
+            ),
+            headers: {
+              'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
+            },
+          )
+          .timeout(_requestTimeout);
       if (response.statusCode != 200) return const <Person>[];
 
       final body = jsonDecode(response.body);
       final value = body is Map ? body['value'] : body;
       if (value is! List) return const <Person>[];
-      return aggregateAdo(
-        prs: value,
-        now: now,
-        self: self,
-      );
+      return aggregateAdo(prs: value, now: now, self: self);
     } catch (e) {
       debugPrint('PeopleService ADO fetch failed for $repoDisplay: $e');
       return const <Person>[];
@@ -381,9 +374,7 @@ class PeopleService {
       if (byReviewRequests != 0) return byReviewRequests;
       final byAuthoredOpenPrs = b.authoredOpenPrs.compareTo(a.authoredOpenPrs);
       if (byAuthoredOpenPrs != 0) return byAuthoredOpenPrs;
-      return a.displayName.toLowerCase().compareTo(
-            b.displayName.toLowerCase(),
-          );
+      return a.displayName.toLowerCase().compareTo(b.displayName.toLowerCase());
     });
   }
 
@@ -407,8 +398,10 @@ class _MutablePerson {
 
   factory _MutablePerson.ado(String name) {
     final trimmed = PeopleService._normalizeName(name);
-    final person = _MutablePerson('ado:${PeopleService._adoIdentity(name)}',
-        trimmed.isEmpty ? name : trimmed);
+    final person = _MutablePerson(
+      'ado:${PeopleService._adoIdentity(name)}',
+      trimmed.isEmpty ? name : trimmed,
+    );
     person.addAdoName(name);
     return person;
   }
@@ -464,15 +457,16 @@ class _MutablePerson {
     final stableKey = logins.isNotEmpty
         ? 'github:${logins.first}'
         : adoKeys.isNotEmpty
-            ? 'ado:${adoKeys.first}'
-            : key;
+        ? 'ado:${adoKeys.first}'
+        : key;
     final fallbackName = logins.isNotEmpty
         ? logins.first
         : adoKeys.isNotEmpty
-            ? adoNames[adoKeys.first]!
-            : stableKey;
-    final shownName =
-        displayName.trim().isEmpty ? fallbackName : displayName.trim();
+        ? adoNames[adoKeys.first]!
+        : stableKey;
+    final shownName = displayName.trim().isEmpty
+        ? fallbackName
+        : displayName.trim();
 
     return Person(
       key: stableKey,

--- a/lib/person.dart
+++ b/lib/person.dart
@@ -8,8 +8,8 @@ class Person {
     this.reviewRequests = 0,
     this.lastSeen,
     this.isSelf = false,
-  })  : githubLogins = Set.unmodifiable(githubLogins),
-        adoNames = Set.unmodifiable(adoNames);
+  }) : githubLogins = Set.unmodifiable(githubLogins),
+       adoNames = Set.unmodifiable(adoNames);
 
   final String key;
   final String displayName;

--- a/lib/radar_page.dart
+++ b/lib/radar_page.dart
@@ -29,8 +29,9 @@ class _RadarPageState extends State<RadarPage> {
     });
 
     try {
-      final activities =
-          await ActivityService.computeAll(client: AppHttp.client);
+      final activities = await ActivityService.computeAll(
+        client: AppHttp.client,
+      );
       if (!mounted) return;
       setState(() {
         _activities = activities;
@@ -268,17 +269,14 @@ class _RadarPageState extends State<RadarPage> {
       return;
     }
 
-    final launched = await launchUrl(
-      uri,
-      mode: LaunchMode.externalApplication,
-    );
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
     if (!mounted) return;
     if (!launched) _showLaunchError(activity.displayName);
   }
 
   void _showLaunchError(String displayName) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Could not open $displayName')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Could not open $displayName')));
   }
 }

--- a/lib/register_ado_repo.dart
+++ b/lib/register_ado_repo.dart
@@ -57,11 +57,14 @@ class _RegisterAdoRepoPageState extends State<RegisterAdoRepoPage> {
   }
 
   Future<bool> _saveRepo(
-      String organization, String project, String repoName) async {
+    String organization,
+    String project,
+    String repoName,
+  ) async {
     final Map<String, String> repo = {
       'organization': organization,
       'project': project,
-      'repoName': repoName
+      'repoName': repoName,
     };
     if (_tokenId != null && _tokenId!.isNotEmpty) {
       repo['tokenId'] = _tokenId!;
@@ -79,7 +82,10 @@ class _RegisterAdoRepoPageState extends State<RegisterAdoRepoPage> {
         try {
           final m = Map<String, String>.from(jsonDecode(raw) as Map);
           final key = RepoDiscoveryService.adoKey(
-              m['organization'] ?? '', m['project'] ?? '', m['repoName'] ?? '');
+            m['organization'] ?? '',
+            m['project'] ?? '',
+            m['repoName'] ?? '',
+          );
           if (key == newKey) return false; // duplicate
         } catch (_) {}
       }
@@ -103,11 +109,13 @@ class _RegisterAdoRepoPageState extends State<RegisterAdoRepoPage> {
         if (!mounted) return; // Ensure the widget is still mounted
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(_isEditing
-                ? 'ADO Repository updated successfully!'
-                : added
-                    ? 'ADO Repository saved successfully!'
-                    : 'That repository is already tracked.'),
+            content: Text(
+              _isEditing
+                  ? 'ADO Repository updated successfully!'
+                  : added
+                  ? 'ADO Repository saved successfully!'
+                  : 'That repository is already tracked.',
+            ),
           ),
         );
         Navigator.pop(context);
@@ -120,7 +128,8 @@ class _RegisterAdoRepoPageState extends State<RegisterAdoRepoPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(
-            _isEditing ? 'Edit ADO Repository' : 'Register ADO Repository'),
+          _isEditing ? 'Edit ADO Repository' : 'Register ADO Repository',
+        ),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -131,9 +140,7 @@ class _RegisterAdoRepoPageState extends State<RegisterAdoRepoPage> {
             children: [
               TextFormField(
                 controller: _organizationController,
-                decoration: const InputDecoration(
-                  labelText: 'Organization',
-                ),
+                decoration: const InputDecoration(labelText: 'Organization'),
                 validator: (value) {
                   if (value == null || value.isEmpty) {
                     return 'Please enter the organization';
@@ -144,9 +151,7 @@ class _RegisterAdoRepoPageState extends State<RegisterAdoRepoPage> {
               const SizedBox(height: 16),
               TextFormField(
                 controller: _projectController,
-                decoration: const InputDecoration(
-                  labelText: 'Project',
-                ),
+                decoration: const InputDecoration(labelText: 'Project'),
                 validator: (value) {
                   if (value == null || value.isEmpty) {
                     return 'Please enter the project';
@@ -157,9 +162,7 @@ class _RegisterAdoRepoPageState extends State<RegisterAdoRepoPage> {
               const SizedBox(height: 16),
               TextFormField(
                 controller: _repoNameController,
-                decoration: const InputDecoration(
-                  labelText: 'Repository Name',
-                ),
+                decoration: const InputDecoration(labelText: 'Repository Name'),
                 validator: (value) {
                   if (value == null || value.isEmpty) {
                     return 'Please enter the repository name';

--- a/lib/register_github_repo.dart
+++ b/lib/register_github_repo.dart
@@ -69,7 +69,9 @@ class _RegisterGithubRepoPageState extends State<RegisterGithubRepoPage> {
         try {
           final m = Map<String, String>.from(jsonDecode(raw) as Map);
           final key = RepoDiscoveryService.githubKey(
-              m['owner'] ?? '', m['repoName'] ?? '');
+            m['owner'] ?? '',
+            m['repoName'] ?? '',
+          );
           if (key == newKey) return false; // duplicate
         } catch (_) {}
       }
@@ -92,11 +94,13 @@ class _RegisterGithubRepoPageState extends State<RegisterGithubRepoPage> {
         if (!mounted) return; // Ensure the widget is still mounted
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(_isEditing
-                ? 'Repository updated successfully!'
-                : added
-                    ? 'Repository saved successfully!'
-                    : 'That repository is already tracked.'),
+            content: Text(
+              _isEditing
+                  ? 'Repository updated successfully!'
+                  : added
+                  ? 'Repository saved successfully!'
+                  : 'That repository is already tracked.',
+            ),
           ),
         );
         Navigator.pop(context);
@@ -108,9 +112,9 @@ class _RegisterGithubRepoPageState extends State<RegisterGithubRepoPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(_isEditing
-            ? 'Edit GitHub Repository'
-            : 'Register GitHub Repository'),
+        title: Text(
+          _isEditing ? 'Edit GitHub Repository' : 'Register GitHub Repository',
+        ),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -134,9 +138,7 @@ class _RegisterGithubRepoPageState extends State<RegisterGithubRepoPage> {
               const SizedBox(height: 16),
               TextFormField(
                 controller: _repoNameController,
-                decoration: const InputDecoration(
-                  labelText: 'Repository Name',
-                ),
+                decoration: const InputDecoration(labelText: 'Repository Name'),
                 validator: (value) {
                   if (value == null || value.isEmpty) {
                     return 'Please enter the repository name';

--- a/lib/repo_discovery_page.dart
+++ b/lib/repo_discovery_page.dart
@@ -91,15 +91,24 @@ class _RepoDiscoveryPageState extends State<RepoDiscoveryPage> {
     for (final raw in prefs.getStringList('github_repos') ?? const []) {
       try {
         final map = Map<String, String>.from(jsonDecode(raw) as Map);
-        keys.add(RepoDiscoveryService.githubKey(
-            map['owner'] ?? '', map['repoName'] ?? ''));
+        keys.add(
+          RepoDiscoveryService.githubKey(
+            map['owner'] ?? '',
+            map['repoName'] ?? '',
+          ),
+        );
       } catch (_) {}
     }
     for (final raw in prefs.getStringList('ado_repos') ?? const []) {
       try {
         final map = Map<String, String>.from(jsonDecode(raw) as Map);
-        keys.add(RepoDiscoveryService.adoKey(map['organization'] ?? '',
-            map['project'] ?? '', map['repoName'] ?? ''));
+        keys.add(
+          RepoDiscoveryService.adoKey(
+            map['organization'] ?? '',
+            map['project'] ?? '',
+            map['repoName'] ?? '',
+          ),
+        );
       } catch (_) {}
     }
     if (!mounted) return;
@@ -197,8 +206,9 @@ class _RepoDiscoveryPageState extends State<RepoDiscoveryPage> {
   Future<void> _addSelected() async {
     setState(() => _adding = true);
     final storageKey = _isGithub ? RepoStore.githubKey : RepoStore.adoKey;
-    final selectedRepos =
-        _repos.where((r) => _selected.contains(r.key)).toList();
+    final selectedRepos = _repos
+        .where((r) => _selected.contains(r.key))
+        .toList();
     final tokenId = (_assignToken && _tokenId != null && _tokenId!.isNotEmpty)
         ? _tokenId
         : null;
@@ -210,11 +220,18 @@ class _RepoDiscoveryPageState extends State<RepoDiscoveryPage> {
       for (final raw in repos) {
         try {
           final m = Map<String, String>.from(jsonDecode(raw) as Map);
-          existing.add(_isGithub
-              ? RepoDiscoveryService.githubKey(
-                  m['owner'] ?? '', m['repoName'] ?? '')
-              : RepoDiscoveryService.adoKey(m['organization'] ?? '',
-                  m['project'] ?? '', m['repoName'] ?? ''));
+          existing.add(
+            _isGithub
+                ? RepoDiscoveryService.githubKey(
+                    m['owner'] ?? '',
+                    m['repoName'] ?? '',
+                  )
+                : RepoDiscoveryService.adoKey(
+                    m['organization'] ?? '',
+                    m['project'] ?? '',
+                    m['repoName'] ?? '',
+                  ),
+          );
         } catch (_) {}
       }
       var count = 0;
@@ -280,9 +297,8 @@ class _RepoDiscoveryPageState extends State<RepoDiscoveryPage> {
             ],
             onChanged: _fetching
                 ? null
-                : (value) => _onProviderChanged(
-                      value ?? TokenStore.providerGithub,
-                    ),
+                : (value) =>
+                      _onProviderChanged(value ?? TokenStore.providerGithub),
           ),
           const SizedBox(height: 12),
           if (_loadingTokens)
@@ -297,12 +313,16 @@ class _RepoDiscoveryPageState extends State<RepoDiscoveryPage> {
                 border: OutlineInputBorder(),
               ),
               items: _tokens
-                  .map((t) => DropdownMenuItem(
-                        value: t.id,
-                        child: Text(t.isDefault
+                  .map(
+                    (t) => DropdownMenuItem(
+                      value: t.id,
+                      child: Text(
+                        t.isDefault
                             ? '${t.label} (default)'
-                            : '${t.label} (${t.scope})'),
-                      ))
+                            : '${t.label} (${t.scope})',
+                      ),
+                    ),
+                  )
                   .toList(),
               onChanged: (value) => setState(() {
                 _tokenId = value;
@@ -402,8 +422,9 @@ class _RepoDiscoveryPageState extends State<RepoDiscoveryPage> {
         final checked =
             !ignored && (alreadyAdded || _selected.contains(repo.key));
 
-        final String? subtitle =
-            ignored ? 'Ignored' : (alreadyAdded ? 'Already monitored' : null);
+        final String? subtitle = ignored
+            ? 'Ignored'
+            : (alreadyAdded ? 'Already monitored' : null);
 
         // Trailing action: un-ignore an ignored repo, or ignore a selectable one.
         Widget? trailing;
@@ -429,12 +450,12 @@ class _RepoDiscoveryPageState extends State<RepoDiscoveryPage> {
           onChanged: disabled
               ? null
               : (value) => setState(() {
-                    if (value == true) {
-                      _selected.add(repo.key);
-                    } else {
-                      _selected.remove(repo.key);
-                    }
-                  }),
+                  if (value == true) {
+                    _selected.add(repo.key);
+                  } else {
+                    _selected.remove(repo.key);
+                  }
+                }),
         );
       },
     );

--- a/lib/repo_discovery_service.dart
+++ b/lib/repo_discovery_service.dart
@@ -57,11 +57,13 @@ class RepoDiscoveryService {
       final owner = ownerMap['login'] as String?;
       final name = item['name'] as String?;
       if (owner == null || name == null) continue;
-      result.add(DiscoveredRepo(
-        key: githubKey(owner, name),
-        display: '$owner/$name',
-        repo: {'owner': owner, 'repoName': name},
-      ));
+      result.add(
+        DiscoveredRepo(
+          key: githubKey(owner, name),
+          display: '$owner/$name',
+          repo: {'owner': owner, 'repoName': name},
+        ),
+      );
     }
     return result;
   }
@@ -79,15 +81,17 @@ class RepoDiscoveryService {
       if (projectMap is! Map) continue;
       final project = projectMap['name'] as String?;
       if (name == null || project == null) continue;
-      result.add(DiscoveredRepo(
-        key: adoKey(organization, project, name),
-        display: '$project/$name',
-        repo: {
-          'organization': organization,
-          'project': project,
-          'repoName': name,
-        },
-      ));
+      result.add(
+        DiscoveredRepo(
+          key: adoKey(organization, project, name),
+          display: '$project/$name',
+          repo: {
+            'organization': organization,
+            'project': project,
+            'repoName': name,
+          },
+        ),
+      );
     }
     return result;
   }
@@ -168,10 +172,15 @@ class RepoDiscoveryService {
     // Cap pagination to avoid runaway requests.
     for (var page = 1; page <= 10; page++) {
       final uri = Uri.parse('$base?per_page=100&page=$page');
-      final response = await client.get(uri, headers: {
-        'Authorization': 'Bearer $secret',
-        'Accept': 'application/vnd.github+json',
-      }).timeout(_requestTimeout);
+      final response = await client
+          .get(
+            uri,
+            headers: {
+              'Authorization': 'Bearer $secret',
+              'Accept': 'application/vnd.github+json',
+            },
+          )
+          .timeout(_requestTimeout);
       if (response.statusCode == 404 && allow404 && page == 1) {
         return null;
       }
@@ -194,10 +203,16 @@ class RepoDiscoveryService {
     String org,
   ) async {
     final uri = Uri.parse(
-        'https://dev.azure.com/$org/_apis/git/repositories?api-version=6.0');
-    final response = await client.get(uri, headers: {
-      'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
-    }).timeout(_requestTimeout);
+      'https://dev.azure.com/$org/_apis/git/repositories?api-version=6.0',
+    );
+    final response = await client
+        .get(
+          uri,
+          headers: {
+            'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
+          },
+        )
+        .timeout(_requestTimeout);
     if (response.statusCode != 200) {
       throw Exception('Azure DevOps returned status ${response.statusCode}');
     }

--- a/lib/repo_store.dart
+++ b/lib/repo_store.dart
@@ -35,8 +35,9 @@ class RepoStore {
   ) {
     return _synchronized(() async {
       final prefs = await SharedPreferences.getInstance();
-      final repos =
-          List<String>.of(prefs.getStringList(storageKey) ?? const []);
+      final repos = List<String>.of(
+        prefs.getStringList(storageKey) ?? const [],
+      );
       final result = mutate(repos);
       await prefs.setStringList(storageKey, repos);
       return result;
@@ -50,8 +51,9 @@ class RepoStore {
   ) {
     return _synchronized(() async {
       final prefs = await SharedPreferences.getInstance();
-      final github =
-          List<String>.of(prefs.getStringList(githubKey) ?? const []);
+      final github = List<String>.of(
+        prefs.getStringList(githubKey) ?? const [],
+      );
       final ado = List<String>.of(prefs.getStringList(adoKey) ?? const []);
       final result = mutate(github, ado);
       await prefs.setStringList(githubKey, github);

--- a/lib/token_override_field.dart
+++ b/lib/token_override_field.dart
@@ -76,18 +76,14 @@ class _TokenOverrideFieldState extends State<TokenOverrideField> {
           child: Text('Auto (match by owner/org)'),
         ),
         ..._tokens.map(
-          (token) => DropdownMenuItem(
-            value: token.id,
-            child: Text(_label(token)),
-          ),
+          (token) =>
+              DropdownMenuItem(value: token.id, child: Text(_label(token))),
         ),
       ],
       onChanged: _loaded
           ? (value) {
               setState(() => _selected = value ?? '');
-              widget.onChanged(
-                (value == null || value.isEmpty) ? null : value,
-              );
+              widget.onChanged((value == null || value.isEmpty) ? null : value);
             }
           : null,
     );

--- a/lib/token_store.dart
+++ b/lib/token_store.dart
@@ -50,20 +50,20 @@ class TokenInfo {
       );
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'provider': provider,
-        'label': label,
-        'scope': scope,
-        'autoAdd': autoAdd,
-      };
+    'id': id,
+    'provider': provider,
+    'label': label,
+    'scope': scope,
+    'autoAdd': autoAdd,
+  };
 
   factory TokenInfo.fromJson(Map<String, dynamic> json) => TokenInfo(
-        id: json['id'] as String,
-        provider: json['provider'] as String? ?? TokenStore.providerGithub,
-        label: json['label'] as String? ?? '',
-        scope: json['scope'] as String? ?? '',
-        autoAdd: json['autoAdd'] as bool? ?? false,
-      );
+    id: json['id'] as String,
+    provider: json['provider'] as String? ?? TokenStore.providerGithub,
+    label: json['label'] as String? ?? '',
+    scope: json['scope'] as String? ?? '',
+    autoAdd: json['autoAdd'] as bool? ?? false,
+  );
 }
 
 /// Manages multiple GitHub / Azure DevOps access tokens.
@@ -113,8 +113,9 @@ class TokenStore {
     }
     // Single-flight the migration so concurrent first-run callers share one
     // pass rather than racing to migrate/persist independently.
-    return _migrationFuture ??=
-        _migrateLegacy(prefs).whenComplete(() => _migrationFuture = null);
+    return _migrationFuture ??= _migrateLegacy(
+      prefs,
+    ).whenComplete(() => _migrationFuture = null);
   }
 
   /// Returns the tokens registered for a given provider.
@@ -220,10 +221,7 @@ class TokenStore {
 
   /// Resolves the secret to use for a GitHub repo owned by [owner], honoring an
   /// optional explicit [tokenId] override.
-  static Future<String?> resolveGithubSecret(
-    String owner, {
-    String? tokenId,
-  }) =>
+  static Future<String?> resolveGithubSecret(String owner, {String? tokenId}) =>
       _resolve(providerGithub, owner, tokenId);
 
   /// Resolves the secret to use for an Azure DevOps [organization], honoring an
@@ -231,8 +229,7 @@ class TokenStore {
   static Future<String?> resolveAdoSecret(
     String organization, {
     String? tokenId,
-  }) =>
-      _resolve(providerAdo, organization, tokenId);
+  }) => _resolve(providerAdo, organization, tokenId);
 
   static Future<String?> _resolve(
     String provider,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -85,26 +85,26 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   dbus:
     dependency: transitive
     description:
       name: dbus
-      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.13"
   fake_async:
     dependency: transitive
     description:
@@ -117,10 +117,18 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -154,34 +162,42 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "7ed76be64e8a7d01dfdf250b8434618e2a028c9dfa2a3c41dc9b531d4b3fc8a5"
+      sha256: a0d7141f14cabcee42967470a858dfc99dd6cfb70d3cab404bacfcafa9e84e70
       url: "https://pub.dev"
     source: hosted
-    version: "19.4.2"
+    version: "22.0.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      sha256: ff0013eae795e8dc8fad4a8992a209e64d3ba2fbd8bf5e43c36bf448f95bd814
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.0"
+    version: "12.0.0"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_local_notifications_windows:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "3.1.1"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -226,10 +242,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -252,10 +268,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
@@ -268,10 +284,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.4"
+    version: "4.9.1"
   jni:
     dependency: transitive
     description:
@@ -292,10 +308,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -324,10 +340,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.0"
   logging:
     dependency: transitive
     description:
@@ -364,10 +380,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   objective_c:
     dependency: transitive
     description:
@@ -420,18 +436,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
@@ -444,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -468,10 +484,10 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "6.5.0"
   pub_semver:
     dependency: transitive
     description:
@@ -492,66 +508,66 @@ packages:
     dependency: transitive
     description:
       name: screen_retriever
-      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
+      sha256: ace919117a7520c13a50a6259e60c4a0d4cbe98809468792a91b5c5adada2aa6
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_linux:
     dependency: transitive
     description:
       name: screen_retriever_linux
-      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+      sha256: "7b52006a5ceae1f3d5af7f77188c3290d6e7d8ded16d99809bea84967c65c257"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_macos:
     dependency: transitive
     description:
       name: screen_retriever_macos
-      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+      sha256: a1489b99cce597c45a54b9aae1cd94c8d4705353b7e0bb2457a6e4de44e0ad8a
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_platform_interface:
     dependency: transitive
     description:
       name: screen_retriever_platform_interface
-      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
+      sha256: "94a5535277510a63184ca178ce12a1449bc0b38618879aa1c18bf57369c5064a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_windows:
     dependency: transitive
     description:
       name: screen_retriever_windows
-      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+      sha256: dafc6922b0bfbf1d48cf3ccbf519b4fff47bdcb820da1728ea6db675fecc9324
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.5"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: a2608114b1ffdcbc9c120eb71a0e207c71da56202852d4aab8a5e30a82269e74
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.12"
+    version: "2.4.27"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.6"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -564,10 +580,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   shared_preferences_web:
     dependency: transitive
     description:
@@ -601,10 +617,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -641,26 +657,26 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   timezone:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.1"
   tray_manager:
     dependency: "direct main"
     description:
       name: tray_manager
-      sha256: "537e539f48cd82d8ee2240d4330158c7b44c7e043e8e18b5811f2f8f6b7df25a"
+      sha256: "1a659b08baa6e9b91ef8ce16eda37740de398be1c4cf322b8a1ddfef25c68c5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.3"
   typed_data:
     dependency: transitive
     description:
@@ -681,34 +697,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "07cffecb7d68cbc6437cd803d5f11a86fe06736735c3dfe46ff73bcb0f958eed"
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.21"
+    version: "6.3.32"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.4"
+    version: "6.4.1"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -721,18 +737,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
@@ -745,10 +761,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   web:
     dependency: transitive
     description:
@@ -761,18 +777,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.3.0"
   window_manager:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
+      sha256: "05c231fd7b23d2380f14c5cc10b7b93d60d4fa4a2fb4e0f032de27e44b5560e9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -785,10 +801,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:
@@ -798,5 +814,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/kamilon/kode_radar
 issue_tracker: https://github.com/kamilon/kode_radar/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_local_notifications: ^19.4.2
+  flutter_local_notifications: ^22.0.1
   window_manager: ^0.5.1
   url_launcher: ^6.3.2
   shared_preferences: ^2.5.3

--- a/test/api_cache_test.dart
+++ b/test/api_cache_test.dart
@@ -47,7 +47,8 @@ void main() {
 
   test('exhausted rate limit serves a cached GET response', () async {
     var calls = 0;
-    final resetSeconds = DateTime.utc(2100).millisecondsSinceEpoch ~/
+    final resetSeconds =
+        DateTime.utc(2100).millisecondsSinceEpoch ~/
         Duration.millisecondsPerSecond;
     final inner = MockClient((_) async {
       calls++;
@@ -76,35 +77,47 @@ void main() {
     expect(client.githubRateLimit.resetAt, DateTime.utc(2100));
   });
 
-  test('an exhausted GitHub scope does not gate other hosts (Azure DevOps)',
-      () async {
-    final resetSeconds = DateTime.utc(2100).millisecondsSinceEpoch ~/
-        Duration.millisecondsPerSecond;
-    var adoCalls = 0;
-    final inner = MockClient((request) async {
-      if (request.url.host == 'api.github.com') {
-        return http.Response('gh', 200, headers: {
-          'etag': '"gh"',
-          'x-ratelimit-remaining': '0',
-          'x-ratelimit-reset': '$resetSeconds',
-        });
-      }
-      adoCalls++;
-      return http.Response('ado', 200);
-    });
-    final client = CachedHttpClient(inner: inner);
-    addTearDown(client.close);
+  test(
+    'an exhausted GitHub scope does not gate other hosts (Azure DevOps)',
+    () async {
+      final resetSeconds =
+          DateTime.utc(2100).millisecondsSinceEpoch ~/
+          Duration.millisecondsPerSecond;
+      var adoCalls = 0;
+      final inner = MockClient((request) async {
+        if (request.url.host == 'api.github.com') {
+          return http.Response(
+            'gh',
+            200,
+            headers: {
+              'etag': '"gh"',
+              'x-ratelimit-remaining': '0',
+              'x-ratelimit-reset': '$resetSeconds',
+            },
+          );
+        }
+        adoCalls++;
+        return http.Response('ado', 200);
+      });
+      final client = CachedHttpClient(inner: inner);
+      addTearDown(client.close);
 
-    // Exhaust the GitHub scope.
-    await client.get(Uri.parse('https://api.github.com/repos/acme/api/pulls'));
-    // Azure DevOps must still reach the network (not gated by GitHub's limit).
-    final adoResponse = await client.get(Uri.parse(
-        'https://dev.azure.com/org/proj/_apis/git/repositories/r/pullrequests'));
+      // Exhaust the GitHub scope.
+      await client.get(
+        Uri.parse('https://api.github.com/repos/acme/api/pulls'),
+      );
+      // Azure DevOps must still reach the network (not gated by GitHub's limit).
+      final adoResponse = await client.get(
+        Uri.parse(
+          'https://dev.azure.com/org/proj/_apis/git/repositories/r/pullrequests',
+        ),
+      );
 
-    expect(adoResponse.statusCode, 200);
-    expect(adoResponse.body, 'ado');
-    expect(adoCalls, 1);
-  });
+      expect(adoResponse.statusCode, 200);
+      expect(adoResponse.body, 'ado');
+      expect(adoCalls, 1);
+    },
+  );
 
   test('parseRateLimit parses GitHub rate limit headers', () {
     final resetAt = DateTime.utc(2026, 7, 14, 8, 30);

--- a/test/attention_service_test.dart
+++ b/test/attention_service_test.dart
@@ -24,7 +24,7 @@ void main() {
           'created_at': daysAgo(3).toIso8601String(),
           'html_url': 'https://github.com/acme/api/pull/12',
           'requested_reviewers': [
-            {'login': 'bob'}
+            {'login': 'bob'},
           ],
         },
       ],
@@ -47,7 +47,7 @@ void main() {
           'created_at': daysAgo(1).toIso8601String(),
           'requested_reviewers': [],
           'requested_teams': [
-            {'slug': 'platform'}
+            {'slug': 'platform'},
           ],
         },
       ],
@@ -55,32 +55,34 @@ void main() {
     expect(items.single.category, 'reviewRequested');
   });
 
-  test('GitHub: old PR with no pending review -> oldOpenPr; fresh -> nothing',
-      () {
-    final items = AttentionService.githubItems(
-      repoDisplay: 'acme/api',
-      now: now,
-      prs: [
-        {
-          'number': 1,
-          'title': 'Old',
-          'user': {'login': 'alice'},
-          'created_at': daysAgo(40).toIso8601String(),
-          'requested_reviewers': [],
-        },
-        {
-          'number': 2,
-          'title': 'Fresh',
-          'user': {'login': 'alice'},
-          'created_at': daysAgo(1).toIso8601String(),
-          'requested_reviewers': [],
-        },
-      ],
-    );
-    expect(items.length, 1);
-    expect(items.single.category, 'oldOpenPr');
-    expect(items.single.title, 'PR #1 open for 40 days');
-  });
+  test(
+    'GitHub: old PR with no pending review -> oldOpenPr; fresh -> nothing',
+    () {
+      final items = AttentionService.githubItems(
+        repoDisplay: 'acme/api',
+        now: now,
+        prs: [
+          {
+            'number': 1,
+            'title': 'Old',
+            'user': {'login': 'alice'},
+            'created_at': daysAgo(40).toIso8601String(),
+            'requested_reviewers': [],
+          },
+          {
+            'number': 2,
+            'title': 'Fresh',
+            'user': {'login': 'alice'},
+            'created_at': daysAgo(1).toIso8601String(),
+            'requested_reviewers': [],
+          },
+        ],
+      );
+      expect(items.length, 1);
+      expect(items.single.category, 'oldOpenPr');
+      expect(items.single.title, 'PR #1 open for 40 days');
+    },
+  );
 
   test('GitHub: draft PRs are ignored', () {
     final items = AttentionService.githubItems(
@@ -94,7 +96,7 @@ void main() {
           'user': {'login': 'alice'},
           'created_at': daysAgo(30).toIso8601String(),
           'requested_reviewers': [
-            {'login': 'bob'}
+            {'login': 'bob'},
           ],
         },
       ],
@@ -102,38 +104,40 @@ void main() {
     expect(items, isEmpty);
   });
 
-  test('category dominates age: old oldOpenPr never outranks a fresh review',
-      () {
-    final review = AttentionService.githubItems(
-      repoDisplay: 'r',
-      now: now,
-      prs: [
-        {
-          'number': 1,
-          'title': 't',
-          'user': {'login': 'a'},
-          'created_at': daysAgo(0).toIso8601String(),
-          'requested_reviewers': [
-            {'login': 'b'}
-          ],
-        },
-      ],
-    ).single;
-    final oldOpen = AttentionService.githubItems(
-      repoDisplay: 'r',
-      now: now,
-      prs: [
-        {
-          'number': 2,
-          'title': 't',
-          'user': {'login': 'a'},
-          'created_at': daysAgo(300).toIso8601String(),
-          'requested_reviewers': [],
-        },
-      ],
-    ).single;
-    expect(review.severity, greaterThan(oldOpen.severity));
-  });
+  test(
+    'category dominates age: old oldOpenPr never outranks a fresh review',
+    () {
+      final review = AttentionService.githubItems(
+        repoDisplay: 'r',
+        now: now,
+        prs: [
+          {
+            'number': 1,
+            'title': 't',
+            'user': {'login': 'a'},
+            'created_at': daysAgo(0).toIso8601String(),
+            'requested_reviewers': [
+              {'login': 'b'},
+            ],
+          },
+        ],
+      ).single;
+      final oldOpen = AttentionService.githubItems(
+        repoDisplay: 'r',
+        now: now,
+        prs: [
+          {
+            'number': 2,
+            'title': 't',
+            'user': {'login': 'a'},
+            'created_at': daysAgo(300).toIso8601String(),
+            'requested_reviewers': [],
+          },
+        ],
+      ).single;
+      expect(review.severity, greaterThan(oldOpen.severity));
+    },
+  );
 
   test('ADO: vote 0 -> reviewRequested; negative vote -> changesRequested', () {
     final waiting = AttentionService.adoItems(
@@ -149,14 +153,16 @@ void main() {
           'createdBy': {'displayName': 'Carol'},
           'creationDate': daysAgo(5).toIso8601String(),
           'reviewers': [
-            {'vote': 0}
+            {'vote': 0},
           ],
         },
       ],
     ).single;
     expect(waiting.category, 'reviewRequested');
     expect(
-        waiting.url, 'https://dev.azure.com/org/proj/_git/repo/pullrequest/42');
+      waiting.url,
+      'https://dev.azure.com/org/proj/_git/repo/pullrequest/42',
+    );
 
     final changes = AttentionService.adoItems(
       repoDisplay: 'org/proj/repo',
@@ -171,7 +177,7 @@ void main() {
           'createdBy': {'displayName': 'Carol'},
           'creationDate': daysAgo(2).toIso8601String(),
           'reviewers': [
-            {'vote': -5}
+            {'vote': -5},
           ],
         },
       ],
@@ -194,7 +200,7 @@ void main() {
           'createdBy': {'displayName': 'Carol'},
           'creationDate': daysAgo(30).toIso8601String(),
           'reviewers': [
-            {'vote': 10}
+            {'vote': 10},
           ],
         },
       ],
@@ -225,7 +231,7 @@ void main() {
           'user': {'login': 42},
           'created_at': daysAgo(2).toIso8601String(),
           'requested_reviewers': [
-            {'login': 'bob'}
+            {'login': 'bob'},
           ],
           'html_url': 99,
         },
@@ -248,7 +254,7 @@ void main() {
           'user': {'login': 'alice'},
           'created_at': daysAgo(1).toIso8601String(),
           'requested_reviewers': [
-            {'login': 'me'}
+            {'login': 'me'},
           ],
         },
         {
@@ -264,7 +270,7 @@ void main() {
           'user': {'login': 'bob'},
           'created_at': daysAgo(1).toIso8601String(),
           'requested_reviewers': [
-            {'login': 'carol'}
+            {'login': 'carol'},
           ],
         },
       ],
@@ -290,7 +296,7 @@ void main() {
           'createdBy': {'displayName': 'Jane Doe'},
           'creationDate': daysAgo(1).toIso8601String(),
           'reviewers': [
-            {'vote': 0, 'displayName': 'Someone'}
+            {'vote': 0, 'displayName': 'Someone'},
           ],
         },
       ],
@@ -305,51 +311,53 @@ void main() {
       SharedPreferences.setMockInitialValues({});
     });
 
-    test('uses the injected clock so age is deterministic (not wall clock)',
-        () async {
-      final token = await TokenStore.addToken(
-        provider: TokenStore.providerGithub,
-        label: 'Acme',
-        scope: 'acme',
-        secret: 'ghp_secret',
-      );
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setStringList('github_repos', [
-        jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': token.id}),
-      ]);
+    test(
+      'uses the injected clock so age is deterministic (not wall clock)',
+      () async {
+        final token = await TokenStore.addToken(
+          provider: TokenStore.providerGithub,
+          label: 'Acme',
+          scope: 'acme',
+          secret: 'ghp_secret',
+        );
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setStringList('github_repos', [
+          jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': token.id}),
+        ]);
 
-      final client = MockClient((request) async {
-        if (request.url.path == '/repos/acme/api/pulls') {
-          return http.Response(
-            jsonEncode([
-              {
-                'number': 7,
-                'title': 'Waiting',
-                'user': {'login': 'alice'},
-                // Created a decade before the injected clock; if the code used
-                // the wall clock this age would be far larger than 10 days.
-                'created_at': '2020-01-01T00:00:00Z',
-                'requested_reviewers': [
-                  {'login': 'bob'}
-                ],
-                'html_url': 'https://github.com/acme/api/pull/7',
-              },
-            ]),
-            200,
-          );
-        }
-        return http.Response('[]', 200);
-      });
+        final client = MockClient((request) async {
+          if (request.url.path == '/repos/acme/api/pulls') {
+            return http.Response(
+              jsonEncode([
+                {
+                  'number': 7,
+                  'title': 'Waiting',
+                  'user': {'login': 'alice'},
+                  // Created a decade before the injected clock; if the code used
+                  // the wall clock this age would be far larger than 10 days.
+                  'created_at': '2020-01-01T00:00:00Z',
+                  'requested_reviewers': [
+                    {'login': 'bob'},
+                  ],
+                  'html_url': 'https://github.com/acme/api/pull/7',
+                },
+              ]),
+              200,
+            );
+          }
+          return http.Response('[]', 200);
+        });
 
-      final items = await AttentionService.computeAll(
-        client: client,
-        now: DateTime.parse('2020-01-11T00:00:00Z'),
-      );
+        final items = await AttentionService.computeAll(
+          client: client,
+          now: DateTime.parse('2020-01-11T00:00:00Z'),
+        );
 
-      expect(items, hasLength(1));
-      expect(items.single.category, 'reviewRequested');
-      expect(items.single.ageDays, 10);
-    });
+        expect(items, hasLength(1));
+        expect(items.single.category, 'reviewRequested');
+        expect(items.single.ageDays, 10);
+      },
+    );
 
     test('filters out snoozed item ids', () async {
       final token = await TokenStore.addToken(
@@ -372,7 +380,7 @@ void main() {
                 'user': {'login': 'a'},
                 'created_at': '2020-01-01T00:00:00Z',
                 'requested_reviewers': [
-                  {'login': 'b'}
+                  {'login': 'b'},
                 ],
                 'html_url': 'https://github.com/acme/api/pull/7',
               },

--- a/test/auto_add_service_test.dart
+++ b/test/auto_add_service_test.dart
@@ -19,49 +19,51 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  test('adds new repos for an auto-add token and skips existing ones',
-      () async {
-    final token = await TokenStore.addToken(
-      provider: TokenStore.providerGithub,
-      label: 'Acme',
-      scope: 'acme',
-      secret: 'ghp_secret',
-      autoAdd: true,
-    );
+  test(
+    'adds new repos for an auto-add token and skips existing ones',
+    () async {
+      final token = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Acme',
+        scope: 'acme',
+        secret: 'ghp_secret',
+        autoAdd: true,
+      );
 
-    final client = MockClient((request) async {
-      if (request.url.path == '/orgs/acme/repos' &&
-          request.url.queryParameters['page'] == '1') {
-        return http.Response(
-          jsonEncode([
-            {
-              'name': 'api',
-              'owner': {'login': 'acme'},
-            },
-            {
-              'name': 'web',
-              'owner': {'login': 'acme'},
-            },
-          ]),
-          200,
-        );
-      }
-      return http.Response('[]', 200);
-    });
+      final client = MockClient((request) async {
+        if (request.url.path == '/orgs/acme/repos' &&
+            request.url.queryParameters['page'] == '1') {
+          return http.Response(
+            jsonEncode([
+              {
+                'name': 'api',
+                'owner': {'login': 'acme'},
+              },
+              {
+                'name': 'web',
+                'owner': {'login': 'acme'},
+              },
+            ]),
+            200,
+          );
+        }
+        return http.Response('[]', 200);
+      });
 
-    final added = await AutoAddService.run(client: client);
-    expect(added, 2);
+      final added = await AutoAddService.run(client: client);
+      expect(added, 2);
 
-    final prefs = await SharedPreferences.getInstance();
-    final repos = prefs.getStringList('github_repos') ?? [];
-    expect(repos.length, 2);
-    final first = Map<String, String>.from(jsonDecode(repos.first));
-    expect(first['owner'], 'acme');
-    expect(first['tokenId'], token.id);
+      final prefs = await SharedPreferences.getInstance();
+      final repos = prefs.getStringList('github_repos') ?? [];
+      expect(repos.length, 2);
+      final first = Map<String, String>.from(jsonDecode(repos.first));
+      expect(first['owner'], 'acme');
+      expect(first['tokenId'], token.id);
 
-    // A second pass adds nothing since everything is already monitored.
-    expect(await AutoAddService.run(client: client), 0);
-  });
+      // A second pass adds nothing since everything is already monitored.
+      expect(await AutoAddService.run(client: client), 0);
+    },
+  );
 
   test('does nothing when no token has auto-add enabled', () async {
     await TokenStore.addToken(

--- a/test/identity_store_test.dart
+++ b/test/identity_store_test.dart
@@ -26,9 +26,9 @@ void main() {
       jsonDecode(prefs.getString('self_github_logins')!) as List<dynamic>,
       ['alice', 'bob'],
     );
-    expect(
-      jsonDecode(prefs.getString('self_ado_names')!) as List<dynamic>,
-      ['Ada Lovelace', 'Grace Hopper'],
-    );
+    expect(jsonDecode(prefs.getString('self_ado_names')!) as List<dynamic>, [
+      'Ada Lovelace',
+      'Grace Hopper',
+    ]);
   });
 }

--- a/test/ignore_store_test.dart
+++ b/test/ignore_store_test.dart
@@ -41,10 +41,7 @@ void main() {
   });
 
   test('remove deletes an ignored key', () async {
-    await IgnoreStore.addAll([
-      'github:owner/repo',
-      'ado:org/project/repo',
-    ]);
+    await IgnoreStore.addAll(['github:owner/repo', 'ado:org/project/repo']);
 
     await IgnoreStore.remove('github:owner/repo');
 

--- a/test/manage_repos_test.dart
+++ b/test/manage_repos_test.dart
@@ -11,8 +11,9 @@ void main() {
     FlutterSecureStorage.setMockInitialValues({});
   });
 
-  testWidgets('lists registered GitHub and ADO repositories',
-      (WidgetTester tester) async {
+  testWidgets('lists registered GitHub and ADO repositories', (
+    WidgetTester tester,
+  ) async {
     SharedPreferences.setMockInitialValues({
       'github_repos': [
         jsonEncode({'owner': 'flutter', 'repoName': 'flutter'}),
@@ -33,8 +34,9 @@ void main() {
     expect(find.text('org/proj/repo'), findsOneWidget);
   });
 
-  testWidgets('deletes a repository after confirmation',
-      (WidgetTester tester) async {
+  testWidgets('deletes a repository after confirmation', (
+    WidgetTester tester,
+  ) async {
     SharedPreferences.setMockInitialValues({
       'github_repos': [
         jsonEncode({'owner': 'flutter', 'repoName': 'flutter'}),
@@ -61,16 +63,14 @@ void main() {
     expect(prefs.getStringList('github_repos'), isEmpty);
   });
 
-  testWidgets('shows an empty state when no repositories are tracked',
-      (WidgetTester tester) async {
+  testWidgets('shows an empty state when no repositories are tracked', (
+    WidgetTester tester,
+  ) async {
     SharedPreferences.setMockInitialValues({});
 
     await tester.pumpWidget(const MaterialApp(home: ManageReposPage()));
     await tester.pumpAndSettle();
 
-    expect(
-      find.text('No repositories are being tracked yet.'),
-      findsOneWidget,
-    );
+    expect(find.text('No repositories are being tracked yet.'), findsOneWidget);
   });
 }

--- a/test/people_service_test.dart
+++ b/test/people_service_test.dart
@@ -45,7 +45,9 @@ void main() {
     expect(bob.reviewRequests, 2);
     expect(carol.reviewRequests, 1);
     expect(
-        people.any((person) => person.key == 'github:draft-author'), isFalse);
+      people.any((person) => person.key == 'github:draft-author'),
+      isFalse,
+    );
   });
 
   test('mergePeople merges shared logins, sums counts, and marks self', () {
@@ -105,10 +107,12 @@ void main() {
 
     // Only the author + the pending reviewer are registered.
     expect(people, hasLength(2));
-    final reviewSum =
-        people.map((p) => p.reviewRequests).fold<int>(0, (a, b) => a + b);
-    final authorSum =
-        people.map((p) => p.authoredOpenPrs).fold<int>(0, (a, b) => a + b);
+    final reviewSum = people
+        .map((p) => p.reviewRequests)
+        .fold<int>(0, (a, b) => a + b);
+    final authorSum = people
+        .map((p) => p.authoredOpenPrs)
+        .fold<int>(0, (a, b) => a + b);
     expect(reviewSum, 1);
     expect(authorSum, 1);
   });

--- a/test/repo_discovery_test.dart
+++ b/test/repo_discovery_test.dart
@@ -26,7 +26,9 @@ void main() {
     expect(repos.first.repo, {'owner': 'Flutter', 'repoName': 'flutter'});
     // Key is case-insensitive.
     expect(
-        repos.first.key, RepoDiscoveryService.githubKey('flutter', 'FLUTTER'));
+      repos.first.key,
+      RepoDiscoveryService.githubKey('flutter', 'FLUTTER'),
+    );
   });
 
   test('parses Azure DevOps repos with project info', () {
@@ -52,39 +54,41 @@ void main() {
     );
   });
 
-  test('falls back to /user/repos filtered by owner for a personal scope',
-      () async {
-    final client = MockClient((request) async {
-      if (request.url.path == '/orgs/octocat/repos') {
-        return http.Response('{"message": "Not Found"}', 404);
-      }
-      if (request.url.path == '/user/repos') {
-        return http.Response(
-          jsonEncode([
-            {
-              'name': 'hello',
-              'owner': {'login': 'octocat'},
-            },
-            {
-              'name': 'other',
-              'owner': {'login': 'someoneelse'},
-            },
-          ]),
-          200,
-        );
-      }
-      return http.Response('[]', 200);
-    });
+  test(
+    'falls back to /user/repos filtered by owner for a personal scope',
+    () async {
+      final client = MockClient((request) async {
+        if (request.url.path == '/orgs/octocat/repos') {
+          return http.Response('{"message": "Not Found"}', 404);
+        }
+        if (request.url.path == '/user/repos') {
+          return http.Response(
+            jsonEncode([
+              {
+                'name': 'hello',
+                'owner': {'login': 'octocat'},
+              },
+              {
+                'name': 'other',
+                'owner': {'login': 'someoneelse'},
+              },
+            ]),
+            200,
+          );
+        }
+        return http.Response('[]', 200);
+      });
 
-    final result = await RepoDiscoveryService.fetch(
-      provider: TokenStore.providerGithub,
-      secret: 'ghp_secret',
-      org: 'octocat',
-      client: client,
-    );
+      final result = await RepoDiscoveryService.fetch(
+        provider: TokenStore.providerGithub,
+        secret: 'ghp_secret',
+        org: 'octocat',
+        client: client,
+      );
 
-    // Only the owner's repo survives the filter.
-    expect(result.repos.length, 1);
-    expect(result.repos.single.display, 'octocat/hello');
-  });
+      // Only the owner's repo survives the filter.
+      expect(result.repos.length, 1);
+      expect(result.repos.single.display, 'octocat/hello');
+    },
+  );
 }

--- a/test/snooze_store_test.dart
+++ b/test/snooze_store_test.dart
@@ -12,10 +12,7 @@ void main() {
   });
 
   test('round-trips a timed snooze and unsnooze', () async {
-    await SnoozeStore.snooze(
-      'item-1',
-      forDuration: const Duration(hours: 1),
-    );
+    await SnoozeStore.snooze('item-1', forDuration: const Duration(hours: 1));
 
     expect(await SnoozeStore.isSnoozed('item-1'), isTrue);
     expect(await SnoozeStore.snoozedIds(), contains('item-1'));
@@ -33,31 +30,22 @@ void main() {
     expect(await SnoozeStore.snoozedIds(), contains('item-2'));
 
     final prefs = await SharedPreferences.getInstance();
-    final stored = jsonDecode(
-      prefs.getString('snoozed_attention')!,
-    ) as Map<String, dynamic>;
+    final stored =
+        jsonDecode(prefs.getString('snoozed_attention')!)
+            as Map<String, dynamic>;
     expect(stored['item-2'], isNull);
   });
 
   test('pruneExpired removes expired entries and keeps active entries', () {
     final now = DateTime.fromMillisecondsSinceEpoch(1000);
 
-    final pruned = SnoozeStore.pruneExpired(
-      <String, int?>{
-        'expired': 999,
-        'exactly-now': 1000,
-        'future': 1001,
-        'forever': null,
-      },
-      now,
-    );
+    final pruned = SnoozeStore.pruneExpired(<String, int?>{
+      'expired': 999,
+      'exactly-now': 1000,
+      'future': 1001,
+      'forever': null,
+    }, now);
 
-    expect(
-      pruned,
-      <String, int?>{
-        'future': 1001,
-        'forever': null,
-      },
-    );
+    expect(pruned, <String, int?>{'future': 1001, 'forever': null});
   });
 }

--- a/test/token_store_test.dart
+++ b/test/token_store_test.dart
@@ -38,32 +38,34 @@ void main() {
     expect(await TokenStore.resolveGithubSecret('other'), 'ghp_default');
   });
 
-  test('per-repo override wins, and falls back when the token is gone',
-      () async {
-    await TokenStore.addToken(
-      provider: TokenStore.providerGithub,
-      label: 'Default',
-      scope: '',
-      secret: 'ghp_default',
-    );
-    final override = await TokenStore.addToken(
-      provider: TokenStore.providerGithub,
-      label: 'Special',
-      scope: 'someorg',
-      secret: 'ghp_special',
-    );
+  test(
+    'per-repo override wins, and falls back when the token is gone',
+    () async {
+      await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Default',
+        scope: '',
+        secret: 'ghp_default',
+      );
+      final override = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Special',
+        scope: 'someorg',
+        secret: 'ghp_special',
+      );
 
-    expect(
-      await TokenStore.resolveGithubSecret('acme', tokenId: override.id),
-      'ghp_special',
-    );
+      expect(
+        await TokenStore.resolveGithubSecret('acme', tokenId: override.id),
+        'ghp_special',
+      );
 
-    await TokenStore.deleteToken(override.id);
-    expect(
-      await TokenStore.resolveGithubSecret('acme', tokenId: override.id),
-      'ghp_default',
-    );
-  });
+      await TokenStore.deleteToken(override.id);
+      expect(
+        await TokenStore.resolveGithubSecret('acme', tokenId: override.id),
+        'ghp_default',
+      );
+    },
+  );
 
   test('GitHub and ADO tokens are resolved independently', () async {
     await TokenStore.addToken(
@@ -92,8 +94,9 @@ void main() {
     );
 
     await TokenStore.updateToken(token.copyWith(label: 'B', scope: 'acme'));
-    final tokens =
-        await TokenStore.getTokensForProvider(TokenStore.providerGithub);
+    final tokens = await TokenStore.getTokensForProvider(
+      TokenStore.providerGithub,
+    );
     expect(tokens.single.label, 'B');
     expect(tokens.single.scope, 'acme');
     expect(await TokenStore.getSecret(token.id), 's1'); // unchanged

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -17,8 +17,9 @@ void main() {
     FlutterSecureStorage.setMockInitialValues({});
   });
 
-  testWidgets('Kode Radar app loads and shows main content',
-      (WidgetTester tester) async {
+  testWidgets('Kode Radar app loads and shows main content', (
+    WidgetTester tester,
+  ) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());
 
@@ -47,7 +48,9 @@ void main() {
     // empty state (no repositories are configured in the test environment).
     expect(find.widgetWithText(AppBar, 'Attention'), findsOneWidget);
     expect(
-        find.text('Nothing needs your attention right now.'), findsOneWidget);
+      find.text('Nothing needs your attention right now.'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('Manage Tokens page can be opened', (WidgetTester tester) async {


### PR DESCRIPTION
Upgrades the Flutter SDK and refreshes all updatable dependencies.

## Flutter
- **3.41.4 -> 3.44.6** (latest stable; Dart 3.12.2).
- CI `flutter-version` bumped to `3.44.6` across all jobs.

## Dependencies
- **flutter_local_notifications `^19.4.2` -> `^22.0.1`** (major). Migrated `initialize()` and `show()` to the new named-parameter API (`settings:`, `id:`/`title:`/`body:`/`notificationDetails:`) in `lib/main.dart` and `lib/notification_service.dart`.
- `pub upgrade --major-versions` refreshed the lockfile to the latest resolvable versions (http, image, xml, win32, window_manager, url_launcher_*, shared_preferences_*, screen_retriever_*, timezone, json_annotation, lints).
- A handful of transitive packages (meta, package_config, record_use, hooks, vector_math, matcher, test_api) remain pinned by the Flutter SDK until a future SDK bump.

## Validation
- `flutter analyze` clean, `dart format` clean, **63 tests pass**.
- iOS release native build succeeds (upgraded pods compile).
- All-platform builds validated by CI.
