### PR TITLE
feature: dark mode (system/light/dark)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,8 +33,8 @@ void main() async {
   // system default if storage is unavailable rather than failing to launch.
   try {
     await ThemeController.instance.load();
-  } catch (e) {
-    debugPrint('Failed to load theme preference: $e');
+  } catch (e, stackTrace) {
+    debugPrint('Failed to load theme preference: $e\n$stackTrace');
   }
 
   // Initialize local notifications

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'radar_page.dart';
 import 'attention_inbox_page.dart';
 import 'people_page.dart';
 import 'teams_page.dart';
+import 'theme_controller.dart';
 import 'auto_add_service.dart';
 import 'token_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -27,6 +28,9 @@ final FlutterLocalNotificationsPlugin _notificationsPlugin =
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Load the persisted light/dark/system theme preference.
+  await ThemeController.instance.load();
 
   // Initialize local notifications
   const AndroidInitializationSettings initializationSettingsAndroid =
@@ -127,13 +131,26 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Kode Radar',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Kode Radar Home Page'),
+    return ListenableBuilder(
+      listenable: ThemeController.instance,
+      builder: (context, _) {
+        return MaterialApp(
+          title: 'Kode Radar',
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+            useMaterial3: true,
+          ),
+          darkTheme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(
+              seedColor: Colors.blue,
+              brightness: Brightness.dark,
+            ),
+            useMaterial3: true,
+          ),
+          themeMode: ThemeController.instance.mode,
+          home: const MyHomePage(title: 'Kode Radar Home Page'),
+        );
+      },
     );
   }
 }
@@ -695,6 +712,11 @@ class _MyHomePageState extends State<MyHomePage>
             tooltip: 'Manage repositories',
             onPressed: _openManageRepos,
           ),
+          IconButton(
+            icon: const Icon(Icons.brightness_6),
+            tooltip: 'Appearance',
+            onPressed: _showAppearancePicker,
+          ),
         ],
         bottom: TabBar(
           controller: _tabController,
@@ -765,6 +787,31 @@ class _MyHomePageState extends State<MyHomePage>
 
   Future<void> _openManageRepos() async {
     await _openRepoPage(const ManageReposPage());
+  }
+
+  Future<void> _showAppearancePicker() async {
+    final current = ThemeController.instance.mode;
+    final selected = await showDialog<ThemeMode>(
+      context: context,
+      builder: (dialogContext) => SimpleDialog(
+        title: const Text('Appearance'),
+        children: [
+          for (final option in const [
+            (ThemeMode.system, 'System'),
+            (ThemeMode.light, 'Light'),
+            (ThemeMode.dark, 'Dark'),
+          ])
+            ListTile(
+              title: Text(option.$2),
+              trailing: current == option.$1 ? const Icon(Icons.check) : null,
+              onTap: () => Navigator.pop(dialogContext, option.$1),
+            ),
+        ],
+      ),
+    );
+    if (selected != null) {
+      await ThemeController.instance.setMode(selected);
+    }
   }
 
   Future<void> _openManageTokens() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,8 +29,13 @@ final FlutterLocalNotificationsPlugin _notificationsPlugin =
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Load the persisted light/dark/system theme preference.
-  await ThemeController.instance.load();
+  // Load the persisted light/dark/system theme preference; fall back to the
+  // system default if storage is unavailable rather than failing to launch.
+  try {
+    await ThemeController.instance.load();
+  } catch (e) {
+    debugPrint('Failed to load theme preference: $e');
+  }
 
   // Initialize local notifications
   const AndroidInitializationSettings initializationSettingsAndroid =

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -815,7 +815,18 @@ class _MyHomePageState extends State<MyHomePage>
       ),
     );
     if (selected != null) {
-      await ThemeController.instance.setMode(selected);
+      try {
+        await ThemeController.instance.setMode(selected);
+      } catch (e) {
+        debugPrint('Failed to save theme preference: $e');
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Could not save appearance preference.'),
+            ),
+          );
+        }
+      }
     }
   }
 

--- a/lib/theme_controller.dart
+++ b/lib/theme_controller.dart
@@ -33,15 +33,23 @@ class ThemeController extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Updates and persists the theme mode.
+  /// Updates and persists the theme mode. Persists first so a failed write
+  /// never leaves the UI on a mode that won't survive a restart.
   Future<void> setMode(ThemeMode mode) async {
     if (mode == _mode) return;
-    _mode = mode;
-    notifyListeners();
     await _runLocked(() async {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(storageKey, mode.name);
     });
+    _mode = mode;
+    notifyListeners();
+  }
+
+  /// Resets the in-memory mode to the default. For tests only, to keep the
+  /// singleton hermetic across test files.
+  @visibleForTesting
+  void debugReset() {
+    _mode = ThemeMode.system;
   }
 
   /// Parses a stored value into a [ThemeMode], defaulting to system.

