### PR TITLE
feature: monitoring M4 — Teams, trends, and digests

### DIFF
--- a/lib/digest_page.dart
+++ b/lib/digest_page.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+
+import 'activity_service.dart';
+import 'app_http.dart';
+import 'digest_service.dart';
+import 'metric_store.dart';
+import 'team_store.dart';
+
+class DigestPage extends StatefulWidget {
+  const DigestPage({super.key});
+
+  @override
+  State<DigestPage> createState() => _DigestPageState();
+}
+
+class _DigestPageState extends State<DigestPage> {
+  Digest? _digest;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDigest();
+  }
+
+  Future<void> _loadDigest() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final teams = await TeamStore.list();
+      final activities = await ActivityService.computeAll(
+        client: AppHttp.client,
+      );
+      // Record a trend snapshot from this load too (deduped ~1/day) before
+      // reading history, so the digest reflects the latest observation.
+      await MetricStore.capture(activities);
+      final history = await MetricStore.all();
+      final digest = DigestService.buildDigest(
+        teams: teams,
+        activities: activities,
+        history: history,
+      );
+
+      if (!mounted) return;
+      setState(() {
+        _digest = digest;
+        _loading = false;
+      });
+    } catch (e) {
+      debugPrint('DigestPage failed to load: $e');
+      if (!mounted) return;
+      setState(() {
+        _error =
+            'Something went wrong while loading your digest. Pull down to try again.';
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Digest'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: _loading ? null : _loadDigest,
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(onRefresh: _loadDigest, child: _buildContent()),
+    );
+  }
+
+  Widget _buildContent() {
+    if (_error != null) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 160),
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Text(
+                _error!,
+                textAlign: TextAlign.center,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    final digest = _digest;
+    if (digest == null) {
+      return _buildEmptyState('No digest data yet. Pull down to refresh.');
+    }
+
+    if (digest.teamLines.isEmpty &&
+        digest.totalOpenPrs == 0 &&
+        digest.totalNeedsReview == 0) {
+      return _buildEmptyState(
+        'No team digest yet. Add teams and repositories to see trends.',
+      );
+    }
+
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.only(bottom: 16),
+      children: [
+        _buildSummaryCard(digest),
+        _sectionTitle('Top movers'),
+        if (digest.movers.isEmpty)
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 4, 16, 12),
+            child: Text('No activity movement in this window.'),
+          )
+        else
+          ...digest.movers.map(_buildLineTile),
+        _sectionTitle('Teams'),
+        if (digest.teamLines.isEmpty)
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 4, 16, 12),
+            child: Text('No teams available yet.'),
+          )
+        else
+          ...digest.teamLines.map(_buildLineTile),
+      ],
+    );
+  }
+
+  Widget _buildEmptyState(String message) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        const SizedBox(height: 140),
+        Center(
+          child: Icon(
+            Icons.summarize_outlined,
+            size: 56,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Text(message, textAlign: TextAlign.center),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSummaryCard(Digest digest) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.summarize, color: theme.colorScheme.primary),
+                const SizedBox(width: 8),
+                Text('Summary', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              children: [
+                _metric(Icons.merge_type, '${digest.totalOpenPrs} open PRs'),
+                _metric(
+                  Icons.rate_review,
+                  '${digest.totalNeedsReview} need review',
+                ),
+                _metric(Icons.groups, '${digest.teamLines.length} teams'),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Window: ${_formatWindow(digest.window)} · Generated ${_relativeTime(digest.generatedAt)}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _sectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 6),
+      child: Text(title, style: Theme.of(context).textTheme.titleMedium),
+    );
+  }
+
+  Widget _buildLineTile(DigestLine line) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: ListTile(
+        title: Text(line.label),
+        subtitle: Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 8,
+            children: [
+              _metric(Icons.merge_type, '${line.openPrs} open PRs'),
+              _metric(Icons.rate_review, '${line.needsReview} need review'),
+              _metric(
+                Icons.auto_graph,
+                'Activity ${_formatNumber(line.activityScore)}',
+              ),
+            ],
+          ),
+        ),
+        trailing: _deltaIndicator(line.activityDelta),
+      ),
+    );
+  }
+
+  Widget _metric(IconData icon, String text) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          icon,
+          size: 16,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+        const SizedBox(width: 4),
+        Text(text),
+      ],
+    );
+  }
+
+  Widget _deltaIndicator(num delta) {
+    final theme = Theme.of(context);
+    final Color color;
+    final IconData icon;
+    if (delta > 0) {
+      color = Colors.green;
+      icon = Icons.arrow_upward;
+    } else if (delta < 0) {
+      color = Colors.red;
+      icon = Icons.arrow_downward;
+    } else {
+      color = theme.colorScheme.onSurfaceVariant;
+      icon = Icons.remove;
+    }
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: color),
+        const SizedBox(width: 4),
+        Text(
+          _formatDelta(delta),
+          style: theme.textTheme.bodyMedium?.copyWith(color: color),
+        ),
+      ],
+    );
+  }
+
+  String _formatDelta(num delta) {
+    if (delta > 0) return '+${_formatNumber(delta)}';
+    return _formatNumber(delta);
+  }
+
+  String _formatNumber(num value) {
+    if (!value.isFinite) return '0';
+    final doubleValue = value.toDouble();
+    if (doubleValue == doubleValue.roundToDouble()) {
+      return doubleValue.toInt().toString();
+    }
+    return doubleValue.toStringAsFixed(1);
+  }
+
+  String _formatWindow(Duration window) {
+    if (window.inDays >= 1 && window.inHours % 24 == 0) {
+      return _plural(window.inDays, 'day');
+    }
+    if (window.inHours >= 1 && window.inMinutes % 60 == 0) {
+      return _plural(window.inHours, 'hour');
+    }
+    if (window.inMinutes >= 1 && window.inSeconds % 60 == 0) {
+      return _plural(window.inMinutes, 'minute');
+    }
+    return _plural(window.inSeconds, 'second');
+  }
+
+  String _plural(int value, String unit) {
+    return '$value $unit${value == 1 ? '' : 's'}';
+  }
+
+  String _relativeTime(DateTime value) {
+    final diff = DateTime.now().difference(value);
+    if (diff.isNegative || diff.inSeconds < 45) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+}

