### PR TITLE
Auto-detect identity from tokens

### DIFF
--- a/lib/identity_service.dart
+++ b/lib/identity_service.dart
@@ -6,7 +6,8 @@ import 'package:http/http.dart' as http;
 import 'identity_store.dart';
 import 'token_store.dart';
 
-/// What identity auto-detection found (and stored).
+/// What identity auto-detection found. These identities are persisted to
+/// [IdentityStore] only when `detectSelf` is called with `persist: true`.
 class IdentityDetectionResult {
   const IdentityDetectionResult({
     required this.githubLogins,

--- a/lib/identity_service.dart
+++ b/lib/identity_service.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import 'identity_store.dart';
+import 'token_store.dart';
+
+/// What identity auto-detection found (and stored).
+class IdentityDetectionResult {
+  const IdentityDetectionResult({
+    required this.githubLogins,
+    required this.adoNames,
+  });
+
+  final Set<String> githubLogins;
+  final Set<String> adoNames;
+
+  bool get isEmpty => githubLogins.isEmpty && adoNames.isEmpty;
+}
+
+/// Detects the current user's identity by asking each stored token who it
+/// belongs to (GitHub `/user`, Azure DevOps profile), then populates
+/// [IdentityStore] so the "You" badge and the inbox "Mine" filter work without
+/// the user typing their usernames.
+class IdentityService {
+  IdentityService._();
+
+  static const Duration _requestTimeout = Duration(seconds: 20);
+
+  // ---- Pure, testable parsers ----------------------------------------------
+
+  static String? parseGithubLogin(dynamic body) {
+    if (body is! Map) return null;
+    final login = body['login'];
+    return login is String && login.trim().isNotEmpty ? login.trim() : null;
+  }
+
+  static String? parseAdoName(dynamic body) {
+    if (body is! Map) return null;
+    final name = body['displayName'];
+    return name is String && name.trim().isNotEmpty ? name.trim() : null;
+  }
+
+  // ---- Detection -----------------------------------------------------------
+
+  /// Queries every stored token for its owning identity.
+  ///
+  /// When [persist] is true (default) the result is written to [IdentityStore]
+  /// ([merge] unions with existing values; otherwise it replaces them). When
+  /// [persist] is false the identities are only returned (e.g. to preview in a
+  /// form). Per-token failures are isolated and never throw.
+  static Future<IdentityDetectionResult> detectSelf({
+    http.Client? client,
+    bool merge = true,
+    bool persist = true,
+  }) async {
+    final httpClient = client ?? http.Client();
+    try {
+      final githubTokens = await TokenStore.getTokensForProvider(
+        TokenStore.providerGithub,
+      );
+      final adoTokens = await TokenStore.getTokensForProvider(
+        TokenStore.providerAdo,
+      );
+
+      // Query every token concurrently so one slow or unreachable token can't
+      // stall the others (each lookup carries its own timeout).
+      final githubFuture = Future.wait(
+        githubTokens.map((token) => _detectGithub(httpClient, token.id)),
+      );
+      final adoFuture = Future.wait(
+        adoTokens.map((token) => _detectAdo(httpClient, token.id)),
+      );
+      final githubResults = await githubFuture;
+      final adoResults = await adoFuture;
+
+      final githubLogins = <String>{for (final login in githubResults) ?login};
+      final adoNames = <String>{for (final name in adoResults) ?name};
+
+      if (persist) {
+        if (merge) {
+          final existingGithub = await IdentityStore.selfGithubLogins();
+          final existingAdo = await IdentityStore.selfAdoNames();
+          await IdentityStore.setSelfGithubLogins({
+            ...existingGithub,
+            ...githubLogins,
+          });
+          await IdentityStore.setSelfAdoNames({...existingAdo, ...adoNames});
+        } else {
+          await IdentityStore.setSelfGithubLogins(githubLogins);
+          await IdentityStore.setSelfAdoNames(adoNames);
+        }
+      }
+
+      return IdentityDetectionResult(
+        githubLogins: githubLogins,
+        adoNames: adoNames,
+      );
+    } finally {
+      if (client == null) httpClient.close();
+    }
+  }
+
+  static Future<String?> _detectGithub(
+    http.Client client,
+    String tokenId,
+  ) async {
+    try {
+      final secret = (await TokenStore.getSecret(tokenId))?.trim();
+      if (secret == null || secret.isEmpty) return null;
+      final response = await client
+          .get(
+            Uri.https('api.github.com', '/user'),
+            headers: {
+              'Authorization': 'Bearer $secret',
+              'Accept': 'application/vnd.github+json',
+            },
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode != 200) return null;
+      return parseGithubLogin(jsonDecode(response.body));
+    } catch (e) {
+      debugPrint('IdentityService: GitHub detection failed for $tokenId: $e');
+      return null;
+    }
+  }
+
+  static Future<String?> _detectAdo(http.Client client, String tokenId) async {
+    try {
+      final secret = (await TokenStore.getSecret(tokenId))?.trim();
+      if (secret == null || secret.isEmpty) return null;
+      final response = await client
+          .get(
+            Uri.https(
+              'app.vssps.visualstudio.com',
+              '/_apis/profile/profiles/me',
+              {'api-version': '6.0'},
+            ),
+            headers: {
+              'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
+            },
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode != 200) return null;
+      return parseAdoName(jsonDecode(response.body));
+    } catch (e) {
+      debugPrint('IdentityService: ADO detection failed for $tokenId: $e');
+      return null;
+    }
+  }
+}

--- a/lib/identity_service.dart
+++ b/lib/identity_service.dart
@@ -122,7 +122,9 @@ class IdentityService {
       if (response.statusCode != 200) return null;
       return parseGithubLogin(jsonDecode(response.body));
     } catch (e) {
-      debugPrint('IdentityService: GitHub detection failed for $tokenId: $e');
+      if (kDebugMode) {
+        debugPrint('IdentityService: GitHub token detection failed: $e');
+      }
       return null;
     }
   }
@@ -146,7 +148,9 @@ class IdentityService {
       if (response.statusCode != 200) return null;
       return parseAdoName(jsonDecode(response.body));
     } catch (e) {
-      debugPrint('IdentityService: ADO detection failed for $tokenId: $e');
+      if (kDebugMode) {
+        debugPrint('IdentityService: ADO token detection failed: $e');
+      }
       return null;
     }
   }

--- a/lib/identity_service.dart
+++ b/lib/identity_service.dart
@@ -29,6 +29,16 @@ class IdentityService {
 
   static const Duration _requestTimeout = Duration(seconds: 20);
 
+  // Serializes the read-modify-write persistence step so concurrent
+  // detectSelf(persist: true, merge: true) calls can't clobber each other.
+  static Future<void> _lock = Future<void>.value();
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
   // ---- Pure, testable parsers ----------------------------------------------
 
   static String? parseGithubLogin(dynamic body) {
@@ -82,18 +92,20 @@ class IdentityService {
       final adoNames = <String>{for (final name in adoResults) ?name};
 
       if (persist) {
-        if (merge) {
-          final existingGithub = await IdentityStore.selfGithubLogins();
-          final existingAdo = await IdentityStore.selfAdoNames();
-          await IdentityStore.setSelfGithubLogins({
-            ...existingGithub,
-            ...githubLogins,
-          });
-          await IdentityStore.setSelfAdoNames({...existingAdo, ...adoNames});
-        } else {
-          await IdentityStore.setSelfGithubLogins(githubLogins);
-          await IdentityStore.setSelfAdoNames(adoNames);
-        }
+        await _runLocked(() async {
+          if (merge) {
+            final existingGithub = await IdentityStore.selfGithubLogins();
+            final existingAdo = await IdentityStore.selfAdoNames();
+            await IdentityStore.setSelfGithubLogins({
+              ...existingGithub,
+              ...githubLogins,
+            });
+            await IdentityStore.setSelfAdoNames({...existingAdo, ...adoNames});
+          } else {
+            await IdentityStore.setSelfGithubLogins(githubLogins);
+            await IdentityStore.setSelfAdoNames(adoNames);
+          }
+        });
       }
 
       return IdentityDetectionResult(

--- a/lib/identity_service.dart
+++ b/lib/identity_service.dart
@@ -34,7 +34,9 @@ class IdentityService {
   static String? parseGithubLogin(dynamic body) {
     if (body is! Map) return null;
     final login = body['login'];
-    return login is String && login.trim().isNotEmpty ? login.trim() : null;
+    if (login is! String) return null;
+    final normalized = login.trim().toLowerCase();
+    return normalized.isNotEmpty ? normalized : null;
   }
 
   static String? parseAdoName(dynamic body) {

--- a/lib/people_page.dart
+++ b/lib/people_page.dart
@@ -82,7 +82,6 @@ class _PeoplePageState extends State<PeoplePage> {
     try {
       final saved = await showDialog<bool>(
         context: context,
-        barrierDismissible: false,
         builder: (dialogContext) => StatefulBuilder(
           builder: (dialogContext, setDialogState) => PopScope(
             canPop: !detecting,

--- a/lib/people_page.dart
+++ b/lib/people_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'app_http.dart';
+import 'identity_service.dart';
 import 'identity_store.dart';
 import 'people_service.dart';
 import 'person.dart';
@@ -77,48 +78,100 @@ class _PeoplePageState extends State<PeoplePage> {
     if (!mounted) return;
     final ghController = TextEditingController(text: gh);
     final adoController = TextEditingController(text: ado);
+    var detecting = false;
     try {
       final saved = await showDialog<bool>(
         context: context,
-        builder: (dialogContext) => AlertDialog(
-          title: const Text('Your identity'),
-          content: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Text(
-                  'Marks "You" here and powers the Attention inbox\'s "Mine" '
-                  'filter. Separate multiple entries with commas.',
-                  style: TextStyle(fontSize: 12),
+        barrierDismissible: false,
+        builder: (dialogContext) => StatefulBuilder(
+          builder: (dialogContext, setDialogState) => PopScope(
+            canPop: !detecting,
+            child: AlertDialog(
+              title: const Text('Your identity'),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Marks "You" here and powers the Attention inbox\'s "Mine" '
+                      'filter. Separate multiple entries with commas.',
+                      style: TextStyle(fontSize: 12),
+                    ),
+                    const SizedBox(height: 12),
+                    TextField(
+                      controller: ghController,
+                      decoration: const InputDecoration(
+                        labelText: 'GitHub username(s)',
+                        hintText: 'octocat, ...',
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: adoController,
+                      decoration: const InputDecoration(
+                        labelText: 'Azure DevOps display name(s)',
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: TextButton.icon(
+                        icon: detecting
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Icon(Icons.person_search),
+                        label: const Text('Detect from my tokens'),
+                        onPressed: detecting
+                            ? null
+                            : () async {
+                                setDialogState(() => detecting = true);
+                                try {
+                                  final result =
+                                      await IdentityService.detectSelf(
+                                        client: AppHttp.client,
+                                        persist: false,
+                                      );
+                                  ghController.text = {
+                                    ..._parseLogins(ghController.text),
+                                    ...result.githubLogins,
+                                  }.join(', ');
+                                  adoController.text = {
+                                    ..._parseNames(adoController.text),
+                                    ...result.adoNames,
+                                  }.join(', ');
+                                } catch (e) {
+                                  debugPrint('Identity detection failed: $e');
+                                } finally {
+                                  setDialogState(() => detecting = false);
+                                }
+                              },
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 12),
-                TextField(
-                  controller: ghController,
-                  decoration: const InputDecoration(
-                    labelText: 'GitHub username(s)',
-                    hintText: 'octocat, ...',
-                  ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: detecting
+                      ? null
+                      : () => Navigator.pop(dialogContext, false),
+                  child: const Text('Cancel'),
                 ),
-                const SizedBox(height: 8),
-                TextField(
-                  controller: adoController,
-                  decoration: const InputDecoration(
-                    labelText: 'Azure DevOps display name(s)',
-                  ),
+                FilledButton(
+                  onPressed: detecting
+                      ? null
+                      : () => Navigator.pop(dialogContext, true),
+                  child: const Text('Save'),
                 ),
               ],
             ),
           ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(dialogContext, false),
-              child: const Text('Cancel'),
-            ),
-            FilledButton(
-              onPressed: () => Navigator.pop(dialogContext, true),
-              child: const Text('Save'),
-            ),
-          ],
         ),
       );
       if (saved == true) {

--- a/lib/people_page.dart
+++ b/lib/people_page.dart
@@ -187,10 +187,11 @@ class _PeoplePageState extends State<PeoplePage> {
     }
   }
 
-  /// GitHub logins never contain whitespace, so split on commas or whitespace.
+  /// GitHub logins never contain whitespace and are case-insensitive, so split
+  /// on commas or whitespace and lowercase to match [IdentityStore] semantics.
   Set<String> _parseLogins(String value) => value
       .split(RegExp(r'[,\s]+'))
-      .map((e) => e.trim())
+      .map((e) => e.trim().toLowerCase())
       .where((e) => e.isNotEmpty)
       .toSet();
 

--- a/test/identity_service_test.dart
+++ b/test/identity_service_test.dart
@@ -1,0 +1,99 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:kode_radar/identity_service.dart';
+import 'package:kode_radar/identity_store.dart';
+import 'package:kode_radar/token_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('parseGithubLogin and parseAdoName are null-tolerant', () {
+    expect(IdentityService.parseGithubLogin({'login': ' octocat '}), 'octocat');
+    expect(IdentityService.parseGithubLogin({'login': 42}), isNull);
+    expect(IdentityService.parseGithubLogin('nope'), isNull);
+    expect(
+      IdentityService.parseAdoName({'displayName': 'Jane Doe'}),
+      'Jane Doe',
+    );
+    expect(IdentityService.parseAdoName({'displayName': ''}), isNull);
+    expect(IdentityService.parseAdoName({}), isNull);
+  });
+
+  test(
+    'detectSelf collects identities from tokens and merges into storage',
+    () async {
+      await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Personal',
+        scope: 'acme',
+        secret: 'ghp_x',
+      );
+      await TokenStore.addToken(
+        provider: TokenStore.providerAdo,
+        label: 'Org',
+        scope: 'org',
+        secret: 'ado_x',
+      );
+      await IdentityStore.setSelfGithubLogins({'existing'});
+
+      final client = MockClient((request) async {
+        if (request.url.host == 'api.github.com' &&
+            request.url.path == '/user') {
+          return http.Response(jsonEncode({'login': 'octocat'}), 200);
+        }
+        if (request.url.host == 'app.vssps.visualstudio.com' &&
+            request.url.path == '/_apis/profile/profiles/me') {
+          return http.Response(jsonEncode({'displayName': 'Jane Doe'}), 200);
+        }
+        return http.Response('{}', 404);
+      });
+
+      final result = await IdentityService.detectSelf(client: client);
+      expect(result.githubLogins, {'octocat'});
+      expect(result.adoNames, {'Jane Doe'});
+      expect(await IdentityStore.selfGithubLogins(), {'existing', 'octocat'});
+      expect(await IdentityStore.selfAdoNames(), {'Jane Doe'});
+    },
+  );
+
+  test('detectSelf with persist:false does not write to storage', () async {
+    await TokenStore.addToken(
+      provider: TokenStore.providerGithub,
+      label: 'Personal',
+      scope: 'acme',
+      secret: 'ghp_x',
+    );
+    final client = MockClient(
+      (request) async => http.Response(jsonEncode({'login': 'octocat'}), 200),
+    );
+
+    final result = await IdentityService.detectSelf(
+      client: client,
+      persist: false,
+    );
+    expect(result.githubLogins, {'octocat'});
+    expect(await IdentityStore.selfGithubLogins(), isEmpty);
+  });
+
+  test('detectSelf isolates per-token failures without throwing', () async {
+    await TokenStore.addToken(
+      provider: TokenStore.providerGithub,
+      label: 'Personal',
+      scope: 'acme',
+      secret: 'ghp_x',
+    );
+    final client = MockClient((request) async => http.Response('nope', 401));
+    final result = await IdentityService.detectSelf(client: client);
+    expect(result.isEmpty, isTrue);
+  });
+}

--- a/test/identity_service_test.dart
+++ b/test/identity_service_test.dart
@@ -19,6 +19,7 @@ void main() {
 
   test('parseGithubLogin and parseAdoName are null-tolerant', () {
     expect(IdentityService.parseGithubLogin({'login': ' octocat '}), 'octocat');
+    expect(IdentityService.parseGithubLogin({'login': 'OctoCat'}), 'octocat');
     expect(IdentityService.parseGithubLogin({'login': 42}), isNull);
     expect(IdentityService.parseGithubLogin('nope'), isNull);
     expect(


### PR DESCRIPTION
## What

Adds identity auto-detection so the People **You** badge and the Attention inbox **Mine** filter work without manually typing usernames.

- **`lib/identity_service.dart`** (new) — `IdentityService.detectSelf({client, merge, persist})` asks each stored token who it belongs to:
  - GitHub tokens → `GET https://api.github.com/user` (Bearer) → `login`
  - Azure DevOps tokens → `GET https://app.vssps.visualstudio.com/_apis/profile/profiles/me` (Basic) → `displayName`
  - Lookups run concurrently; per-token failures are isolated (never throw); secrets are never logged. Pure parsers `parseGithubLogin`/`parseAdoName`.
- **`lib/people_page.dart`** — the "Your identity" dialog gains a **"Detect from my tokens"** button that previews detected values into the fields (`persist: false`); identities persist only on **Save**. Dialog dismissal is blocked while detection is in flight (no setState/controller-after-dispose).
- **`test/identity_service_test.dart`** (new) — parser null-tolerance, merge-into-storage, `persist:false` no-write, per-token failure isolation, exact ADO URL path.

## Validation

`flutter analyze --fatal-infos` clean · `dart format` clean · **85 tests pass**. Deployed to device for hands-on testing.