--- a/lib/theme_controller.dart
+++ b/lib/theme_controller.dart
@@ -50,6 +50,7 @@ class ThemeController extends ChangeNotifier {
   @visibleForTesting
   void debugReset() {
     _mode = ThemeMode.system;
+    _lock = Future<void>.value();
   }
 
   /// Parses a stored value into a [ThemeMode], defaulting to system.

--- a/lib/theme_controller.dart
+++ b/lib/theme_controller.dart
@@ -10,14 +10,26 @@ class ThemeController extends ChangeNotifier {
 
   static const String storageKey = 'theme_mode';
 
+  // Serializes SharedPreferences access so rapid theme changes can't persist
+  // out of order (matches TokenStore/RepoStore).
+  static Future<void> _lock = Future<void>.value();
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
   ThemeMode _mode = ThemeMode.system;
 
   ThemeMode get mode => _mode;
 
   /// Loads the persisted preference. Safe to call once at startup.
   Future<void> load() async {
-    final prefs = await SharedPreferences.getInstance();
-    _mode = parseMode(prefs.getString(storageKey));
+    await _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      _mode = parseMode(prefs.getString(storageKey));
+    });
     notifyListeners();
   }
 
@@ -26,8 +38,10 @@ class ThemeController extends ChangeNotifier {
     if (mode == _mode) return;
     _mode = mode;
     notifyListeners();
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(storageKey, mode.name);
+    await _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(storageKey, mode.name);
+    });
   }
 
   /// Parses a stored value into a [ThemeMode], defaulting to system.

--- a/lib/theme_controller.dart
+++ b/lib/theme_controller.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Holds and persists the app-wide light/dark/system theme preference, and
+/// notifies listeners (the root [MaterialApp]) when it changes.
+class ThemeController extends ChangeNotifier {
+  ThemeController._();
+
+  static final ThemeController instance = ThemeController._();
+
+  static const String storageKey = 'theme_mode';
+
+  ThemeMode _mode = ThemeMode.system;
+
+  ThemeMode get mode => _mode;
+
+  /// Loads the persisted preference. Safe to call once at startup.
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _mode = parseMode(prefs.getString(storageKey));
+    notifyListeners();
+  }
+
+  /// Updates and persists the theme mode.
+  Future<void> setMode(ThemeMode mode) async {
+    if (mode == _mode) return;
+    _mode = mode;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(storageKey, mode.name);
+  }
+
+  /// Parses a stored value into a [ThemeMode], defaulting to system.
+  static ThemeMode parseMode(String? value) => switch (value) {
+    'light' => ThemeMode.light,
+    'dark' => ThemeMode.dark,
+    _ => ThemeMode.system,
+  };
+}

--- a/lib/theme_controller.dart
+++ b/lib/theme_controller.dart
@@ -33,16 +33,18 @@ class ThemeController extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Updates and persists the theme mode. Persists first so a failed write
-  /// never leaves the UI on a mode that won't survive a restart.
+  /// Updates and persists the theme mode. The check-persist-update runs inside
+  /// the lock so concurrent changes serialize correctly, and the UI is only
+  /// notified after a successful persist that actually changed the mode.
   Future<void> setMode(ThemeMode mode) async {
-    if (mode == _mode) return;
-    await _runLocked(() async {
+    final changed = await _runLocked(() async {
+      if (mode == _mode) return false;
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(storageKey, mode.name);
+      _mode = mode;
+      return true;
     });
-    _mode = mode;
-    notifyListeners();
+    if (changed) notifyListeners();
   }
 
   /// Resets the in-memory mode to the default. For tests only, to keep the

--- a/test/theme_controller_test.dart
+++ b/test/theme_controller_test.dart
@@ -8,6 +8,11 @@ void main() {
 
   setUp(() {
     SharedPreferences.setMockInitialValues({});
+    ThemeController.instance.debugReset();
+  });
+
+  tearDown(() {
+    ThemeController.instance.debugReset();
   });
 
   test('parseMode maps stored strings to ThemeMode (default system)', () {

--- a/test/theme_controller_test.dart
+++ b/test/theme_controller_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:kode_radar/theme_controller.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('parseMode maps stored strings to ThemeMode (default system)', () {
+    expect(ThemeController.parseMode('light'), ThemeMode.light);
+    expect(ThemeController.parseMode('dark'), ThemeMode.dark);
+    expect(ThemeController.parseMode('system'), ThemeMode.system);
+    expect(ThemeController.parseMode(null), ThemeMode.system);
+    expect(ThemeController.parseMode('bogus'), ThemeMode.system);
+  });
+
+  test('setMode persists the choice and load restores it', () async {
+    final controller = ThemeController.instance;
+
+    await controller.setMode(ThemeMode.dark);
+    expect(controller.mode, ThemeMode.dark);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString(ThemeController.storageKey), 'dark');
+
+    // Persist a value and confirm load() reads it back.
+    await prefs.setString(ThemeController.storageKey, 'light');
+    await controller.load();
+    expect(controller.mode, ThemeMode.light);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -36,6 +36,9 @@ void main() {
     // Verify that the Teams action is present
     expect(find.byIcon(Icons.groups), findsOneWidget);
 
+    // Verify that the appearance (theme) action is present
+    expect(find.byIcon(Icons.brightness_6), findsOneWidget);
+
     // Verify that the add button is present
     expect(find.byIcon(Icons.add), findsOneWidget);
   });


### PR DESCRIPTION
Adds a persisted app-wide theme preference (System / Light / Dark).

- `ThemeController` (ChangeNotifier) persists the choice in SharedPreferences and is loaded at startup.
- Root `MaterialApp` now provides `theme` (light), `darkTheme` (dark, seeded Material 3), and `themeMode`, rebuilding via `ListenableBuilder`.
- New **Appearance** AppBar action opens a System/Light/Dark picker.

Tests: `theme_controller_test` (parse + persist/load) and a widget assertion. `flutter analyze --fatal-infos` clean, `dart format` clean, 81 tests pass.