--- a/lib/digest_service.dart
+++ b/lib/digest_service.dart
@@ -1,0 +1,138 @@
+import 'activity_service.dart';
+import 'metric_snapshot.dart';
+import 'team.dart';
+
+class DigestLine {
+  const DigestLine({
+    required this.label,
+    required this.openPrs,
+    required this.needsReview,
+    required this.activityScore,
+    required this.activityDelta,
+  });
+
+  final String label;
+  final int openPrs;
+  final int needsReview;
+  final num activityScore;
+  final num activityDelta;
+}
+
+class Digest {
+  const Digest({
+    required this.generatedAt,
+    required this.window,
+    required this.totalOpenPrs,
+    required this.totalNeedsReview,
+    required this.teamLines,
+    required this.movers,
+  });
+
+  final DateTime generatedAt;
+  final Duration window;
+  final int totalOpenPrs;
+  final int totalNeedsReview;
+  final List<DigestLine> teamLines;
+  final List<DigestLine> movers;
+}
+
+class DigestService {
+  DigestService._();
+
+  static Digest buildDigest({
+    required List<Team> teams,
+    required List<RepoActivity> activities,
+    required Map<String, List<MetricSnapshot>> history,
+    DateTime? now,
+    Duration window = const Duration(days: 7),
+  }) {
+    final generatedAt = now ?? DateTime.now();
+    final cutoff = generatedAt.subtract(window);
+
+    // Only repos we currently have valid (non-errored) data for; an errored
+    // fetch must not read as a healthy zero.
+    final byKey = <String, RepoActivity>{
+      for (final activity in activities)
+        if (activity.error == null) activity.repoKey: activity,
+    };
+
+    final totalOpenPrs = byKey.values.fold<int>(
+      0,
+      (total, activity) => total + activity.openPrCount,
+    );
+    final totalNeedsReview = byKey.values.fold<int>(
+      0,
+      (total, activity) => total + activity.needsReviewCount,
+    );
+
+    final teamLines = <DigestLine>[];
+    for (final team in teams) {
+      var openPrs = 0;
+      var needsReview = 0;
+      num activityScore = 0;
+      // Delta is computed only over member repos that have a baseline snapshot
+      // within the window, comparing their current score to that baseline. A
+      // team with no such baseline has no meaningful trend yet (delta 0), so it
+      // is not treated as a mover.
+      num deltaCurrent = 0;
+      num deltaBaseline = 0;
+      var hasBaseline = false;
+
+      for (final repoKey in team.repoKeys) {
+        final activity = byKey[repoKey];
+        if (activity != null) {
+          openPrs += activity.openPrCount;
+          needsReview += activity.needsReviewCount;
+          activityScore += _safeScore(activity.activityScore);
+        }
+        final baseline = _oldestSnapshotInWindow(history[repoKey], cutoff);
+        if (baseline != null && activity != null) {
+          hasBaseline = true;
+          deltaBaseline += _safeScore(baseline.activityScore);
+          deltaCurrent += _safeScore(activity.activityScore);
+        }
+      }
+
+      teamLines.add(
+        DigestLine(
+          label: team.name,
+          openPrs: openPrs,
+          needsReview: needsReview,
+          activityScore: activityScore,
+          activityDelta: hasBaseline ? deltaCurrent - deltaBaseline : 0,
+        ),
+      );
+    }
+
+    // Sort by magnitude so large drops surface alongside large rises.
+    final movers = teamLines.where((line) => line.activityDelta != 0).toList()
+      ..sort((a, b) => b.activityDelta.abs().compareTo(a.activityDelta.abs()));
+
+    return Digest(
+      generatedAt: generatedAt,
+      window: window,
+      totalOpenPrs: totalOpenPrs,
+      totalNeedsReview: totalNeedsReview,
+      teamLines: teamLines,
+      movers: movers.take(5).toList(),
+    );
+  }
+
+  static MetricSnapshot? _oldestSnapshotInWindow(
+    List<MetricSnapshot>? snapshots,
+    DateTime cutoff,
+  ) {
+    if (snapshots == null || snapshots.isEmpty) return null;
+
+    MetricSnapshot? oldest;
+    for (final snapshot in snapshots) {
+      if (snapshot.at.isBefore(cutoff)) continue;
+      if (oldest == null || snapshot.at.isBefore(oldest.at)) {
+        oldest = snapshot;
+      }
+    }
+    return oldest;
+  }
+
+  static num _safeScore(num value) => value.isFinite ? value : 0;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'manage_tokens_page.dart';
 import 'radar_page.dart';
 import 'attention_inbox_page.dart';
 import 'people_page.dart';
+import 'teams_page.dart';
 import 'auto_add_service.dart';
 import 'token_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -671,6 +672,16 @@ class _MyHomePageState extends State<MyHomePage>
               await Navigator.push(
                 context,
                 MaterialPageRoute(builder: (_) => const PeoplePage()),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.groups),
+            tooltip: 'Teams',
+            onPressed: () async {
+              await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const TeamsPage()),
               );
             },
           ),

--- a/lib/manage_teams_page.dart
+++ b/lib/manage_teams_page.dart
@@ -1,0 +1,408 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'repo_discovery_service.dart';
+import 'repo_store.dart';
+import 'team.dart';
+import 'team_store.dart';
+
+class ManageTeamsPage extends StatefulWidget {
+  const ManageTeamsPage({super.key});
+
+  @override
+  State<ManageTeamsPage> createState() => _ManageTeamsPageState();
+}
+
+class _ManageTeamsPageState extends State<ManageTeamsPage> {
+  List<Team> _teams = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadTeams();
+  }
+
+  Future<void> _loadTeams() async {
+    final teams = await TeamStore.list();
+    if (!mounted) return;
+    setState(() {
+      _teams = teams;
+      _isLoading = false;
+    });
+  }
+
+  Future<void> _createTeam() async {
+    final name = await _showNameDialog(title: 'Create team');
+    if (name == null) return;
+
+    final team = await TeamStore.add(name);
+    await _loadTeams();
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Created "${team.name}".')));
+  }
+
+  Future<void> _renameTeam(Team team) async {
+    final name = await _showNameDialog(
+      title: 'Rename team',
+      initialValue: team.name,
+    );
+    if (name == null) return;
+
+    await TeamStore.rename(team.id, name);
+    await _loadTeams();
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Renamed to "$name".')));
+  }
+
+  Future<void> _deleteTeam(Team team) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('Delete team?'),
+          content: Text(
+            'Delete "${team.name}"?\n\n'
+            'This only removes the team grouping. Repositories remain tracked.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              style: TextButton.styleFrom(foregroundColor: Colors.red),
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Delete'),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed != true) return;
+
+    await TeamStore.delete(team.id);
+    await _loadTeams();
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Deleted "${team.name}".')));
+  }
+
+  Future<void> _assignRepos(Team team) async {
+    final saved = await Navigator.push<bool>(
+      context,
+      MaterialPageRoute(builder: (_) => _AssignReposPage(team: team)),
+    );
+    await _loadTeams();
+    if (!mounted) return;
+    if (saved == true) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Updated "${team.name}".')));
+    }
+  }
+
+  Future<String?> _showNameDialog({
+    required String title,
+    String initialValue = '',
+  }) async {
+    final controller = TextEditingController(text: initialValue);
+    try {
+      final result = await showDialog<String>(
+        context: context,
+        builder: (dialogContext) {
+          return AlertDialog(
+            title: Text(title),
+            content: SingleChildScrollView(
+              child: TextField(
+                controller: controller,
+                autofocus: true,
+                decoration: const InputDecoration(labelText: 'Team name'),
+                textInputAction: TextInputAction.done,
+                onSubmitted: (_) => _popName(dialogContext, controller),
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: () => _popName(dialogContext, controller),
+                child: const Text('Save'),
+              ),
+            ],
+          );
+        },
+      );
+      return result;
+    } finally {
+      controller.dispose();
+    }
+  }
+
+  void _popName(BuildContext dialogContext, TextEditingController controller) {
+    final name = controller.text.trim();
+    if (name.isEmpty) return;
+    Navigator.of(dialogContext).pop(name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Manage Teams')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _createTeam,
+        tooltip: 'Create team',
+        child: const Icon(Icons.add),
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_teams.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.groups_outlined, size: 48, color: Colors.grey[400]),
+            const SizedBox(height: 12),
+            const Text('No teams created yet.'),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: _createTeam,
+              icon: const Icon(Icons.add),
+              label: const Text('Create team'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: _teams.map(_buildTeamTile).toList(),
+    );
+  }
+
+  Widget _buildTeamTile(Team team) {
+    return ListTile(
+      leading: const Icon(Icons.groups_outlined),
+      title: Text(team.name),
+      subtitle: Text(_repoCountLabel(team.repoKeys.length)),
+      onTap: () => _assignRepos(team),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.playlist_add_check),
+            tooltip: 'Assign repositories',
+            onPressed: () => _assignRepos(team),
+          ),
+          IconButton(
+            icon: const Icon(Icons.edit),
+            tooltip: 'Rename',
+            onPressed: () => _renameTeam(team),
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Delete',
+            color: Colors.red,
+            onPressed: () => _deleteTeam(team),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _repoCountLabel(int count) =>
+      '$count ${count == 1 ? 'repository' : 'repositories'}';
+}
+
+class _AssignReposPage extends StatefulWidget {
+  const _AssignReposPage({required this.team});
+
+  final Team team;
+
+  @override
+  State<_AssignReposPage> createState() => _AssignReposPageState();
+}
+
+class _AssignReposPageState extends State<_AssignReposPage> {
+  List<_RepoOption> _repos = [];
+  late Set<String> _selected;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = widget.team.repoKeys.toSet();
+    _loadRepos();
+  }
+
+  Future<void> _loadRepos() async {
+    final repos = await _loadRepoOptions();
+    if (!mounted) return;
+    setState(() {
+      _repos = repos;
+      _selected = _selected.intersection(repos.map((repo) => repo.key).toSet());
+      _isLoading = false;
+    });
+  }
+
+  Future<void> _save() async {
+    await TeamStore.setRepos(widget.team.id, _selected);
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
+  }
+
+  void _toggle(String key, bool selected) {
+    setState(() {
+      if (selected) {
+        _selected.add(key);
+      } else {
+        _selected.remove(key);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Assign Repositories'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.check),
+            tooltip: 'Save',
+            onPressed: _isLoading ? null : _save,
+          ),
+        ],
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_repos.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.inbox_outlined, size: 48, color: Colors.grey[400]),
+            const SizedBox(height: 12),
+            const Text('No repositories are being tracked yet.'),
+          ],
+        ),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: _repos.map(_buildRepoTile).toList(),
+    );
+  }
+
+  Widget _buildRepoTile(_RepoOption repo) {
+    return CheckboxListTile(
+      secondary: Icon(
+        repo.provider == _RepoProvider.github ? Icons.code : Icons.account_tree,
+      ),
+      title: Text(repo.label),
+      subtitle: Text(repo.providerLabel),
+      value: _selected.contains(repo.key),
+      onChanged: (checked) => _toggle(repo.key, checked ?? false),
+    );
+  }
+}
+
+enum _RepoProvider { github, ado }
+
+class _RepoOption {
+  const _RepoOption({
+    required this.key,
+    required this.label,
+    required this.provider,
+  });
+
+  final String key;
+  final String label;
+  final _RepoProvider provider;
+
+  String get providerLabel =>
+      provider == _RepoProvider.github ? 'GitHub' : 'Azure DevOps';
+}
+
+Future<List<_RepoOption>> _loadRepoOptions() async {
+  final prefs = await SharedPreferences.getInstance();
+  final repos = <String, _RepoOption>{};
+
+  for (final entry in prefs.getStringList(RepoStore.githubKey) ?? const []) {
+    final repo = _parseRepoEntry(entry);
+    final owner = _stringValue(repo?['owner']);
+    final name = _stringValue(repo?['repoName']);
+    if (owner == null || name == null) {
+      debugPrint('Skipping malformed GitHub repo entry.');
+      continue;
+    }
+    final key = RepoDiscoveryService.githubKey(owner, name);
+    repos[key] = _RepoOption(
+      key: key,
+      label: '$owner/$name',
+      provider: _RepoProvider.github,
+    );
+  }
+
+  for (final entry in prefs.getStringList(RepoStore.adoKey) ?? const []) {
+    final repo = _parseRepoEntry(entry);
+    final organization = _stringValue(repo?['organization']);
+    final project = _stringValue(repo?['project']);
+    final name = _stringValue(repo?['repoName']);
+    if (organization == null || project == null || name == null) {
+      debugPrint('Skipping malformed Azure DevOps repo entry.');
+      continue;
+    }
+    final key = RepoDiscoveryService.adoKey(organization, project, name);
+    repos[key] = _RepoOption(
+      key: key,
+      label: '$organization/$project/$name',
+      provider: _RepoProvider.ado,
+    );
+  }
+
+  final sorted = repos.values.toList()
+    ..sort((a, b) {
+      final provider = a.provider.index.compareTo(b.provider.index);
+      if (provider != 0) return provider;
+      return a.label.toLowerCase().compareTo(b.label.toLowerCase());
+    });
+  return sorted;
+}
+
+Map? _parseRepoEntry(String entry) {
+  try {
+    final decoded = jsonDecode(entry);
+    return decoded is Map ? decoded : null;
+  } catch (error) {
+    debugPrint('Failed to parse repo entry: $error');
+    return null;
+  }
+}
+
+String? _stringValue(Object? value) {
+  if (value is! String) return null;
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}

--- a/lib/metric_snapshot.dart
+++ b/lib/metric_snapshot.dart
@@ -1,0 +1,50 @@
+class MetricSnapshot {
+  const MetricSnapshot({
+    required this.at,
+    required this.openPrs,
+    required this.needsReview,
+    required this.activityScore,
+  });
+
+  final DateTime at;
+  final int openPrs;
+  final int needsReview;
+  final num activityScore;
+
+  Map<String, Object> toJson() => {
+    'at': at.toUtc().toIso8601String(),
+    'openPrs': openPrs,
+    'needsReview': needsReview,
+    'activityScore': activityScore,
+  };
+
+  static MetricSnapshot? fromJson(Map json) {
+    try {
+      final rawAt = json['at'];
+      final rawOpenPrs = json['openPrs'];
+      final rawNeedsReview = json['needsReview'];
+      final rawActivityScore = json['activityScore'];
+
+      if (rawAt is! String ||
+          rawOpenPrs is! int ||
+          rawNeedsReview is! int ||
+          rawActivityScore is! num) {
+        return null;
+      }
+
+      final at = DateTime.tryParse(rawAt);
+      if (at == null) {
+        return null;
+      }
+
+      return MetricSnapshot(
+        at: at.toUtc(),
+        openPrs: rawOpenPrs,
+        needsReview: rawNeedsReview,
+        activityScore: rawActivityScore,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/metric_store.dart
+++ b/lib/metric_store.dart
@@ -1,0 +1,154 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'activity_service.dart';
+import 'metric_snapshot.dart';
+
+class MetricStore {
+  MetricStore._();
+
+  static const String storageKey = 'metric_history';
+  static const int maxPerRepo = 60;
+  static const Duration minCaptureInterval = Duration(hours: 24);
+
+  static Future<void> _lock = Future<void>.value();
+
+  static Future<T> runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    // Keep the chain alive whether the action succeeds or fails.
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  static bool shouldCapture(DateTime? lastAt, DateTime now) =>
+      lastAt == null || now.difference(lastAt) >= minCaptureInterval;
+
+  static Future<void> capture(List<RepoActivity> activities, {DateTime? now}) {
+    final capturedAt = (now ?? DateTime.now()).toUtc();
+    return runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final histories = _readFrom(prefs);
+      var changed = false;
+
+      for (final activity in activities) {
+        if (activity.error != null) {
+          continue;
+        }
+
+        final history = histories.putIfAbsent(
+          activity.repoKey,
+          () => <MetricSnapshot>[],
+        );
+        final lastAt = history.isEmpty ? null : history.last.at;
+        if (!shouldCapture(lastAt, capturedAt)) {
+          continue;
+        }
+
+        history.add(
+          MetricSnapshot(
+            at: capturedAt,
+            openPrs: activity.openPrCount,
+            needsReview: activity.needsReviewCount,
+            activityScore: activity.activityScore,
+          ),
+        );
+        if (history.length > maxPerRepo) {
+          history.removeRange(0, history.length - maxPerRepo);
+        }
+        changed = true;
+      }
+
+      if (changed) {
+        await _writeTo(prefs, histories);
+      }
+    });
+  }
+
+  static Future<Map<String, List<MetricSnapshot>>> all() async {
+    final prefs = await SharedPreferences.getInstance();
+    return _readFrom(prefs);
+  }
+
+  static Future<List<MetricSnapshot>> historyFor(String repoKey) async {
+    final histories = await all();
+    return List<MetricSnapshot>.of(
+      histories[repoKey] ?? const <MetricSnapshot>[],
+    );
+  }
+
+  static Future<List<num>> seriesFor(
+    String repoKey, {
+    String metric = 'activityScore',
+  }) async {
+    final history = await historyFor(repoKey);
+    return switch (metric) {
+      'openPrs' => history.map<num>((snapshot) => snapshot.openPrs).toList(),
+      'needsReview' =>
+        history.map<num>((snapshot) => snapshot.needsReview).toList(),
+      'activityScore' =>
+        history.map<num>((snapshot) => snapshot.activityScore).toList(),
+      _ => _unknownMetric(metric),
+    };
+  }
+
+  static List<num> _unknownMetric(String metric) {
+    debugPrint('MetricStore unknown metric "$metric"');
+    return <num>[];
+  }
+
+  static Map<String, List<MetricSnapshot>> _readFrom(SharedPreferences prefs) {
+    final raw = prefs.getString(storageKey);
+    if (raw == null || raw.trim().isEmpty) {
+      return <String, List<MetricSnapshot>>{};
+    }
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        debugPrint('MetricStore expected $storageKey to be a JSON map.');
+        return <String, List<MetricSnapshot>>{};
+      }
+
+      final histories = <String, List<MetricSnapshot>>{};
+      for (final entry in decoded.entries) {
+        final key = entry.key;
+        final value = entry.value;
+        if (key is! String || value is! List) {
+          continue;
+        }
+
+        final snapshots = <MetricSnapshot>[];
+        for (final item in value) {
+          if (item is! Map) {
+            continue;
+          }
+
+          final snapshot = MetricSnapshot.fromJson(item);
+          if (snapshot != null) {
+            snapshots.add(snapshot);
+          }
+        }
+        histories[key] = snapshots;
+      }
+      return histories;
+    } catch (e) {
+      debugPrint('MetricStore failed to read $storageKey: $e');
+      return <String, List<MetricSnapshot>>{};
+    }
+  }
+
+  static Future<void> _writeTo(
+    SharedPreferences prefs,
+    Map<String, List<MetricSnapshot>> histories,
+  ) {
+    final encoded = histories.map(
+      (repoKey, snapshots) => MapEntry(
+        repoKey,
+        snapshots.map((snapshot) => snapshot.toJson()).toList(),
+      ),
+    );
+    return prefs.setString(storageKey, jsonEncode(encoded));
+  }
+}

--- a/lib/radar_page.dart
+++ b/lib/radar_page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/radar_page.dart
+++ b/lib/radar_page.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'activity_service.dart';
 import 'app_http.dart';
+import 'metric_store.dart';
+import 'sparkline.dart';
 
 class RadarPage extends StatefulWidget {
   const RadarPage({super.key});
@@ -13,6 +17,7 @@ class RadarPage extends StatefulWidget {
 
 class _RadarPageState extends State<RadarPage> {
   List<RepoActivity> _activities = const [];
+  Map<String, List<num>> _series = const {};
   bool _loading = true;
   String? _error;
 
@@ -32,9 +37,18 @@ class _RadarPageState extends State<RadarPage> {
       final activities = await ActivityService.computeAll(
         client: AppHttp.client,
       );
+      // Record a trend snapshot (deduped ~1/day), then load per-repo series.
+      await MetricStore.capture(activities);
+      final history = await MetricStore.all();
       if (!mounted) return;
       setState(() {
         _activities = activities;
+        _series = {
+          for (final a in activities)
+            a.repoKey: (history[a.repoKey] ?? const [])
+                .map((s) => s.activityScore)
+                .toList(),
+        };
         _loading = false;
       });
     } catch (e) {
@@ -143,6 +157,10 @@ class _RadarPageState extends State<RadarPage> {
                       ),
                     ],
                   ),
+                  if ((_series[activity.repoKey] ?? const []).length >= 2) ...[
+                    const SizedBox(height: 8),
+                    Sparkline(values: _series[activity.repoKey]!, width: 120),
+                  ],
                   if (activity.oldestOpenPrAgeDays != null) ...[
                     const SizedBox(height: 6),
                     Text(

--- a/lib/sparkline.dart
+++ b/lib/sparkline.dart
@@ -1,0 +1,111 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+class Sparkline extends StatelessWidget {
+  const Sparkline({
+    super.key,
+    required this.values,
+    this.color,
+    this.height = 24,
+    this.width = 80,
+  });
+
+  final List<num> values;
+  final Color? color;
+  final double height;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    final paintColor = color ?? Theme.of(context).colorScheme.primary;
+    return SizedBox(
+      height: height,
+      width: width,
+      child: CustomPaint(
+        painter: _SparklinePainter(
+          values: List<num>.of(values),
+          color: paintColor,
+        ),
+      ),
+    );
+  }
+}
+
+class _SparklinePainter extends CustomPainter {
+  const _SparklinePainter({required this.values, required this.color});
+
+  final List<num> values;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (values.isEmpty || size.width <= 0 || size.height <= 0) {
+      return;
+    }
+
+    final paint = Paint()
+      ..color = color
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..strokeWidth = math.min(2.0, math.max(1.0, size.height / 12))
+      ..style = PaintingStyle.stroke;
+
+    if (values.length == 1) {
+      final radius = math.min(
+        3.0,
+        math.max(1.0, math.min(size.width, size.height) / 4),
+      );
+      canvas.drawCircle(
+        Offset(size.width / 2, size.height / 2),
+        radius,
+        paint..style = PaintingStyle.fill,
+      );
+      return;
+    }
+
+    var minValue = values.first.toDouble();
+    var maxValue = minValue;
+    for (final value in values.skip(1)) {
+      final doubleValue = value.toDouble();
+      minValue = math.min(minValue, doubleValue);
+      maxValue = math.max(maxValue, doubleValue);
+    }
+
+    final range = maxValue - minValue;
+    final lastIndex = values.length - 1;
+    final path = Path();
+
+    for (var index = 0; index < values.length; index += 1) {
+      final value = values[index].toDouble();
+      final normalized = range == 0 ? 0.5 : (value - minValue) / range;
+      final point = Offset(
+        size.width * index / lastIndex,
+        size.height - (normalized * size.height),
+      );
+      if (index == 0) {
+        path.moveTo(point.dx, point.dy);
+      } else {
+        path.lineTo(point.dx, point.dy);
+      }
+    }
+
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _SparklinePainter oldDelegate) {
+    if (oldDelegate.color != color ||
+        oldDelegate.values.length != values.length) {
+      return true;
+    }
+
+    for (var index = 0; index < values.length; index += 1) {
+      if (oldDelegate.values[index] != values[index]) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/lib/team.dart
+++ b/lib/team.dart
@@ -1,0 +1,40 @@
+class Team {
+  const Team({required this.id, required this.name, this.repoKeys = const {}});
+
+  final String id;
+  final String name;
+  final Set<String> repoKeys;
+
+  Team copyWith({String? id, String? name, Set<String>? repoKeys}) => Team(
+    id: id ?? this.id,
+    name: name ?? this.name,
+    repoKeys: repoKeys ?? this.repoKeys,
+  );
+
+  Map<String, dynamic> toJson() {
+    final sortedRepoKeys = repoKeys.toList()..sort();
+    return {'id': id, 'name': name, 'repoKeys': sortedRepoKeys};
+  }
+
+  factory Team.fromJson(Map json) {
+    final rawRepoKeys = json['repoKeys'];
+    final repoKeys = <String>{};
+    if (rawRepoKeys is List) {
+      for (final entry in rawRepoKeys) {
+        if (entry is String && entry.isNotEmpty) {
+          repoKeys.add(entry);
+        }
+      }
+    }
+
+    final rawId = json['id'];
+    final rawName = json['name'];
+    return Team(
+      id: rawId is String && rawId.isNotEmpty
+          ? rawId
+          : DateTime.now().microsecondsSinceEpoch.toString(),
+      name: rawName is String ? rawName : '',
+      repoKeys: repoKeys,
+    );
+  }
+}

--- a/lib/team_service.dart
+++ b/lib/team_service.dart
@@ -1,0 +1,77 @@
+import 'activity_service.dart';
+import 'team.dart';
+
+class TeamRollup {
+  const TeamRollup({
+    required this.repoCount,
+    required this.openPrs,
+    required this.needsReview,
+    required this.oldestOpenPrAgeDays,
+    required this.contributors,
+    required this.activityScore,
+    required this.lastActivity,
+  });
+
+  final int repoCount;
+  final int openPrs;
+  final int needsReview;
+  final int? oldestOpenPrAgeDays;
+  final Set<String> contributors;
+  final num activityScore;
+  final DateTime? lastActivity;
+}
+
+class TeamService {
+  TeamService._();
+
+  static TeamRollup rollup(Team team, List<RepoActivity> activities) {
+    final matchedRepoKeys = <String>{};
+    final contributors = <String>{};
+    var openPrs = 0;
+    var needsReview = 0;
+    int? oldestOpenPrAgeDays;
+    num activityScore = 0;
+    DateTime? lastActivity;
+
+    for (final activity in activities) {
+      if (!team.repoKeys.contains(activity.repoKey)) continue;
+      // Skip repos whose fetch errored so stale zeros don't read as healthy.
+      if (activity.error != null) continue;
+
+      matchedRepoKeys.add(activity.repoKey);
+      openPrs += activity.openPrCount;
+      needsReview += activity.needsReviewCount;
+      activityScore += activity.activityScore;
+      contributors.addAll(activity.contributors);
+
+      final age = activity.oldestOpenPrAgeDays;
+      if (age != null &&
+          (oldestOpenPrAgeDays == null || age > oldestOpenPrAgeDays)) {
+        oldestOpenPrAgeDays = age;
+      }
+
+      final activityTime = activity.lastActivity;
+      if (activityTime != null &&
+          (lastActivity == null || activityTime.isAfter(lastActivity))) {
+        lastActivity = activityTime;
+      }
+    }
+
+    return TeamRollup(
+      repoCount: matchedRepoKeys.length,
+      openPrs: openPrs,
+      needsReview: needsReview,
+      oldestOpenPrAgeDays: oldestOpenPrAgeDays,
+      contributors: contributors,
+      activityScore: activityScore,
+      lastActivity: lastActivity,
+    );
+  }
+
+  static Map<String, TeamRollup> rollupAll(
+    List<Team> teams,
+    List<RepoActivity> activities,
+  ) {
+    return {for (final team in teams) team.id: rollup(team, activities)};
+  }
+}

--- a/lib/team_store.dart
+++ b/lib/team_store.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'team.dart';
+
+class TeamStore {
+  TeamStore._();
+
+  static const String _teamsKey = 'teams';
+
+  static int _idSuffix = 0;
+  static Future<void> _lock = Future<void>.value();
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  static String _newId() =>
+      '${DateTime.now().microsecondsSinceEpoch}_${_idSuffix++}';
+
+  static Future<List<Team>> list() async {
+    final prefs = await SharedPreferences.getInstance();
+    return _readFrom(prefs);
+  }
+
+  static Future<Team> add(String name) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final teams = _readFrom(prefs);
+      final team = Team(id: _newId(), name: name.trim());
+      teams.add(team);
+      await _writeTo(prefs, teams);
+      return team;
+    });
+  }
+
+  static Future<void> rename(String id, String name) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final teams = _readFrom(prefs);
+      final index = teams.indexWhere((team) => team.id == id);
+      if (index == -1) return;
+      teams[index] = teams[index].copyWith(name: name.trim());
+      await _writeTo(prefs, teams);
+    });
+  }
+
+  static Future<void> delete(String id) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final teams = _readFrom(prefs)..removeWhere((team) => team.id == id);
+      await _writeTo(prefs, teams);
+    });
+  }
+
+  static Future<void> setRepos(String id, Set<String> repoKeys) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final teams = _readFrom(prefs);
+      final index = teams.indexWhere((team) => team.id == id);
+      if (index == -1) return;
+      teams[index] = teams[index].copyWith(
+        repoKeys: repoKeys.where((key) => key.isNotEmpty).toSet(),
+      );
+      await _writeTo(prefs, teams);
+    });
+  }
+
+  static List<Team> _readFrom(SharedPreferences prefs) {
+    final raw = prefs.getString(_teamsKey);
+    if (raw == null || raw.trim().isEmpty) return <Team>[];
+
+    final decoded = _decode(raw);
+    if (decoded is! List) {
+      debugPrint('Skipping teams storage because it is not a JSON list.');
+      return <Team>[];
+    }
+
+    final teams = <Team>[];
+    for (final entry in decoded) {
+      if (entry is! Map) {
+        debugPrint('Skipping malformed team entry: expected object.');
+        continue;
+      }
+      final id = entry['id'];
+      final name = entry['name'];
+      if (id is! String || id.isEmpty || name is! String) {
+        debugPrint('Skipping malformed team entry: missing id or name.');
+        continue;
+      }
+      teams.add(Team.fromJson(entry));
+    }
+    return teams;
+  }
+
+  static Object? _decode(String raw) {
+    try {
+      return jsonDecode(raw);
+    } catch (error) {
+      debugPrint('Failed to parse stored teams: $error');
+      return null;
+    }
+  }
+
+  static Future<void> _writeTo(
+    SharedPreferences prefs,
+    List<Team> teams,
+  ) async {
+    await prefs.setString(
+      _teamsKey,
+      jsonEncode(teams.map((team) => team.toJson()).toList()),
+    );
+  }
+}

--- a/lib/team_store.dart
+++ b/lib/team_store.dart
@@ -28,10 +28,14 @@ class TeamStore {
   }
 
   static Future<Team> add(String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'Team name cannot be empty');
+    }
     return _runLocked(() async {
       final prefs = await SharedPreferences.getInstance();
       final teams = _readFrom(prefs);
-      final team = Team(id: _newId(), name: name.trim());
+      final team = Team(id: _newId(), name: trimmed);
       teams.add(team);
       await _writeTo(prefs, teams);
       return team;
@@ -39,12 +43,14 @@ class TeamStore {
   }
 
   static Future<void> rename(String id, String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return Future<void>.value();
     return _runLocked(() async {
       final prefs = await SharedPreferences.getInstance();
       final teams = _readFrom(prefs);
       final index = teams.indexWhere((team) => team.id == id);
       if (index == -1) return;
-      teams[index] = teams[index].copyWith(name: name.trim());
+      teams[index] = teams[index].copyWith(name: trimmed);
       await _writeTo(prefs, teams);
     });
   }
@@ -64,7 +70,10 @@ class TeamStore {
       final index = teams.indexWhere((team) => team.id == id);
       if (index == -1) return;
       teams[index] = teams[index].copyWith(
-        repoKeys: repoKeys.where((key) => key.isNotEmpty).toSet(),
+        repoKeys: repoKeys
+            .map((key) => key.trim())
+            .where((key) => key.isNotEmpty)
+            .toSet(),
       );
       await _writeTo(prefs, teams);
     });
@@ -88,7 +97,10 @@ class TeamStore {
       }
       final id = entry['id'];
       final name = entry['name'];
-      if (id is! String || id.isEmpty || name is! String) {
+      if (id is! String ||
+          id.isEmpty ||
+          name is! String ||
+          name.trim().isEmpty) {
         debugPrint('Skipping malformed team entry: missing id or name.');
         continue;
       }

--- a/lib/teams_page.dart
+++ b/lib/teams_page.dart
@@ -1,0 +1,247 @@
+import 'package:flutter/material.dart';
+
+import 'activity_service.dart';
+import 'app_http.dart';
+import 'digest_page.dart';
+import 'manage_teams_page.dart';
+import 'metric_snapshot.dart';
+import 'metric_store.dart';
+import 'sparkline.dart';
+import 'team.dart';
+import 'team_service.dart';
+import 'team_store.dart';
+
+/// Team-first monitoring lens: per-team rollups of repo activity, with a trend
+/// sparkline, plus entry points to the Digest and Manage Teams.
+class TeamsPage extends StatefulWidget {
+  const TeamsPage({super.key});
+
+  @override
+  State<TeamsPage> createState() => _TeamsPageState();
+}
+
+class _TeamsPageState extends State<TeamsPage> {
+  List<Team> _teams = const [];
+  Map<String, TeamRollup> _rollups = const {};
+  Map<String, List<num>> _series = const {};
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final teams = await TeamStore.list();
+      final activities = await ActivityService.computeAll(
+        client: AppHttp.client,
+      );
+      // Record a trend snapshot from this load too (deduped ~1/day).
+      await MetricStore.capture(activities);
+      final rollups = TeamService.rollupAll(teams, activities);
+      final history = await MetricStore.all();
+      final series = <String, List<num>>{
+        for (final team in teams) team.id: _teamSeries(team, history),
+      };
+      if (!mounted) return;
+      setState(() {
+        _teams = teams;
+        _rollups = rollups;
+        _series = series;
+        _loading = false;
+      });
+    } catch (e) {
+      debugPrint('TeamsPage failed to load: $e');
+      if (!mounted) return;
+      setState(() {
+        _error = 'Something went wrong while loading teams. Pull to retry.';
+        _loading = false;
+      });
+    }
+  }
+
+  /// Aggregate the team's member-repo activity-score series into one trend by
+  /// summing the most-recent points (aligned newest-first, shorter series
+  /// contribute where they have data).
+  List<num> _teamSeries(Team team, Map<String, List<MetricSnapshot>> history) {
+    // Bucket member-repo snapshots by calendar day and sum activityScore per
+    // day, so repos with different capture histories align by date (not by
+    // list index).
+    final byDay = <DateTime, num>{};
+    for (final key in team.repoKeys) {
+      final snaps = history[key];
+      if (snaps == null) continue;
+      for (final s in snaps) {
+        final day = DateTime.utc(s.at.year, s.at.month, s.at.day);
+        byDay[day] = (byDay[day] ?? 0) + s.activityScore;
+      }
+    }
+    if (byDay.isEmpty) return const [];
+    final days = byDay.keys.toList()..sort();
+    return [for (final d in days) byDay[d]!];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Teams'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.summarize),
+            tooltip: 'Digest',
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const DigestPage()),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.manage_accounts),
+            tooltip: 'Manage teams',
+            onPressed: () async {
+              await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const ManageTeamsPage()),
+              );
+              if (!mounted) return;
+              await _load();
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: _loading ? null : _load,
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(onRefresh: _load, child: _buildContent()),
+    );
+  }
+
+  Widget _buildContent() {
+    if (_error != null) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 160),
+          Center(
+            child: Text(_error!, style: const TextStyle(color: Colors.red)),
+          ),
+        ],
+      );
+    }
+
+    if (_teams.isEmpty) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 140),
+          const Center(child: Text('No teams yet.')),
+          const SizedBox(height: 8),
+          Center(
+            child: FilledButton.icon(
+              icon: const Icon(Icons.add),
+              label: const Text('Create a team'),
+              onPressed: () async {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const ManageTeamsPage()),
+                );
+                if (!mounted) return;
+                await _load();
+              },
+            ),
+          ),
+        ],
+      );
+    }
+
+    return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.all(12),
+      itemCount: _teams.length,
+      itemBuilder: (context, index) {
+        final team = _teams[index];
+        final rollup = _rollups[team.id];
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        team.name,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ),
+                    Sparkline(values: _series[team.id] ?? const []),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (rollup == null || rollup.repoCount == 0)
+                  Text(
+                    'No repositories assigned yet.',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  )
+                else
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 8,
+                    children: [
+                      _metric(Icons.folder, '${rollup.repoCount} repos'),
+                      _metric(Icons.merge_type, '${rollup.openPrs} open PRs'),
+                      _metric(
+                        Icons.rate_review,
+                        '${rollup.needsReview} review requested',
+                      ),
+                      _metric(
+                        Icons.people,
+                        '${rollup.contributors.length} contributors',
+                      ),
+                      _metric(Icons.update, _relativeTime(rollup.lastActivity)),
+                      if (rollup.oldestOpenPrAgeDays != null)
+                        _metric(
+                          Icons.schedule,
+                          'oldest ${rollup.oldestOpenPrAgeDays}d',
+                        ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _metric(IconData icon, String text) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: Colors.grey[600]),
+        const SizedBox(width: 4),
+        Text(text, style: const TextStyle(fontSize: 12)),
+      ],
+    );
+  }
+
+  String _relativeTime(DateTime? value) {
+    if (value == null) return 'no activity';
+    final diff = DateTime.now().difference(value);
+    if (diff.isNegative || diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+}

--- a/lib/teams_page.dart
+++ b/lib/teams_page.dart
@@ -67,9 +67,9 @@ class _TeamsPageState extends State<TeamsPage> {
     }
   }
 
-  /// Aggregate the team's member-repo activity-score series into one trend by
-  /// summing the most-recent points (aligned newest-first, shorter series
-  /// contribute where they have data).
+  /// Aggregates the team's member-repo snapshots into a single day-bucketed
+  /// activity-score series (ascending by day), so repos with uneven capture
+  /// histories align by date rather than by list index.
   List<num> _teamSeries(Team team, Map<String, List<MetricSnapshot>> history) {
     // Bucket member-repo snapshots by calendar day and sum activityScore per
     // day, so repos with different capture histories align by date (not by
@@ -240,7 +240,8 @@ class _TeamsPageState extends State<TeamsPage> {
   String _relativeTime(DateTime? value) {
     if (value == null) return 'no activity';
     final diff = DateTime.now().difference(value);
-    if (diff.isNegative || diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.isNegative || diff.inMinutes < 1) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
     if (diff.inHours < 24) return '${diff.inHours}h ago';
     return '${diff.inDays}d ago';
   }

--- a/lib/teams_page.dart
+++ b/lib/teams_page.dart
@@ -190,9 +190,15 @@ class _TeamsPageState extends State<TeamsPage> {
                   ],
                 ),
                 const SizedBox(height: 8),
-                if (rollup == null || rollup.repoCount == 0)
+                if (team.repoKeys.isEmpty)
                   Text(
                     'No repositories assigned yet.',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  )
+                else if (rollup == null || rollup.repoCount == 0)
+                  Text(
+                    'No data yet — assigned repos are loading or failed to '
+                    'fetch.',
                     style: Theme.of(context).textTheme.bodySmall,
                   )
                 else

--- a/test/digest_service_test.dart
+++ b/test/digest_service_test.dart
@@ -1,0 +1,262 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/activity_service.dart';
+import 'package:kode_radar/digest_service.dart';
+import 'package:kode_radar/metric_snapshot.dart';
+import 'package:kode_radar/team.dart';
+
+void main() {
+  test('totals are summed across all activities', () {
+    final digest = DigestService.buildDigest(
+      teams: const [],
+      activities: [
+        _activity(repoKey: 'github:acme/app', openPrs: 2, needsReview: 1),
+        _activity(repoKey: 'github:acme/api', openPrs: 3, needsReview: 2),
+      ],
+      history: const {},
+      now: DateTime.parse('2026-07-14T12:00:00Z'),
+    );
+
+    expect(digest.totalOpenPrs, 5);
+    expect(digest.totalNeedsReview, 3);
+  });
+
+  test('per-team lines sum activity for member repos', () {
+    final digest = DigestService.buildDigest(
+      teams: const [
+        Team(
+          id: 'platform',
+          name: 'Platform',
+          repoKeys: {'github:acme/app', 'github:acme/api'},
+        ),
+        Team(id: 'tools', name: 'Tools', repoKeys: {'github:acme/tools'}),
+      ],
+      activities: [
+        _activity(
+          repoKey: 'github:acme/app',
+          openPrs: 2,
+          needsReview: 1,
+          activityScore: 4,
+        ),
+        _activity(
+          repoKey: 'github:acme/api',
+          openPrs: 3,
+          needsReview: 2,
+          activityScore: 6,
+        ),
+        _activity(
+          repoKey: 'github:acme/tools',
+          openPrs: 1,
+          needsReview: 0,
+          activityScore: 2,
+        ),
+      ],
+      history: const {},
+      now: DateTime.parse('2026-07-14T12:00:00Z'),
+    );
+
+    final platform = digest.teamLines.singleWhere(
+      (line) => line.label == 'Platform',
+    );
+    expect(platform.openPrs, 5);
+    expect(platform.needsReview, 3);
+    expect(platform.activityScore, 10);
+  });
+
+  test(
+    'activityDelta compares current score to oldest in-window snapshots',
+    () {
+      final now = DateTime.parse('2026-07-14T12:00:00Z');
+      final digest = DigestService.buildDigest(
+        teams: const [
+          Team(
+            id: 'platform',
+            name: 'Platform',
+            repoKeys: {'github:acme/app', 'github:acme/api'},
+          ),
+        ],
+        activities: [
+          _activity(repoKey: 'github:acme/app', activityScore: 10),
+          _activity(repoKey: 'github:acme/api', activityScore: 8),
+        ],
+        history: {
+          'github:acme/app': [
+            MetricSnapshot(
+              at: now.subtract(const Duration(days: 8)),
+              openPrs: 0,
+              needsReview: 0,
+              activityScore: 100,
+            ),
+            MetricSnapshot(
+              at: now.subtract(const Duration(days: 6)),
+              openPrs: 0,
+              needsReview: 0,
+              activityScore: 3,
+            ),
+            MetricSnapshot(
+              at: now.subtract(const Duration(days: 2)),
+              openPrs: 0,
+              needsReview: 0,
+              activityScore: 7,
+            ),
+          ],
+          'github:acme/api': [
+            MetricSnapshot(
+              at: now.subtract(const Duration(days: 1)),
+              openPrs: 0,
+              needsReview: 0,
+              activityScore: 4,
+            ),
+          ],
+        },
+        now: now,
+      );
+
+      expect(digest.teamLines.single.activityDelta, 11);
+    },
+  );
+
+  test('movers sort by magnitude (rises and drops) and limit to five', () {
+    final now = DateTime.parse('2026-07-14T12:00:00Z');
+    // Each team's repo has a baseline of 10 five days ago; current score is
+    // 10 + delta, so the resulting deltas are [1,2,3,4,5,-20,0].
+    final deltas = [1, 2, 3, 4, 5, -20, 0];
+    final teams = List.generate(
+      7,
+      (index) => Team(
+        id: 'team-$index',
+        name: 'Team $index',
+        repoKeys: {'repo-$index'},
+      ),
+    );
+    final activities = List.generate(
+      7,
+      (index) =>
+          _activity(repoKey: 'repo-$index', activityScore: 10 + deltas[index]),
+    );
+    final history = {
+      for (var index = 0; index < 7; index++)
+        'repo-$index': [
+          MetricSnapshot(
+            at: now.subtract(const Duration(days: 5)),
+            openPrs: 0,
+            needsReview: 0,
+            activityScore: 10,
+          ),
+        ],
+    };
+
+    final digest = DigestService.buildDigest(
+      teams: teams,
+      activities: activities,
+      history: history,
+      now: now,
+    );
+
+    // Team 6 (delta 0) is excluded; the top 5 by magnitude include the big drop.
+    expect(digest.movers, hasLength(5));
+    expect(digest.movers.map((line) => line.label), [
+      'Team 5',
+      'Team 4',
+      'Team 3',
+      'Team 2',
+      'Team 1',
+    ]);
+    expect(digest.movers.first.activityDelta, -20);
+  });
+
+  test('no in-window history means no movers (no fabricated trend)', () {
+    final now = DateTime.parse('2026-07-14T12:00:00Z');
+    final teams = List.generate(
+      3,
+      (index) => Team(
+        id: 'team-$index',
+        name: 'Team $index',
+        repoKeys: {'repo-$index'},
+      ),
+    );
+    final activities = List.generate(
+      3,
+      (index) =>
+          _activity(repoKey: 'repo-$index', activityScore: (index + 1) * 5),
+    );
+
+    final digest = DigestService.buildDigest(
+      teams: teams,
+      activities: activities,
+      history: const {},
+      now: now,
+    );
+
+    expect(digest.movers, isEmpty);
+    expect(digest.teamLines.every((line) => line.activityDelta == 0), isTrue);
+  });
+
+  test('errored repos are excluded from totals and team sums', () {
+    final now = DateTime.parse('2026-07-14T12:00:00Z');
+    final digest = DigestService.buildDigest(
+      teams: const [
+        Team(id: 'platform', name: 'Platform', repoKeys: {'ok', 'broken'}),
+      ],
+      activities: [
+        _activity(repoKey: 'ok', openPrs: 4, needsReview: 2, activityScore: 9),
+        _activity(
+          repoKey: 'broken',
+          openPrs: 0,
+          needsReview: 0,
+          activityScore: 0,
+          error: 'GitHub returned 500',
+        ),
+      ],
+      history: const {},
+      now: now,
+    );
+
+    // The errored repo contributes nothing (no false healthy zeros).
+    expect(digest.totalOpenPrs, 4);
+    expect(digest.totalNeedsReview, 2);
+    final platform = digest.teamLines.single;
+    expect(platform.openPrs, 4);
+    expect(platform.activityScore, 9);
+  });
+
+  test('empty inputs return a zeroed digest without throwing', () {
+    final now = DateTime.parse('2026-07-14T12:00:00Z');
+
+    final digest = DigestService.buildDigest(
+      teams: const [],
+      activities: const [],
+      history: const {},
+      now: now,
+    );
+
+    expect(digest.generatedAt, now);
+    expect(digest.window, const Duration(days: 7));
+    expect(digest.totalOpenPrs, 0);
+    expect(digest.totalNeedsReview, 0);
+    expect(digest.teamLines, isEmpty);
+    expect(digest.movers, isEmpty);
+  });
+}
+
+RepoActivity _activity({
+  required String repoKey,
+  int openPrs = 0,
+  int needsReview = 0,
+  num activityScore = 0,
+  String? error,
+}) {
+  return RepoActivity(
+    repoKey: repoKey,
+    provider: 'github',
+    displayName: repoKey,
+    url: 'https://example.com/$repoKey',
+    openPrCount: openPrs,
+    needsReviewCount: needsReview,
+    oldestOpenPrAgeDays: null,
+    lastActivity: null,
+    ciStatus: 'unknown',
+    contributors: const [],
+    activityScore: activityScore,
+    error: error,
+  );
+}

--- a/test/metric_store_test.dart
+++ b/test/metric_store_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/activity_service.dart';
+import 'package:kode_radar/metric_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('shouldCapture honors the minimum capture interval', () {
+    final now = DateTime.utc(2026, 1, 1, 12);
+
+    expect(MetricStore.shouldCapture(null, now), isTrue);
+    expect(
+      MetricStore.shouldCapture(
+        now.subtract(const Duration(hours: 23, minutes: 59)),
+        now,
+      ),
+      isFalse,
+    );
+    expect(
+      MetricStore.shouldCapture(
+        now.subtract(MetricStore.minCaptureInterval),
+        now,
+      ),
+      isTrue,
+    );
+    expect(
+      MetricStore.shouldCapture(now.subtract(const Duration(hours: 25)), now),
+      isTrue,
+    );
+  });
+
+  test('capture appends one snapshot per repo and dedups within 24h', () async {
+    final now = DateTime.utc(2026, 1, 1, 12);
+
+    await MetricStore.capture([
+      _activity('github:owner/one', openPrCount: 1),
+      _activity('github:owner/two', openPrCount: 2),
+    ], now: now);
+    await MetricStore.capture([
+      _activity('github:owner/one', openPrCount: 3),
+      _activity('github:owner/two', openPrCount: 4),
+    ], now: now.add(const Duration(hours: 1)));
+    await MetricStore.capture([
+      _activity('github:owner/one', openPrCount: 5),
+      _activity('github:owner/two', openPrCount: 6),
+    ], now: now.add(const Duration(hours: 25)));
+
+    final all = await MetricStore.all();
+    expect(all.keys, {'github:owner/one', 'github:owner/two'});
+    expect(all['github:owner/one'], hasLength(2));
+    expect(all['github:owner/two'], hasLength(2));
+    expect(all['github:owner/one']?.map((snapshot) => snapshot.openPrs), [
+      1,
+      5,
+    ]);
+    expect(all['github:owner/two']?.map((snapshot) => snapshot.openPrs), [
+      2,
+      6,
+    ]);
+  });
+
+  test('capture trims history to maxPerRepo most recent snapshots', () async {
+    final now = DateTime.utc(2026, 1, 1, 12);
+    final total = MetricStore.maxPerRepo + 5;
+
+    for (var index = 0; index < total; index += 1) {
+      await MetricStore.capture([
+        _activity(
+          'github:owner/repo',
+          openPrCount: index,
+          needsReviewCount: index,
+          activityScore: index,
+        ),
+      ], now: now.add(Duration(hours: 25 * index)));
+    }
+
+    final history = await MetricStore.historyFor('github:owner/repo');
+    expect(history, hasLength(MetricStore.maxPerRepo));
+    expect(history.first.openPrs, total - MetricStore.maxPerRepo);
+    expect(history.last.openPrs, total - 1);
+  });
+
+  test('capture skips activities with errors', () async {
+    final now = DateTime.utc(2026, 1, 1, 12);
+
+    await MetricStore.capture([
+      _activity('github:owner/ok'),
+      _activity('github:owner/error', error: 'failed'),
+    ], now: now);
+
+    final all = await MetricStore.all();
+    expect(all.keys, {'github:owner/ok'});
+  });
+
+  test('seriesFor returns oldest to newest values for each metric', () async {
+    final now = DateTime.utc(2026, 1, 1, 12);
+
+    await MetricStore.capture([
+      _activity(
+        'github:owner/repo',
+        openPrCount: 1,
+        needsReviewCount: 2,
+        activityScore: 3.5,
+      ),
+    ], now: now);
+    await MetricStore.capture([
+      _activity(
+        'github:owner/repo',
+        openPrCount: 4,
+        needsReviewCount: 5,
+        activityScore: 6.5,
+      ),
+    ], now: now.add(const Duration(hours: 25)));
+
+    expect(
+      await MetricStore.seriesFor('github:owner/repo', metric: 'openPrs'),
+      [1, 4],
+    );
+    expect(
+      await MetricStore.seriesFor('github:owner/repo', metric: 'needsReview'),
+      [2, 5],
+    );
+    expect(await MetricStore.seriesFor('github:owner/repo'), [3.5, 6.5]);
+  });
+}
+
+RepoActivity _activity(
+  String repoKey, {
+  int openPrCount = 1,
+  int needsReviewCount = 2,
+  num activityScore = 3,
+  String? error,
+}) {
+  return RepoActivity(
+    repoKey: repoKey,
+    provider: 'github',
+    displayName: repoKey,
+    url: 'https://example.com/$repoKey',
+    openPrCount: openPrCount,
+    needsReviewCount: needsReviewCount,
+    oldestOpenPrAgeDays: null,
+    lastActivity: null,
+    ciStatus: 'unknown',
+    contributors: const <String>[],
+    activityScore: activityScore,
+    error: error,
+  );
+}

--- a/test/team_service_test.dart
+++ b/test/team_service_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/activity_service.dart';
+import 'package:kode_radar/team.dart';
+import 'package:kode_radar/team_service.dart';
+
+void main() {
+  test('rollup sums and aggregates only member repositories', () {
+    final older = DateTime.utc(2026, 1, 1);
+    final newer = DateTime.utc(2026, 1, 3);
+    const team = Team(
+      id: 'team-1',
+      name: 'Platform',
+      repoKeys: {'github:owner/repo', 'ado:org/project/repo'},
+    );
+
+    final rollup = TeamService.rollup(team, [
+      _activity(
+        repoKey: 'github:owner/repo',
+        openPrCount: 2,
+        needsReviewCount: 1,
+        oldestOpenPrAgeDays: 3,
+        lastActivity: older,
+        contributors: ['ada', 'grace'],
+        activityScore: 10,
+      ),
+      _activity(
+        repoKey: 'ado:org/project/repo',
+        openPrCount: 4,
+        needsReviewCount: 2,
+        oldestOpenPrAgeDays: 7,
+        lastActivity: newer,
+        contributors: ['grace', 'linus'],
+        activityScore: 2.5,
+      ),
+      _activity(
+        repoKey: 'github:other/repo',
+        openPrCount: 100,
+        needsReviewCount: 100,
+        oldestOpenPrAgeDays: 30,
+        lastActivity: DateTime.utc(2026, 1, 10),
+        contributors: ['ignored'],
+        activityScore: 100,
+      ),
+    ]);
+
+    expect(rollup.repoCount, 2);
+    expect(rollup.openPrs, 6);
+    expect(rollup.needsReview, 3);
+    expect(rollup.oldestOpenPrAgeDays, 7);
+    expect(rollup.lastActivity, newer);
+    expect(rollup.contributors, {'ada', 'grace', 'linus'});
+    expect(rollup.activityScore, 12.5);
+  });
+
+  test('rollupAll is keyed by team id', () {
+    const teams = [
+      Team(id: 'one', name: 'One', repoKeys: {'github:owner/repo'}),
+      Team(id: 'two', name: 'Two', repoKeys: {'github:unknown/repo'}),
+    ];
+
+    final rollups = TeamService.rollupAll(teams, [
+      _activity(repoKey: 'github:owner/repo', openPrCount: 1),
+    ]);
+
+    expect(rollups.keys, {'one', 'two'});
+    expect(rollups['one']?.repoCount, 1);
+    expect(rollups['two']?.repoCount, 0);
+    expect(rollups['two']?.openPrs, 0);
+  });
+}
+
+RepoActivity _activity({
+  required String repoKey,
+  int openPrCount = 0,
+  int needsReviewCount = 0,
+  int? oldestOpenPrAgeDays,
+  DateTime? lastActivity,
+  List<String> contributors = const [],
+  num activityScore = 0,
+}) {
+  return RepoActivity(
+    repoKey: repoKey,
+    provider: repoKey.startsWith('ado:') ? 'ado' : 'github',
+    displayName: repoKey,
+    url: '',
+    openPrCount: openPrCount,
+    needsReviewCount: needsReviewCount,
+    oldestOpenPrAgeDays: oldestOpenPrAgeDays,
+    lastActivity: lastActivity,
+    ciStatus: '',
+    contributors: contributors,
+    activityScore: activityScore,
+  );
+}

--- a/test/team_store_test.dart
+++ b/test/team_store_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/team_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('add, rename, setRepos, and delete roundtrip', () async {
+    final team = await TeamStore.add('Platform');
+
+    expect(team.name, 'Platform');
+    expect((await TeamStore.list()).single.id, team.id);
+
+    await TeamStore.rename(team.id, 'Ops');
+    expect((await TeamStore.list()).single.name, 'Ops');
+
+    await TeamStore.setRepos(team.id, {
+      'github:owner/repo',
+      'ado:org/project/repo',
+    });
+    expect((await TeamStore.list()).single.repoKeys, {
+      'github:owner/repo',
+      'ado:org/project/repo',
+    });
+
+    await TeamStore.delete(team.id);
+    expect(await TeamStore.list(), isEmpty);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -33,8 +33,22 @@ void main() {
     // Verify that the attention inbox action is present
     expect(find.byIcon(Icons.inbox), findsOneWidget);
 
+    // Verify that the Teams action is present
+    expect(find.byIcon(Icons.groups), findsOneWidget);
+
     // Verify that the add button is present
     expect(find.byIcon(Icons.add), findsOneWidget);
+  });
+
+  testWidgets('Teams page can be opened', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    await tester.tap(find.byIcon(Icons.groups));
+    await tester.pumpAndSettle();
+
+    // Navigated to the Teams page; empty state since no teams are configured.
+    expect(find.widgetWithText(AppBar, 'Teams'), findsOneWidget);
+    expect(find.text('No teams yet.'), findsOneWidget);
   });
 
   testWidgets('Attention inbox can be opened', (WidgetTester tester) async {


### PR DESCRIPTION
Monitoring milestone **M4 — Teams + Trends + Digests**, built on top of M1 Radar, M2 Attention Inbox, M3 People, and M5-lite caching.

## Teams
- Group repos into named teams (`Manage Teams`), with a **team-first rollup lens** (`TeamsPage`): per-team open PRs, review load, contributors, activity, oldest PR — plus an aggregate trend sparkline. A new `Icons.groups` AppBar action opens the Teams hub, which also hosts Digest + Manage Teams.

## Trends
- Per-repo **activity snapshots** captured on Radar/Teams/Digest loads (deduped to ~1/day, bounded 60/repo), rendered as **sparklines** on Radar cards and team rows via a `CustomPainter` (no new dependency).

## Digest
- A 7-day rollup: totals, per-team lines, and **top movers**. Deltas only use repos with a real in-window baseline (no fabricated first-run trends), errored repos are excluded from aggregation, and movers sort by magnitude so big drops surface too.

## Notes
- All storage is local (SharedPreferences); no backend.
- Reviewed via code-review + rubber-duck; feedback implemented (honest digest deltas, errored-repo exclusion, magnitude-sorted movers, day-bucketed team series, mounted guards) with regression tests.
- Known follow-up: prune metric history / team assignments when a repo is removed from monitoring.

**Validation:** `flutter analyze --fatal-infos` clean, `dart format` clean, **79 tests pass** (+15 for M4).
