### PR TITLE
Activity Feed of normalized cross-repo events

### DIFF
--- a/lib/activity_event.dart
+++ b/lib/activity_event.dart
@@ -1,0 +1,120 @@
+/// The kinds of activity the feed normalizes across providers.
+///
+/// Stored as plain strings (mirroring the string-category style used elsewhere,
+/// e.g. `AttentionItem.category`) so events serialize trivially and are easy to
+/// group/filter in the UI.
+abstract final class ActivityType {
+  static const String prOpened = 'prOpened';
+  static const String prMerged = 'prMerged';
+  static const String prClosed = 'prClosed';
+  static const String reviewSubmitted = 'reviewSubmitted';
+  static const String push = 'push';
+  static const String release = 'release';
+  static const String ciFailed = 'ciFailed';
+
+  /// The coarse group a type belongs to, used for the feed's filter chips.
+  /// One of: `prs`, `reviews`, `ci`, `releases`, `pushes`.
+  static String groupOf(String type) {
+    switch (type) {
+      case prOpened:
+      case prMerged:
+      case prClosed:
+        return groupPrs;
+      case reviewSubmitted:
+        return groupReviews;
+      case ciFailed:
+        return groupCi;
+      case release:
+        return groupReleases;
+      case push:
+        return groupPushes;
+      default:
+        return groupPrs;
+    }
+  }
+
+  static const String groupPrs = 'prs';
+  static const String groupReviews = 'reviews';
+  static const String groupCi = 'ci';
+  static const String groupReleases = 'releases';
+  static const String groupPushes = 'pushes';
+
+  /// All groups in display order (used to render filter chips consistently).
+  static const List<String> groups = [
+    groupPrs,
+    groupReviews,
+    groupCi,
+    groupReleases,
+    groupPushes,
+  ];
+
+  static String groupLabel(String group) {
+    switch (group) {
+      case groupPrs:
+        return 'PRs';
+      case groupReviews:
+        return 'Reviews';
+      case groupCi:
+        return 'CI';
+      case groupReleases:
+        return 'Releases';
+      case groupPushes:
+        return 'Pushes';
+      default:
+        return group;
+    }
+  }
+}
+
+/// A single normalized activity event shown in the Activity Feed.
+///
+/// Providers (GitHub events/Actions, Azure DevOps PRs/pushes/builds) are
+/// normalized to this one shape so the feed is provider-agnostic.
+class ActivityEvent {
+  const ActivityEvent({
+    required this.id,
+    required this.type,
+    required this.provider,
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.actor,
+    required this.title,
+    required this.subtitle,
+    required this.occurredAt,
+    this.url,
+    this.isMine = false,
+  });
+
+  /// Stable identity (provider event/PR/build id where available) so the feed
+  /// can de-duplicate overlapping fetches and use it as a list key.
+  final String id;
+
+  /// One of the [ActivityType] constants.
+  final String type;
+
+  /// `github` or `ado`.
+  final String provider;
+
+  /// Repo identity key ([RepoDiscoveryService.githubKey]/`adoKey`) used to
+  /// filter the feed by team.
+  final String repoKey;
+
+  /// Human-readable repo label (e.g. `owner/name`).
+  final String repoDisplay;
+
+  /// Who performed the action (GitHub login / ADO display name); may be empty.
+  final String actor;
+
+  final String title;
+  final String subtitle;
+
+  /// When the event occurred (UTC).
+  final DateTime occurredAt;
+
+  final String? url;
+
+  /// True when [actor] matches the current user's stored identity.
+  final bool isMine;
+
+  String get group => ActivityType.groupOf(type);
+}

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -1,0 +1,434 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'activity_event.dart';
+import 'activity_feed_service.dart';
+import 'app_http.dart';
+import 'identity_store.dart';
+import 'team.dart';
+import 'team_store.dart';
+
+/// A reverse-chronological stream of normalized activity across all monitored
+/// repositories (PRs opened/merged/closed, reviews, pushes, releases, and CI
+/// failures). Filterable by kind, team, and "mine"; tap an item to open it.
+class ActivityFeedPage extends StatefulWidget {
+  const ActivityFeedPage({super.key});
+
+  @override
+  State<ActivityFeedPage> createState() => _ActivityFeedPageState();
+}
+
+class _ActivityFeedPageState extends State<ActivityFeedPage> {
+  List<ActivityEvent> _events = const [];
+  List<Team> _teams = const [];
+  bool _loading = true;
+  bool _refreshing = false;
+  bool _mineOnly = false;
+  bool _identitySet = false;
+  int _failedSources = 0;
+  bool _truncated = false;
+  String? _error;
+  DateTime? _lastChecked;
+
+  /// Selected type groups; empty means "all kinds".
+  final Set<String> _groups = <String>{};
+
+  /// Selected team id; null means "all teams".
+  String? _teamId;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    if (_refreshing) return;
+    _refreshing = true;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final teams = await TeamStore.list();
+      final selfGithub = await IdentityStore.selfGithubLogins();
+      final selfAdo = await IdentityStore.selfAdoNames();
+      final result = await ActivityFeedService.computeAll(
+        client: AppHttp.client,
+        selfGithubLogins: selfGithub,
+        selfAdoNames: selfAdo,
+      );
+      if (!mounted) return;
+      setState(() {
+        _events = result.events;
+        _failedSources = result.failedSources;
+        _truncated = result.truncated;
+        _teams = teams;
+        // Drop a stale team filter if the team was deleted.
+        if (_teamId != null && !teams.any((t) => t.id == _teamId)) {
+          _teamId = null;
+        }
+        _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
+        _lastChecked = DateTime.now();
+        _loading = false;
+      });
+    } catch (e) {
+      debugPrint('ActivityFeed failed to load: $e');
+      if (!mounted) return;
+      setState(() {
+        _error =
+            'Something went wrong while loading the feed. Pull down to try again.';
+        _loading = false;
+      });
+    } finally {
+      _refreshing = false;
+    }
+  }
+
+  List<ActivityEvent> get _visibleEvents {
+    Set<String>? teamRepoKeys;
+    if (_teamId != null) {
+      final team = _teams.firstWhere(
+        (t) => t.id == _teamId,
+        orElse: () => const Team(id: '', name: ''),
+      );
+      teamRepoKeys = team.repoKeys;
+    }
+    return _events.where((event) {
+      if (_mineOnly && !event.isMine) return false;
+      if (_groups.isNotEmpty && !_groups.contains(event.group)) return false;
+      if (teamRepoKeys != null && !teamRepoKeys.contains(event.repoKey)) {
+        return false;
+      }
+      return true;
+    }).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Activity'),
+        actions: [
+          IconButton(
+            icon: Icon(_mineOnly ? Icons.person : Icons.people_outline),
+            tooltip: _mineOnly
+                ? 'Showing yours — tap for all'
+                : 'Show only mine',
+            onPressed: _loading
+                ? null
+                : () => setState(() => _mineOnly = !_mineOnly),
+          ),
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: _loading ? null : _load,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _buildFilterBar(),
+          const Divider(height: 1),
+          if (!_loading && _error == null && (_failedSources > 0 || _truncated))
+            _buildNotice(),
+          Expanded(
+            child: _loading
+                ? const Center(child: CircularProgressIndicator())
+                : RefreshIndicator(onRefresh: _load, child: _buildContent()),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNotice() {
+    final parts = <String>[];
+    if (_failedSources > 0) {
+      parts.add(
+        '$_failedSources source${_failedSources == 1 ? '' : 's'} '
+        'couldn\'t be loaded',
+      );
+    }
+    if (_truncated) parts.add('older items may be omitted');
+    return Container(
+      width: double.infinity,
+      color: Colors.amber.shade100,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          Icon(Icons.info_outline, size: 16, color: Colors.amber.shade900),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '${parts.join(' · ')}. Pull to retry.',
+              style: TextStyle(fontSize: 12, color: Colors.amber.shade900),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterBar() {
+    final chips = <Widget>[
+      FilterChip(
+        label: const Text('All'),
+        selected: _groups.isEmpty,
+        onSelected: _loading ? null : (_) => setState(_groups.clear),
+      ),
+      for (final group in ActivityType.groups)
+        Padding(
+          padding: const EdgeInsets.only(left: 8),
+          child: FilterChip(
+            label: Text(ActivityType.groupLabel(group)),
+            selected: _groups.contains(group),
+            onSelected: _loading
+                ? null
+                : (selected) => setState(() {
+                    if (selected) {
+                      _groups.add(group);
+                    } else {
+                      _groups.remove(group);
+                    }
+                  }),
+          ),
+        ),
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(children: chips),
+          ),
+          if (_teams.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Row(
+                children: [
+                  const Icon(Icons.groups, size: 18),
+                  const SizedBox(width: 8),
+                  DropdownButton<String?>(
+                    value: _teamId,
+                    isDense: true,
+                    hint: const Text('All teams'),
+                    onChanged: _loading
+                        ? null
+                        : (value) => setState(() => _teamId = value),
+                    items: [
+                      const DropdownMenuItem<String?>(child: Text('All teams')),
+                      for (final team in _teams)
+                        DropdownMenuItem<String?>(
+                          value: team.id,
+                          child: Text(team.name),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    if (_error != null) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 160),
+          Center(
+            child: Text(_error!, style: const TextStyle(color: Colors.red)),
+          ),
+        ],
+      );
+    }
+
+    final visible = _visibleEvents;
+    if (visible.isEmpty) return _buildEmptyState();
+
+    final rows = _buildRows(visible);
+    return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
+      itemCount: rows.length,
+      itemBuilder: (context, index) {
+        final row = rows[index];
+        if (row.header != null) return _buildDayHeader(row.header!);
+        return _buildEventTile(row.event!);
+      },
+    );
+  }
+
+  Widget _buildEmptyState() {
+    final String message;
+    if (_events.isEmpty && _failedSources > 0) {
+      message = 'Couldn\'t load activity right now. Pull down to retry.';
+    } else if (_events.isEmpty) {
+      message = 'No recent activity in the last 14 days.';
+    } else if (_mineOnly && !_identitySet) {
+      message = 'Set your identity in People to use the "Mine" filter.';
+    } else {
+      message = 'No activity matches the current filters.';
+    }
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        const SizedBox(height: 140),
+        Center(child: Icon(Icons.timeline, size: 56, color: Colors.grey[400])),
+        const SizedBox(height: 12),
+        Center(child: Text(message, textAlign: TextAlign.center)),
+        const SizedBox(height: 6),
+        Center(
+          child: Text(
+            _lastChecked == null
+                ? 'Pull down to refresh.'
+                : 'Checked ${_relativeTime(_lastChecked!)} · pull down to refresh.',
+            style: TextStyle(color: Colors.grey[600], fontSize: 12),
+          ),
+        ),
+      ],
+    );
+  }
+
+  List<_FeedRow> _buildRows(List<ActivityEvent> events) {
+    final rows = <_FeedRow>[];
+    String? currentDay;
+    for (final event in events) {
+      final day = _dayLabel(event.occurredAt.toLocal());
+      if (day != currentDay) {
+        currentDay = day;
+        rows.add(_FeedRow.header(day));
+      }
+      rows.add(_FeedRow.event(event));
+    }
+    return rows;
+  }
+
+  Widget _buildDayHeader(String label) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: Colors.grey[600],
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEventTile(ActivityEvent event) {
+    final visual = _visualFor(event.type);
+    return ListTile(
+      leading: Icon(visual.icon, color: visual.color),
+      title: Text(event.title),
+      subtitle: Text(
+        '${event.subtitle} · ${_relativeTime(event.occurredAt.toLocal())}',
+      ),
+      trailing: event.url != null
+          ? const Icon(Icons.open_in_new, size: 16)
+          : null,
+      onTap: event.url == null ? null : () => _open(event.url!),
+    );
+  }
+
+  ({IconData icon, Color color}) _visualFor(String type) {
+    switch (type) {
+      case ActivityType.prOpened:
+        return (icon: Icons.merge_type, color: Colors.green);
+      case ActivityType.prMerged:
+        return (icon: Icons.merge, color: Colors.purple);
+      case ActivityType.prClosed:
+        return (icon: Icons.cancel_outlined, color: Colors.blueGrey);
+      case ActivityType.reviewSubmitted:
+        return (icon: Icons.rate_review, color: Colors.orange);
+      case ActivityType.push:
+        return (icon: Icons.commit, color: Colors.blue);
+      case ActivityType.release:
+        return (icon: Icons.rocket_launch, color: Colors.teal);
+      case ActivityType.ciFailed:
+        return (icon: Icons.error_outline, color: Colors.red);
+      default:
+        return (icon: Icons.circle_notifications, color: Colors.grey);
+    }
+  }
+
+  /// "Today" / "Yesterday" / "Mon, Jul 14".
+  String _dayLabel(DateTime local) {
+    final now = DateTime.now();
+    // Compare via UTC-midnight anchors so calendar-day math stays exact across
+    // DST transitions (local midnights can be 23/25h apart).
+    final today = DateTime.utc(now.year, now.month, now.day);
+    final that = DateTime.utc(local.year, local.month, local.day);
+    final diff = today.difference(that).inDays;
+    if (diff == 0) return 'Today';
+    if (diff == 1) return 'Yesterday';
+    const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    final weekday = weekdays[local.weekday - 1];
+    final month = months[local.month - 1];
+    return '$weekday, $month ${local.day}';
+  }
+
+  String _relativeTime(DateTime value) {
+    final diff = DateTime.now().difference(value);
+    if (diff.isNegative) return 'just now';
+    if (diff.inSeconds < 45) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+
+  Future<void> _open(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      _showOpenError(url);
+      return;
+    }
+    final canLaunch = await canLaunchUrl(uri);
+    if (!mounted) return;
+    if (!canLaunch) {
+      _showOpenError(url);
+      return;
+    }
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!mounted) return;
+    if (!launched) _showOpenError(url);
+  }
+
+  void _showOpenError(String url) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Could not open $url')));
+  }
+}
+
+/// A row in the flattened feed: either a day header or an event.
+class _FeedRow {
+  const _FeedRow.header(this.header) : event = null;
+  const _FeedRow.event(this.event) : header = null;
+
+  final String? header;
+  final ActivityEvent? event;
+}

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -153,6 +153,9 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
       );
     }
     if (_truncated) parts.add('older items may be omitted');
+    // Retrying only helps when a source actually failed; truncation won't
+    // change on refresh.
+    final suffix = _failedSources > 0 ? ' Pull to retry.' : '';
     return Container(
       width: double.infinity,
       color: Colors.amber.shade100,
@@ -163,7 +166,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              '${parts.join(' · ')}. Pull to retry.',
+              '${parts.join(' · ')}.$suffix',
               style: TextStyle(fontSize: 12, color: Colors.amber.shade900),
             ),
           ),

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -272,7 +272,8 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
     if (_events.isEmpty && _failedSources > 0) {
       message = 'Couldn\'t load activity right now. Pull down to retry.';
     } else if (_events.isEmpty) {
-      message = 'No recent activity in the last 14 days.';
+      final days = ActivityFeedService.defaultLookback.inDays;
+      message = 'No recent activity in the last $days days.';
     } else if (_mineOnly && !_identitySet) {
       message = 'Set your identity in People to use the "Mine" filter.';
     } else {

--- a/lib/activity_feed_service.dart
+++ b/lib/activity_feed_service.dart
@@ -225,6 +225,9 @@ class ActivityFeedService {
       final name =
           _str(run, 'name') ?? _str(run, 'display_title') ?? 'Workflow';
       final branch = _str(run, 'head_branch');
+      final branchSuffix = (branch == null || branch.isEmpty)
+          ? ''
+          : ' on $branch';
       final actor =
           _nested(run['actor'], 'login') ??
           _nested(run['triggering_actor'], 'login') ??
@@ -239,7 +242,7 @@ class ActivityFeedService {
           repoKey: repoKey,
           repoDisplay: repoDisplay,
           actor: actor,
-          title: 'CI failed: $name${branch == null ? '' : ' on $branch'}',
+          title: 'CI failed: $name$branchSuffix',
           subtitle: repoDisplay,
           occurredAt: occurredAt,
           url: _str(run, 'html_url'),

--- a/lib/activity_feed_service.dart
+++ b/lib/activity_feed_service.dart
@@ -79,9 +79,14 @@ class ActivityFeedService {
           final noun = count == 1 ? 'commit' : 'commits';
           final before = _str(payload, 'before');
           final head = _str(payload, 'head');
-          final url = (before != null && head != null)
-              ? 'https://github.com/$repoDisplay/compare/$before...$head'
-              : 'https://github.com/$repoDisplay/commits/$branch';
+          final String url;
+          if (before != null && head != null) {
+            url = 'https://github.com/$repoDisplay/compare/$before...$head';
+          } else if (branch.isEmpty) {
+            url = 'https://github.com/$repoDisplay/commits';
+          } else {
+            url = 'https://github.com/$repoDisplay/commits/$branch';
+          }
           result.add(
             ActivityEvent(
               id: 'gh-event:${eventId ?? '$repoKey:${occurredAt.toIso8601String()}'}',
@@ -91,7 +96,8 @@ class ActivityFeedService {
               repoDisplay: repoDisplay,
               actor: actor,
               title:
-                  '${actor.isEmpty ? 'Someone' : actor} pushed $count $noun to $branch',
+                  '${actor.isEmpty ? 'Someone' : actor} pushed $count $noun'
+                  '${branch.isEmpty ? '' : ' to $branch'}',
               subtitle: repoDisplay,
               occurredAt: occurredAt,
               url: url,
@@ -807,7 +813,7 @@ class ActivityFeedService {
       }
     }
 
-    final workerCount = concurrency.clamp(1, tasks.length);
+    final workerCount = concurrency.clamp(1, tasks.length).toInt();
     await Future.wait(List.generate(workerCount, (_) => worker()));
     return results;
   }

--- a/lib/activity_feed_service.dart
+++ b/lib/activity_feed_service.dart
@@ -465,6 +465,7 @@ class ActivityFeedService {
             name,
             tokenId,
             selfGithubLogins,
+            since,
           ),
         );
       }
@@ -485,6 +486,7 @@ class ActivityFeedService {
             name,
             tokenId,
             selfAdoNames,
+            since,
           ),
         );
       }
@@ -507,6 +509,7 @@ class ActivityFeedService {
     String name,
     String? tokenId,
     Set<String> selfGithubLogins,
+    DateTime since,
   ) async {
     final repoDisplay = '$owner/$name';
     final repoKey = RepoDiscoveryService.githubKey(owner, name);
@@ -543,7 +546,12 @@ class ActivityFeedService {
           events: body,
           selfGithubLogins: selfGithubLogins,
         ),
-        truncated: body.length >= 100,
+        truncated: _truncatedByWindow(
+          body,
+          100,
+          since,
+          (e) => e is Map ? _parseDate(e['created_at']) : null,
+        ),
       );
     });
 
@@ -566,7 +574,14 @@ class ActivityFeedService {
           body: body,
           selfGithubLogins: selfGithubLogins,
         ),
-        truncated: runs is List && runs.length >= 30,
+        truncated: _truncatedByWindow(
+          runs,
+          30,
+          since,
+          (r) => r is Map
+              ? (_parseDate(r['updated_at']) ?? _parseDate(r['run_started_at']))
+              : null,
+        ),
       );
     });
 
@@ -580,6 +595,7 @@ class ActivityFeedService {
     String name,
     String? tokenId,
     Set<String> selfAdoNames,
+    DateTime since,
   ) async {
     final repoDisplay = '$organization/$project/$name';
     final repoKey = RepoDiscoveryService.adoKey(organization, project, name);
@@ -625,7 +641,12 @@ class ActivityFeedService {
           prs: value,
           selfAdoNames: selfAdoNames,
         ),
-        truncated: value.length >= 50,
+        truncated: _truncatedByWindow(
+          value,
+          50,
+          since,
+          (p) => p is Map ? _parseDate(p['creationDate']) : null,
+        ),
       );
     });
 
@@ -653,7 +674,12 @@ class ActivityFeedService {
           body: body,
           selfAdoNames: selfAdoNames,
         ),
-        truncated: value is List && value.length >= 30,
+        truncated: _truncatedByWindow(
+          value,
+          30,
+          since,
+          (p) => p is Map ? _parseDate(p['date']) : null,
+        ),
       );
     });
 
@@ -701,7 +727,12 @@ class ActivityFeedService {
           body: body,
           selfAdoNames: selfAdoNames,
         ),
-        truncated: value is List && value.length >= 30,
+        truncated: _truncatedByWindow(
+          value,
+          30,
+          since,
+          (b) => b is Map ? _parseDate(b['finishTime']) : null,
+        ),
       );
     });
 
@@ -709,6 +740,26 @@ class ActivityFeedService {
   }
 
   // ---- Helpers -------------------------------------------------------------
+
+  /// True when a fetched [page] is full (>= [cap]) AND its oldest item is still
+  /// at/after [since] — i.e. older *in-window* items may lie beyond this page.
+  /// If the oldest item is already older than [since], the page already spans
+  /// the whole window and nothing in-window was omitted.
+  static bool _truncatedByWindow(
+    dynamic page,
+    int cap,
+    DateTime since,
+    DateTime? Function(dynamic item) dateOf,
+  ) {
+    if (page is! List || page.length < cap) return false;
+    DateTime? oldest;
+    for (final item in page) {
+      final date = dateOf(item);
+      if (date == null) continue;
+      if (oldest == null || date.isBefore(oldest)) oldest = date;
+    }
+    return oldest == null || !oldest.isBefore(since);
+  }
 
   static ActivityEvent _adoPrEvent({
     required String id,

--- a/lib/activity_feed_service.dart
+++ b/lib/activity_feed_service.dart
@@ -1,0 +1,846 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'activity_event.dart';
+import 'repo_discovery_service.dart';
+import 'repo_store.dart';
+import 'token_store.dart';
+
+/// Outcome of fetching the whole feed: the merged events plus health signals
+/// so the UI can distinguish "genuinely quiet" from "some sources failed" or
+/// "there may be more than we fetched".
+class ActivityFeedResult {
+  const ActivityFeedResult({
+    required this.events,
+    this.failedSources = 0,
+    this.truncated = false,
+  });
+
+  final List<ActivityEvent> events;
+
+  /// Number of source fetches that errored or returned a non-200 status.
+  final int failedSources;
+
+  /// True when at least one history source returned a full page, so older
+  /// in-window events may have been omitted.
+  final bool truncated;
+}
+
+/// Builds a reverse-chronological, provider-agnostic activity feed across all
+/// monitored repositories.
+///
+/// GitHub is sourced from the repo events timeline (`/events`) plus Actions run
+/// history (for CI failures); Azure DevOps is derived from pull requests,
+/// pushes, and failed builds. Every source is normalized to [ActivityEvent] and
+/// merged into one time-ordered stream. Per-source failures are isolated so one
+/// slow or forbidden endpoint never blanks the whole feed.
+class ActivityFeedService {
+  ActivityFeedService._();
+
+  static const Duration _requestTimeout = Duration(seconds: 20);
+
+  /// Events older than this (relative to `now`) are dropped from the feed.
+  static const Duration defaultLookback = Duration(days: 14);
+
+  /// Safety cap on the merged feed length.
+  static const int maxEvents = 500;
+
+  // ---- Pure, testable normalizers ------------------------------------------
+
+  /// Normalizes a GitHub `/events` timeline into activity events.
+  static List<ActivityEvent> githubEventsToActivity({
+    required String repoDisplay,
+    required String repoKey,
+    required List<dynamic> events,
+    Set<String> selfGithubLogins = const {},
+  }) {
+    final self = selfGithubLogins.map((e) => e.trim().toLowerCase()).toSet();
+    final result = <ActivityEvent>[];
+    for (final event in events) {
+      if (event is! Map) continue;
+      final occurredAt = _parseDate(event['created_at']);
+      if (occurredAt == null) continue;
+      final actor = _nested(event['actor'], 'login') ?? '';
+      final mine = self.isNotEmpty && self.contains(actor.trim().toLowerCase());
+      final eventId = _stringy(event['id']);
+      final payload = event['payload'];
+      final ghType = _str(event, 'type');
+      if (payload is! Map || ghType == null) continue;
+
+      switch (ghType) {
+        case 'PushEvent':
+          final branch = _branchFromRef(_str(payload, 'ref'));
+          final size = _int(payload['size']) ?? _int(payload['distinct_size']);
+          final commits = payload['commits'];
+          final count = size ?? (commits is List ? commits.length : null) ?? 0;
+          final noun = count == 1 ? 'commit' : 'commits';
+          final before = _str(payload, 'before');
+          final head = _str(payload, 'head');
+          final url = (before != null && head != null)
+              ? 'https://github.com/$repoDisplay/compare/$before...$head'
+              : 'https://github.com/$repoDisplay/commits/$branch';
+          result.add(
+            ActivityEvent(
+              id: 'gh-event:${eventId ?? '$repoKey:${occurredAt.toIso8601String()}'}',
+              type: ActivityType.push,
+              provider: 'github',
+              repoKey: repoKey,
+              repoDisplay: repoDisplay,
+              actor: actor,
+              title:
+                  '${actor.isEmpty ? 'Someone' : actor} pushed $count $noun to $branch',
+              subtitle: repoDisplay,
+              occurredAt: occurredAt,
+              url: url,
+              isMine: mine,
+            ),
+          );
+          break;
+        case 'PullRequestEvent':
+          final action = _str(payload, 'action');
+          final pr = payload['pull_request'];
+          if (pr is! Map) break;
+          final number = _stringy(pr['number']);
+          final prTitle = _str(pr, 'title') ?? 'Untitled PR';
+          final url = _str(pr, 'html_url');
+          String? type;
+          String verb;
+          if (action == 'opened' || action == 'reopened') {
+            type = ActivityType.prOpened;
+            verb = 'opened';
+          } else if (action == 'closed') {
+            final merged = pr['merged'] == true || pr['merged_at'] != null;
+            type = merged ? ActivityType.prMerged : ActivityType.prClosed;
+            verb = merged ? 'merged' : 'closed';
+          } else {
+            break; // ignore edited/labeled/synchronize/etc.
+          }
+          result.add(
+            ActivityEvent(
+              id: 'gh-event:${eventId ?? '$repoKey:pr$number:$verb'}',
+              type: type,
+              provider: 'github',
+              repoKey: repoKey,
+              repoDisplay: repoDisplay,
+              actor: actor,
+              title: '${actor.isEmpty ? 'Someone' : actor} $verb PR #$number',
+              subtitle: '$repoDisplay · $prTitle',
+              occurredAt: occurredAt,
+              url: url,
+              isMine: mine,
+            ),
+          );
+          break;
+        case 'PullRequestReviewEvent':
+          if (_str(payload, 'action') != 'submitted') break;
+          final pr = payload['pull_request'];
+          final review = payload['review'];
+          if (pr is! Map) break;
+          final number = _stringy(pr['number']);
+          final prTitle = _str(pr, 'title') ?? 'Untitled PR';
+          final state = review is Map ? _str(review, 'state') : null;
+          final verb = _reviewVerb(state);
+          final url =
+              (review is Map ? _str(review, 'html_url') : null) ??
+              _str(pr, 'html_url');
+          result.add(
+            ActivityEvent(
+              id: 'gh-event:${eventId ?? '$repoKey:review:pr$number'}',
+              type: ActivityType.reviewSubmitted,
+              provider: 'github',
+              repoKey: repoKey,
+              repoDisplay: repoDisplay,
+              actor: actor,
+              title: '${actor.isEmpty ? 'Someone' : actor} $verb PR #$number',
+              subtitle: '$repoDisplay · $prTitle',
+              occurredAt: occurredAt,
+              url: url,
+              isMine: mine,
+            ),
+          );
+          break;
+        case 'ReleaseEvent':
+          if (_str(payload, 'action') != 'published') break;
+          final release = payload['release'];
+          if (release is! Map) break;
+          final tag = _str(release, 'tag_name') ?? '';
+          final relName = _str(release, 'name');
+          final url = _str(release, 'html_url');
+          result.add(
+            ActivityEvent(
+              id: 'gh-event:${eventId ?? '$repoKey:release:$tag'}',
+              type: ActivityType.release,
+              provider: 'github',
+              repoKey: repoKey,
+              repoDisplay: repoDisplay,
+              actor: actor,
+              title:
+                  '${actor.isEmpty ? 'Someone' : actor} released ${tag.isEmpty ? (relName ?? 'a new version') : tag}',
+              subtitle: relName == null || relName.isEmpty
+                  ? repoDisplay
+                  : '$repoDisplay · $relName',
+              occurredAt: occurredAt,
+              url: url,
+              isMine: mine,
+            ),
+          );
+          break;
+        default:
+          break;
+      }
+    }
+    return result;
+  }
+
+  /// Normalizes a GitHub Actions `/actions/runs` response into CI-failure
+  /// events (completed runs whose conclusion indicates failure).
+  static List<ActivityEvent> githubRunsToActivity({
+    required String repoDisplay,
+    required String repoKey,
+    required dynamic body,
+    Set<String> selfGithubLogins = const {},
+  }) {
+    final self = selfGithubLogins.map((e) => e.trim().toLowerCase()).toSet();
+    final runs = body is Map ? body['workflow_runs'] : null;
+    if (runs is! List) return const [];
+    const failing = {'failure', 'timed_out', 'startup_failure'};
+    final result = <ActivityEvent>[];
+    for (final run in runs) {
+      if (run is! Map) continue;
+      if (_str(run, 'status') != 'completed') continue;
+      final conclusion = _str(run, 'conclusion');
+      if (conclusion == null || !failing.contains(conclusion)) continue;
+      final occurredAt =
+          _parseDate(run['updated_at']) ?? _parseDate(run['run_started_at']);
+      if (occurredAt == null) continue;
+      final name =
+          _str(run, 'name') ?? _str(run, 'display_title') ?? 'Workflow';
+      final branch = _str(run, 'head_branch');
+      final actor =
+          _nested(run['actor'], 'login') ??
+          _nested(run['triggering_actor'], 'login') ??
+          '';
+      final runId = _stringy(run['id']);
+      final mine = self.isNotEmpty && self.contains(actor.trim().toLowerCase());
+      result.add(
+        ActivityEvent(
+          id: 'gh-run:${runId ?? '$repoKey:${occurredAt.toIso8601String()}'}',
+          type: ActivityType.ciFailed,
+          provider: 'github',
+          repoKey: repoKey,
+          repoDisplay: repoDisplay,
+          actor: actor,
+          title: 'CI failed: $name${branch == null ? '' : ' on $branch'}',
+          subtitle: repoDisplay,
+          occurredAt: occurredAt,
+          url: _str(run, 'html_url'),
+          isMine: mine,
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// Normalizes an Azure DevOps pull-request list (`status=all`) into
+  /// opened/merged/closed events.
+  static List<ActivityEvent> adoPrsToActivity({
+    required String repoDisplay,
+    required String repoKey,
+    required String organization,
+    required String project,
+    required String name,
+    required List<dynamic> prs,
+    Set<String> selfAdoNames = const {},
+  }) {
+    final self = selfAdoNames.map((e) => e.trim().toLowerCase()).toSet();
+    final result = <ActivityEvent>[];
+    for (final pr in prs) {
+      if (pr is! Map) continue;
+      final id = _stringy(pr['pullRequestId']);
+      if (id == null) continue;
+      final title = _str(pr, 'title') ?? 'Untitled PR';
+      final opener = _nested(pr['createdBy'], 'displayName') ?? '';
+      final url =
+          'https://dev.azure.com/$organization/$project/_git/$name/'
+          'pullrequest/$id';
+
+      final opened = _parseDate(pr['creationDate']);
+      if (opened != null) {
+        result.add(
+          _adoPrEvent(
+            id: 'ado-pr:$repoKey:$id:opened',
+            type: ActivityType.prOpened,
+            repoKey: repoKey,
+            repoDisplay: repoDisplay,
+            actor: opener,
+            title: '${opener.isEmpty ? 'Someone' : opener} opened PR #$id',
+            subtitle: '$repoDisplay · $title',
+            occurredAt: opened,
+            url: url,
+            self: self,
+          ),
+        );
+      }
+
+      final status = _str(pr, 'status');
+      final closed = _parseDate(pr['closedDate']);
+      if (closed != null && (status == 'completed' || status == 'abandoned')) {
+        final merged = status == 'completed';
+        final actor = _nested(pr['closedBy'], 'displayName') ?? '';
+        result.add(
+          _adoPrEvent(
+            id: 'ado-pr:$repoKey:$id:${merged ? 'merged' : 'closed'}',
+            type: merged ? ActivityType.prMerged : ActivityType.prClosed,
+            repoKey: repoKey,
+            repoDisplay: repoDisplay,
+            actor: actor,
+            title:
+                '${actor.isEmpty ? 'Someone' : actor} ${merged ? 'completed' : 'abandoned'} PR #$id',
+            subtitle: '$repoDisplay · $title',
+            occurredAt: closed,
+            url: url,
+            self: self,
+          ),
+        );
+      }
+    }
+    return result;
+  }
+
+  /// Normalizes an Azure DevOps pushes response into push events.
+  static List<ActivityEvent> adoPushesToActivity({
+    required String repoDisplay,
+    required String repoKey,
+    required String organization,
+    required String project,
+    required String name,
+    required dynamic body,
+    Set<String> selfAdoNames = const {},
+  }) {
+    final self = selfAdoNames.map((e) => e.trim().toLowerCase()).toSet();
+    final pushes = body is Map ? body['value'] : body;
+    if (pushes is! List) return const [];
+    final result = <ActivityEvent>[];
+    for (final push in pushes) {
+      if (push is! Map) continue;
+      final pushId = _stringy(push['pushId']);
+      final occurredAt = _parseDate(push['date']);
+      if (occurredAt == null) continue;
+      final actor = _nested(push['pushedBy'], 'displayName') ?? '';
+      final refUpdates = push['refUpdates'];
+      String branch = '';
+      if (refUpdates is List && refUpdates.isNotEmpty) {
+        branch = _branchFromRef(_nested(refUpdates.first, 'name'));
+      }
+      final mine = self.isNotEmpty && self.contains(actor.trim().toLowerCase());
+      result.add(
+        ActivityEvent(
+          id: 'ado-push:$repoKey:${pushId ?? occurredAt.toIso8601String()}',
+          type: ActivityType.push,
+          provider: 'ado',
+          repoKey: repoKey,
+          repoDisplay: repoDisplay,
+          actor: actor,
+          title:
+              '${actor.isEmpty ? 'Someone' : actor} pushed${branch.isEmpty ? '' : ' to $branch'}',
+          subtitle: repoDisplay,
+          occurredAt: occurredAt,
+          url: pushId == null
+              ? null
+              : 'https://dev.azure.com/$organization/$project/_git/$name/'
+                    'pushes/$pushId',
+          isMine: mine,
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// Normalizes an Azure DevOps builds response into CI-failure events.
+  static List<ActivityEvent> adoBuildsToActivity({
+    required String repoDisplay,
+    required String repoKey,
+    required dynamic body,
+    Set<String> selfAdoNames = const {},
+  }) {
+    final self = selfAdoNames.map((e) => e.trim().toLowerCase()).toSet();
+    final builds = body is Map ? body['value'] : body;
+    if (builds is! List) return const [];
+    final result = <ActivityEvent>[];
+    for (final build in builds) {
+      if (build is! Map) continue;
+      if (_str(build, 'result') != 'failed') continue;
+      final occurredAt = _parseDate(build['finishTime']);
+      if (occurredAt == null) continue;
+      final buildId = _stringy(build['id']);
+      final defName = _nested(build['definition'], 'name') ?? 'Build';
+      final branch = _branchFromRef(_str(build, 'sourceBranch'));
+      final actor = _nested(build['requestedFor'], 'displayName') ?? '';
+      final url = _nested(_nested2(build['_links'], 'web'), 'href');
+      final mine = self.isNotEmpty && self.contains(actor.trim().toLowerCase());
+      result.add(
+        ActivityEvent(
+          id: 'ado-build:$repoKey:${buildId ?? occurredAt.toIso8601String()}',
+          type: ActivityType.ciFailed,
+          provider: 'ado',
+          repoKey: repoKey,
+          repoDisplay: repoDisplay,
+          actor: actor,
+          title: 'CI failed: $defName${branch.isEmpty ? '' : ' on $branch'}',
+          subtitle: repoDisplay,
+          occurredAt: occurredAt,
+          url: url,
+          isMine: mine,
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// Sorts newest-first, de-duplicates by id, and keeps only events at or after
+  /// [since] (capped at [maxEvents]).
+  static List<ActivityEvent> mergeAndWindow(
+    Iterable<ActivityEvent> events,
+    DateTime since,
+  ) {
+    final seen = <String>{};
+    final windowed = <ActivityEvent>[];
+    for (final event in events) {
+      if (event.occurredAt.isBefore(since)) continue;
+      if (!seen.add(event.id)) continue;
+      windowed.add(event);
+    }
+    windowed.sort((a, b) => b.occurredAt.compareTo(a.occurredAt));
+    if (windowed.length > maxEvents) {
+      return windowed.sublist(0, maxEvents);
+    }
+    return windowed;
+  }
+
+  // ---- Fetching ------------------------------------------------------------
+
+  /// Fetches, normalizes, and merges the activity feed across all monitored
+  /// repositories.
+  static Future<ActivityFeedResult> computeAll({
+    http.Client? client,
+    int concurrency = 5,
+    DateTime? now,
+    Duration lookback = defaultLookback,
+    Set<String> selfGithubLogins = const {},
+    Set<String> selfAdoNames = const {},
+  }) async {
+    final httpClient = client ?? http.Client();
+    final effectiveNow = (now ?? DateTime.now()).toUtc();
+    final since = effectiveNow.subtract(lookback);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final githubRepos =
+          prefs.getStringList(RepoStore.githubKey) ?? const <String>[];
+      final adoRepos =
+          prefs.getStringList(RepoStore.adoKey) ?? const <String>[];
+
+      final tasks = <Future<_FetchOutcome> Function()>[];
+
+      for (final raw in githubRepos) {
+        final map = _decode(raw);
+        if (map == null) continue;
+        final owner = _str(map, 'owner');
+        final name = _str(map, 'repoName');
+        if (owner == null || name == null) continue;
+        final tokenId = _str(map, 'tokenId');
+        tasks.add(
+          () => _githubRepoEvents(
+            httpClient,
+            owner,
+            name,
+            tokenId,
+            selfGithubLogins,
+          ),
+        );
+      }
+
+      for (final raw in adoRepos) {
+        final map = _decode(raw);
+        if (map == null) continue;
+        final organization = _str(map, 'organization');
+        final project = _str(map, 'project');
+        final name = _str(map, 'repoName');
+        if (organization == null || project == null || name == null) continue;
+        final tokenId = _str(map, 'tokenId');
+        tasks.add(
+          () => _adoRepoEvents(
+            httpClient,
+            organization,
+            project,
+            name,
+            tokenId,
+            selfAdoNames,
+          ),
+        );
+      }
+
+      final outcomes = await _runBounded(tasks, concurrency);
+      final combined = _FetchOutcome.merge(outcomes);
+      return ActivityFeedResult(
+        events: mergeAndWindow(combined.events, since),
+        failedSources: combined.failedCount,
+        truncated: combined.truncated,
+      );
+    } finally {
+      if (client == null) httpClient.close();
+    }
+  }
+
+  static Future<_FetchOutcome> _githubRepoEvents(
+    http.Client client,
+    String owner,
+    String name,
+    String? tokenId,
+    Set<String> selfGithubLogins,
+  ) async {
+    final repoDisplay = '$owner/$name';
+    final repoKey = RepoDiscoveryService.githubKey(owner, name);
+    final secret = (await TokenStore.resolveGithubSecret(
+      owner,
+      tokenId: tokenId,
+    ))?.trim();
+    if (secret == null || secret.isEmpty) {
+      return const _FetchOutcome(<ActivityEvent>[]);
+    }
+    final headers = {
+      'Authorization': 'Bearer $secret',
+      'Accept': 'application/vnd.github+json',
+    };
+
+    final events = await _guard('GitHub events', repoDisplay, () async {
+      final response = await client
+          .get(
+            Uri.https('api.github.com', '/repos/$owner/$name/events', {
+              'per_page': '100',
+            }),
+            headers: headers,
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode != 200) return _FetchOutcome.failure;
+      final body = jsonDecode(response.body);
+      if (body is! List) return const _FetchOutcome(<ActivityEvent>[]);
+      return _FetchOutcome(
+        githubEventsToActivity(
+          repoDisplay: repoDisplay,
+          repoKey: repoKey,
+          events: body,
+          selfGithubLogins: selfGithubLogins,
+        ),
+        truncated: body.length >= 100,
+      );
+    });
+
+    final runs = await _guard('GitHub runs', repoDisplay, () async {
+      final response = await client
+          .get(
+            Uri.https('api.github.com', '/repos/$owner/$name/actions/runs', {
+              'per_page': '30',
+            }),
+            headers: headers,
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode != 200) return _FetchOutcome.failure;
+      return _FetchOutcome(
+        githubRunsToActivity(
+          repoDisplay: repoDisplay,
+          repoKey: repoKey,
+          body: jsonDecode(response.body),
+          selfGithubLogins: selfGithubLogins,
+        ),
+      );
+    });
+
+    return _FetchOutcome.merge([events, runs]);
+  }
+
+  static Future<_FetchOutcome> _adoRepoEvents(
+    http.Client client,
+    String organization,
+    String project,
+    String name,
+    String? tokenId,
+    Set<String> selfAdoNames,
+  ) async {
+    final repoDisplay = '$organization/$project/$name';
+    final repoKey = RepoDiscoveryService.adoKey(organization, project, name);
+    final secret = (await TokenStore.resolveAdoSecret(
+      organization,
+      tokenId: tokenId,
+    ))?.trim();
+    if (secret == null || secret.isEmpty) {
+      return const _FetchOutcome(<ActivityEvent>[]);
+    }
+    final headers = {
+      'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
+    };
+
+    final prs = await _guard('ADO PRs', repoDisplay, () async {
+      final response = await client
+          .get(
+            Uri.https(
+              'dev.azure.com',
+              '/$organization/$project/_apis/git/repositories/$name/pullrequests',
+              {
+                'searchCriteria.status': 'all',
+                r'$top': '50',
+                'api-version': '6.0',
+              },
+            ),
+            headers: headers,
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode != 200) return _FetchOutcome.failure;
+      final body = jsonDecode(response.body);
+      final value = body is Map ? body['value'] : body;
+      if (value is! List) return const _FetchOutcome(<ActivityEvent>[]);
+      return _FetchOutcome(
+        adoPrsToActivity(
+          repoDisplay: repoDisplay,
+          repoKey: repoKey,
+          organization: organization,
+          project: project,
+          name: name,
+          prs: value,
+          selfAdoNames: selfAdoNames,
+        ),
+        truncated: value.length >= 50,
+      );
+    });
+
+    final pushes = await _guard('ADO pushes', repoDisplay, () async {
+      final response = await client
+          .get(
+            Uri.https(
+              'dev.azure.com',
+              '/$organization/$project/_apis/git/repositories/$name/pushes',
+              {r'$top': '30', 'api-version': '6.0'},
+            ),
+            headers: headers,
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode != 200) return _FetchOutcome.failure;
+      return _FetchOutcome(
+        adoPushesToActivity(
+          repoDisplay: repoDisplay,
+          repoKey: repoKey,
+          organization: organization,
+          project: project,
+          name: name,
+          body: jsonDecode(response.body),
+          selfAdoNames: selfAdoNames,
+        ),
+      );
+    });
+
+    final builds = await _guard('ADO builds', repoDisplay, () async {
+      // Builds are project-wide; scope CI failures to THIS repo by resolving
+      // its GUID first, otherwise we'd surface unrelated builds.
+      final repoResp = await client
+          .get(
+            Uri.https(
+              'dev.azure.com',
+              '/$organization/$project/_apis/git/repositories/$name',
+              {'api-version': '6.0'},
+            ),
+            headers: headers,
+          )
+          .timeout(_requestTimeout);
+      if (repoResp.statusCode != 200) return _FetchOutcome.failure;
+      final decoded = jsonDecode(repoResp.body);
+      final repositoryId = decoded is Map ? _str(decoded, 'id') : null;
+      if (repositoryId == null) return const _FetchOutcome(<ActivityEvent>[]);
+      final response = await client
+          .get(
+            Uri.https(
+              'dev.azure.com',
+              '/$organization/$project/_apis/build/builds',
+              {
+                'repositoryId': repositoryId,
+                'repositoryType': 'TfsGit',
+                'resultFilter': 'failed',
+                'statusFilter': 'completed',
+                r'$top': '30',
+                'api-version': '6.0',
+              },
+            ),
+            headers: headers,
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode != 200) return _FetchOutcome.failure;
+      return _FetchOutcome(
+        adoBuildsToActivity(
+          repoDisplay: repoDisplay,
+          repoKey: repoKey,
+          body: jsonDecode(response.body),
+          selfAdoNames: selfAdoNames,
+        ),
+      );
+    });
+
+    return _FetchOutcome.merge([prs, pushes, builds]);
+  }
+
+  // ---- Helpers -------------------------------------------------------------
+
+  static ActivityEvent _adoPrEvent({
+    required String id,
+    required String type,
+    required String repoKey,
+    required String repoDisplay,
+    required String actor,
+    required String title,
+    required String subtitle,
+    required DateTime occurredAt,
+    required String url,
+    required Set<String> self,
+  }) {
+    return ActivityEvent(
+      id: id,
+      type: type,
+      provider: 'ado',
+      repoKey: repoKey,
+      repoDisplay: repoDisplay,
+      actor: actor,
+      title: title,
+      subtitle: subtitle,
+      occurredAt: occurredAt,
+      url: url,
+      isMine: self.isNotEmpty && self.contains(actor.trim().toLowerCase()),
+    );
+  }
+
+  static String _reviewVerb(String? state) {
+    switch (state) {
+      case 'approved':
+        return 'approved';
+      case 'changes_requested':
+        return 'requested changes on';
+      case 'commented':
+      case 'dismissed':
+      default:
+        return 'reviewed';
+    }
+  }
+
+  static Future<_FetchOutcome> _guard(
+    String source,
+    String repoDisplay,
+    Future<_FetchOutcome> Function() action,
+  ) async {
+    try {
+      return await action();
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('ActivityFeedService: $source failed for $repoDisplay: $e');
+      }
+      return _FetchOutcome.failure;
+    }
+  }
+
+  static String _branchFromRef(String? ref) {
+    if (ref == null || ref.isEmpty) return '';
+    const prefixes = ['refs/heads/', 'refs/tags/'];
+    for (final prefix in prefixes) {
+      if (ref.startsWith(prefix)) return ref.substring(prefix.length);
+    }
+    return ref;
+  }
+
+  static DateTime? _parseDate(dynamic value) {
+    if (value is! String || value.isEmpty) return null;
+    final parsed = DateTime.tryParse(value);
+    return parsed?.toUtc();
+  }
+
+  static String? _str(Map map, String key) {
+    final value = map[key];
+    return value is String ? value : null;
+  }
+
+  static String? _nested(dynamic map, String key) =>
+      map is Map && map[key] is String ? map[key] as String : null;
+
+  static dynamic _nested2(dynamic map, String key) =>
+      map is Map ? map[key] : null;
+
+  static String? _stringy(dynamic value) {
+    if (value == null) return null;
+    if (value is String) return value.isEmpty ? null : value;
+    return value.toString();
+  }
+
+  static int? _int(dynamic value) {
+    if (value is int) return value;
+    if (value is String) return int.tryParse(value);
+    return null;
+  }
+
+  static Map<String, dynamic>? _decode(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      return decoded is Map ? Map<String, dynamic>.from(decoded) : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static Future<List<T>> _runBounded<T>(
+    List<Future<T> Function()> tasks,
+    int concurrency,
+  ) async {
+    if (tasks.isEmpty) return <T>[];
+    final results = <T>[];
+    var next = 0;
+    Future<void> worker() async {
+      while (true) {
+        final i = next++;
+        if (i >= tasks.length) break;
+        results.add(await tasks[i]());
+      }
+    }
+
+    final workerCount = concurrency.clamp(1, tasks.length);
+    await Future.wait(List.generate(workerCount, (_) => worker()));
+    return results;
+  }
+}
+
+/// Internal per-source fetch result: parsed events plus how many sources failed
+/// and whether any hit its page cap. Aggregated into [ActivityFeedResult].
+class _FetchOutcome {
+  const _FetchOutcome(
+    this.events, {
+    this.failedCount = 0,
+    this.truncated = false,
+  });
+
+  /// A single failed source (non-200 or thrown).
+  static const _FetchOutcome failure = _FetchOutcome(
+    <ActivityEvent>[],
+    failedCount: 1,
+  );
+
+  final List<ActivityEvent> events;
+  final int failedCount;
+  final bool truncated;
+
+  static _FetchOutcome merge(Iterable<_FetchOutcome> parts) {
+    final events = <ActivityEvent>[];
+    var failed = 0;
+    var truncated = false;
+    for (final part in parts) {
+      events.addAll(part.events);
+      failed += part.failedCount;
+      truncated = truncated || part.truncated;
+    }
+    return _FetchOutcome(events, failedCount: failed, truncated: truncated);
+  }
+}

--- a/lib/activity_feed_service.dart
+++ b/lib/activity_feed_service.dart
@@ -304,7 +304,8 @@ class ActivityFeedService {
             repoDisplay: repoDisplay,
             actor: actor,
             title:
-                '${actor.isEmpty ? 'Someone' : actor} ${merged ? 'completed' : 'abandoned'} PR #$id',
+                '${actor.isEmpty ? 'Someone' : actor} '
+                '${merged ? 'merged' : 'closed'} PR #$id',
             subtitle: '$repoDisplay · $title',
             occurredAt: closed,
             url: url,
@@ -556,13 +557,16 @@ class ActivityFeedService {
           )
           .timeout(_requestTimeout);
       if (response.statusCode != 200) return _FetchOutcome.failure;
+      final body = jsonDecode(response.body);
+      final runs = body is Map ? body['workflow_runs'] : null;
       return _FetchOutcome(
         githubRunsToActivity(
           repoDisplay: repoDisplay,
           repoKey: repoKey,
-          body: jsonDecode(response.body),
+          body: body,
           selfGithubLogins: selfGithubLogins,
         ),
+        truncated: runs is List && runs.length >= 30,
       );
     });
 
@@ -637,6 +641,8 @@ class ActivityFeedService {
           )
           .timeout(_requestTimeout);
       if (response.statusCode != 200) return _FetchOutcome.failure;
+      final body = jsonDecode(response.body);
+      final value = body is Map ? body['value'] : null;
       return _FetchOutcome(
         adoPushesToActivity(
           repoDisplay: repoDisplay,
@@ -644,9 +650,10 @@ class ActivityFeedService {
           organization: organization,
           project: project,
           name: name,
-          body: jsonDecode(response.body),
+          body: body,
           selfAdoNames: selfAdoNames,
         ),
+        truncated: value is List && value.length >= 30,
       );
     });
 
@@ -685,13 +692,16 @@ class ActivityFeedService {
           )
           .timeout(_requestTimeout);
       if (response.statusCode != 200) return _FetchOutcome.failure;
+      final body = jsonDecode(response.body);
+      final value = body is Map ? body['value'] : null;
       return _FetchOutcome(
         adoBuildsToActivity(
           repoDisplay: repoDisplay,
           repoKey: repoKey,
-          body: jsonDecode(response.body),
+          body: body,
           selfAdoNames: selfAdoNames,
         ),
+        truncated: value is List && value.length >= 30,
       );
     });
 

--- a/lib/activity_feed_service.dart
+++ b/lib/activity_feed_service.dart
@@ -761,7 +761,10 @@ class ActivityFeedService {
       if (date == null) continue;
       if (oldest == null || date.isBefore(oldest)) oldest = date;
     }
-    return oldest == null || !oldest.isBefore(since);
+    // Only assert truncation when provable: an unknown oldest date (all items
+    // unparseable) is treated as not truncated.
+    if (oldest == null) return false;
+    return !oldest.isBefore(since);
   }
 
   static ActivityEvent _adoPrEvent({

--- a/lib/activity_feed_service.dart
+++ b/lib/activity_feed_service.dart
@@ -112,8 +112,8 @@ class ActivityFeedService {
           final number = _stringy(pr['number']);
           final prTitle = _str(pr, 'title') ?? 'Untitled PR';
           final url = _str(pr, 'html_url');
-          String? type;
-          String verb;
+          final String type;
+          final String verb;
           if (action == 'opened' || action == 'reopened') {
             type = ActivityType.prOpened;
             verb = 'opened';
@@ -514,7 +514,9 @@ class ActivityFeedService {
       tokenId: tokenId,
     ))?.trim();
     if (secret == null || secret.isEmpty) {
-      return const _FetchOutcome(<ActivityEvent>[]);
+      // A configured repo with no resolvable token can't be loaded — surface it
+      // as a failed source rather than silent emptiness.
+      return _FetchOutcome.failure;
     }
     final headers = {
       'Authorization': 'Bearer $secret',
@@ -582,7 +584,9 @@ class ActivityFeedService {
       tokenId: tokenId,
     ))?.trim();
     if (secret == null || secret.isEmpty) {
-      return const _FetchOutcome(<ActivityEvent>[]);
+      // A configured repo with no resolvable token can't be loaded — surface it
+      // as a failed source rather than silent emptiness.
+      return _FetchOutcome.failure;
     }
     final headers = {
       'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'manage_repos_page.dart';
 import 'manage_tokens_page.dart';
 import 'radar_page.dart';
 import 'attention_inbox_page.dart';
+import 'activity_feed_page.dart';
 import 'people_page.dart';
 import 'teams_page.dart';
 import 'theme_controller.dart';
@@ -674,6 +675,16 @@ class _MyHomePageState extends State<MyHomePage>
               await Navigator.push(
                 context,
                 MaterialPageRoute(builder: (_) => const AttentionInboxPage()),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.dynamic_feed),
+            tooltip: 'Activity',
+            onPressed: () async {
+              await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const ActivityFeedPage()),
               );
             },
           ),

--- a/test/activity_feed_service_test.dart
+++ b/test/activity_feed_service_test.dart
@@ -1,0 +1,464 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:kode_radar/activity_event.dart';
+import 'package:kode_radar/activity_feed_service.dart';
+import 'package:kode_radar/token_store.dart';
+
+void main() {
+  const repoDisplay = 'acme/api';
+  const repoKey = 'github:acme/api';
+
+  group('githubEventsToActivity', () {
+    test('normalizes push, PR lifecycle, review, and release events', () {
+      final events = ActivityFeedService.githubEventsToActivity(
+        repoDisplay: repoDisplay,
+        repoKey: repoKey,
+        selfGithubLogins: {'octocat'},
+        events: [
+          {
+            'id': '1',
+            'type': 'PushEvent',
+            'actor': {'login': 'octocat'},
+            'created_at': '2026-07-14T10:00:00Z',
+            'payload': {
+              'ref': 'refs/heads/main',
+              'size': 3,
+              'before': 'aaa',
+              'head': 'bbb',
+            },
+          },
+          {
+            'id': '2',
+            'type': 'PullRequestEvent',
+            'actor': {'login': 'alice'},
+            'created_at': '2026-07-14T11:00:00Z',
+            'payload': {
+              'action': 'opened',
+              'pull_request': {
+                'number': 7,
+                'title': 'Add feature',
+                'html_url': 'https://github.com/acme/api/pull/7',
+              },
+            },
+          },
+          {
+            'id': '3',
+            'type': 'PullRequestEvent',
+            'actor': {'login': 'bob'},
+            'created_at': '2026-07-14T12:00:00Z',
+            'payload': {
+              'action': 'closed',
+              'pull_request': {
+                'number': 6,
+                'title': 'Old work',
+                'merged': true,
+                'html_url': 'https://github.com/acme/api/pull/6',
+              },
+            },
+          },
+          {
+            'id': '4',
+            'type': 'PullRequestReviewEvent',
+            'actor': {'login': 'carol'},
+            'created_at': '2026-07-14T13:00:00Z',
+            'payload': {
+              'action': 'submitted',
+              'review': {
+                'state': 'changes_requested',
+                'html_url': 'https://github.com/acme/api/pull/7#r1',
+              },
+              'pull_request': {'number': 7, 'title': 'Add feature'},
+            },
+          },
+          {
+            'id': '5',
+            'type': 'ReleaseEvent',
+            'actor': {'login': 'octocat'},
+            'created_at': '2026-07-14T14:00:00Z',
+            'payload': {
+              'action': 'published',
+              'release': {
+                'tag_name': 'v1.2.0',
+                'name': 'Big release',
+                'html_url': 'https://github.com/acme/api/releases/v1.2.0',
+              },
+            },
+          },
+          // Ignored: non-lifecycle PR action.
+          {
+            'id': '6',
+            'type': 'PullRequestEvent',
+            'actor': {'login': 'alice'},
+            'created_at': '2026-07-14T15:00:00Z',
+            'payload': {
+              'action': 'labeled',
+              'pull_request': {'number': 7, 'title': 'Add feature'},
+            },
+          },
+        ],
+      );
+
+      final byType = {for (final e in events) e.type: e};
+      expect(events, hasLength(5));
+      expect(
+        byType[ActivityType.push]!.title,
+        'octocat pushed 3 commits to main',
+      );
+      expect(byType[ActivityType.push]!.isMine, isTrue);
+      expect(
+        byType[ActivityType.push]!.url,
+        'https://github.com/acme/api/compare/aaa...bbb',
+      );
+      expect(byType[ActivityType.prOpened]!.title, 'alice opened PR #7');
+      expect(byType[ActivityType.prOpened]!.isMine, isFalse);
+      expect(byType[ActivityType.prMerged]!.title, 'bob merged PR #6');
+      expect(
+        byType[ActivityType.reviewSubmitted]!.title,
+        'carol requested changes on PR #7',
+      );
+      expect(byType[ActivityType.release]!.title, 'octocat released v1.2.0');
+      expect(byType[ActivityType.release]!.isMine, isTrue);
+    });
+
+    test('closed-but-unmerged PR is prClosed, not prMerged', () {
+      final events = ActivityFeedService.githubEventsToActivity(
+        repoDisplay: repoDisplay,
+        repoKey: repoKey,
+        events: [
+          {
+            'id': '9',
+            'type': 'PullRequestEvent',
+            'actor': {'login': 'alice'},
+            'created_at': '2026-07-14T12:00:00Z',
+            'payload': {
+              'action': 'closed',
+              'pull_request': {
+                'number': 8,
+                'title': 'Rejected',
+                'merged': false,
+              },
+            },
+          },
+        ],
+      );
+      expect(events.single.type, ActivityType.prClosed);
+      expect(events.single.title, 'alice closed PR #8');
+    });
+  });
+
+  group('githubRunsToActivity', () {
+    test('emits ciFailed only for completed failing runs', () {
+      final events = ActivityFeedService.githubRunsToActivity(
+        repoDisplay: repoDisplay,
+        repoKey: repoKey,
+        selfGithubLogins: {'octocat'},
+        body: {
+          'workflow_runs': [
+            {
+              'id': 101,
+              'name': 'CI',
+              'status': 'completed',
+              'conclusion': 'failure',
+              'head_branch': 'main',
+              'updated_at': '2026-07-14T09:00:00Z',
+              'html_url': 'https://github.com/acme/api/actions/runs/101',
+              'actor': {'login': 'octocat'},
+            },
+            {
+              'id': 102,
+              'status': 'completed',
+              'conclusion': 'success',
+              'updated_at': '2026-07-14T09:30:00Z',
+            },
+            {
+              'id': 103,
+              'status': 'in_progress',
+              'conclusion': null,
+              'updated_at': '2026-07-14T09:45:00Z',
+            },
+          ],
+        },
+      );
+      expect(events, hasLength(1));
+      expect(events.single.type, ActivityType.ciFailed);
+      expect(events.single.title, 'CI failed: CI on main');
+      expect(events.single.isMine, isTrue);
+    });
+  });
+
+  group('adoPrsToActivity', () {
+    test('produces opened + merged/abandoned events with deep links', () {
+      final events = ActivityFeedService.adoPrsToActivity(
+        repoDisplay: 'contoso/web/site',
+        repoKey: 'ado:contoso/web/site',
+        organization: 'contoso',
+        project: 'web',
+        name: 'site',
+        selfAdoNames: {'jane doe'},
+        prs: [
+          {
+            'pullRequestId': 12,
+            'title': 'Feature',
+            'status': 'completed',
+            'creationDate': '2026-07-13T08:00:00Z',
+            'closedDate': '2026-07-14T08:00:00Z',
+            'createdBy': {'displayName': 'Jane Doe'},
+            'closedBy': {'displayName': 'Jane Doe'},
+          },
+          {
+            'pullRequestId': 13,
+            'title': 'Dropped',
+            'status': 'abandoned',
+            'creationDate': '2026-07-13T09:00:00Z',
+            'closedDate': '2026-07-14T09:00:00Z',
+            'createdBy': {'displayName': 'Sam'},
+          },
+        ],
+      );
+
+      final types = events.map((e) => e.type).toList();
+      expect(types, contains(ActivityType.prOpened));
+      expect(types, contains(ActivityType.prMerged));
+      expect(types, contains(ActivityType.prClosed));
+      final merged = events.firstWhere((e) => e.type == ActivityType.prMerged);
+      expect(
+        merged.url,
+        'https://dev.azure.com/contoso/web/_git/site/pullrequest/12',
+      );
+      expect(merged.isMine, isTrue);
+    });
+  });
+
+  group('adoPushesToActivity and adoBuildsToActivity', () {
+    test('push events carry the branch', () {
+      final events = ActivityFeedService.adoPushesToActivity(
+        repoDisplay: 'contoso/web/site',
+        repoKey: 'ado:contoso/web/site',
+        organization: 'contoso',
+        project: 'web',
+        name: 'site',
+        body: {
+          'value': [
+            {
+              'pushId': 5,
+              'date': '2026-07-14T07:00:00Z',
+              'pushedBy': {'displayName': 'Jane Doe'},
+              'refUpdates': [
+                {'name': 'refs/heads/main'},
+              ],
+            },
+          ],
+        },
+      );
+      expect(events.single.type, ActivityType.push);
+      expect(events.single.title, 'Jane Doe pushed to main');
+    });
+
+    test('only failed builds become ciFailed', () {
+      final events = ActivityFeedService.adoBuildsToActivity(
+        repoDisplay: 'contoso/web/site',
+        repoKey: 'ado:contoso/web/site',
+        body: {
+          'value': [
+            {
+              'id': 1,
+              'result': 'failed',
+              'finishTime': '2026-07-14T06:00:00Z',
+              'definition': {'name': 'Nightly'},
+              'sourceBranch': 'refs/heads/main',
+              'requestedFor': {'displayName': 'Jane Doe'},
+              '_links': {
+                'web': {'href': 'https://dev.azure.com/contoso/web/_build/1'},
+              },
+            },
+            {
+              'id': 2,
+              'result': 'succeeded',
+              'finishTime': '2026-07-14T06:30:00Z',
+            },
+          ],
+        },
+      );
+      expect(events, hasLength(1));
+      expect(events.single.type, ActivityType.ciFailed);
+      expect(events.single.title, 'CI failed: Nightly on main');
+      expect(events.single.url, 'https://dev.azure.com/contoso/web/_build/1');
+    });
+  });
+
+  group('mergeAndWindow', () {
+    test('drops old events, dedupes by id, and sorts newest-first', () {
+      final since = DateTime.parse('2026-07-01T00:00:00Z');
+      ActivityEvent make(String id, String iso) => ActivityEvent(
+        id: id,
+        type: ActivityType.push,
+        provider: 'github',
+        repoKey: repoKey,
+        repoDisplay: repoDisplay,
+        actor: 'octocat',
+        title: 't',
+        subtitle: 's',
+        occurredAt: DateTime.parse(iso),
+      );
+
+      final merged = ActivityFeedService.mergeAndWindow([
+        make('a', '2026-07-10T00:00:00Z'),
+        make('b', '2026-07-12T00:00:00Z'),
+        make('a', '2026-07-10T00:00:00Z'), // duplicate id
+        make('old', '2026-06-01T00:00:00Z'), // before window
+      ], since);
+
+      expect(merged.map((e) => e.id).toList(), ['b', 'a']);
+    });
+  });
+
+  group('computeAll', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      FlutterSecureStorage.setMockInitialValues({});
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('merges GitHub + ADO sources and windows to the lookback', () async {
+      final gh = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Acme',
+        scope: 'acme',
+        secret: 'ghp_secret',
+      );
+      final ado = await TokenStore.addToken(
+        provider: TokenStore.providerAdo,
+        label: 'Contoso',
+        scope: 'contoso',
+        secret: 'ado_secret',
+      );
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList('github_repos', [
+        jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': gh.id}),
+      ]);
+      await prefs.setStringList('ado_repos', [
+        jsonEncode({
+          'organization': 'contoso',
+          'project': 'web',
+          'repoName': 'site',
+          'tokenId': ado.id,
+        }),
+      ]);
+
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (path == '/repos/acme/api/events') {
+          return http.Response(
+            jsonEncode([
+              {
+                'id': '1',
+                'type': 'PullRequestEvent',
+                'actor': {'login': 'alice'},
+                'created_at': '2026-07-14T11:00:00Z',
+                'payload': {
+                  'action': 'opened',
+                  'pull_request': {'number': 7, 'title': 'Feat'},
+                },
+              },
+              // Outside the 14-day window relative to the injected clock.
+              {
+                'id': '2',
+                'type': 'PushEvent',
+                'actor': {'login': 'alice'},
+                'created_at': '2026-06-01T00:00:00Z',
+                'payload': {'ref': 'refs/heads/main', 'size': 1},
+              },
+            ]),
+            200,
+          );
+        }
+        if (path == '/repos/acme/api/actions/runs') {
+          return http.Response(jsonEncode({'workflow_runs': []}), 200);
+        }
+        if (path == '/contoso/web/_apis/git/repositories/site/pullrequests') {
+          return http.Response(
+            jsonEncode({
+              'value': [
+                {
+                  'pullRequestId': 12,
+                  'title': 'Ship',
+                  'status': 'completed',
+                  'creationDate': '2026-07-13T08:00:00Z',
+                  'closedDate': '2026-07-14T08:00:00Z',
+                  'createdBy': {'displayName': 'Jane Doe'},
+                },
+              ],
+            }),
+            200,
+          );
+        }
+        if (path == '/contoso/web/_apis/git/repositories/site/pushes') {
+          return http.Response(jsonEncode({'value': []}), 200);
+        }
+        if (path == '/contoso/web/_apis/git/repositories/site') {
+          return http.Response(jsonEncode({'id': 'guid-1'}), 200);
+        }
+        if (path == '/contoso/web/_apis/build/builds') {
+          return http.Response(jsonEncode({'value': []}), 200);
+        }
+        return http.Response('{}', 404);
+      });
+
+      final result = await ActivityFeedService.computeAll(
+        client: client,
+        now: DateTime.parse('2026-07-15T12:00:00Z'),
+      );
+      final events = result.events;
+
+      // The June push is windowed out; GitHub PR-opened + ADO PR opened/merged
+      // remain (3 events), newest-first.
+      expect(result.failedSources, 0);
+      expect(events, hasLength(3));
+      expect(events.any((e) => e.provider == 'github'), isTrue);
+      expect(events.any((e) => e.provider == 'ado'), isTrue);
+      expect(events.every((e) => e.occurredAt.year == 2026), isTrue);
+      expect(events.any((e) => e.type == ActivityType.push), isFalse);
+      // Sorted strictly newest-first.
+      for (var i = 1; i < events.length; i++) {
+        expect(
+          events[i - 1].occurredAt.isBefore(events[i].occurredAt),
+          isFalse,
+        );
+      }
+    });
+
+    test('reports failedSources when a source errors', () async {
+      final gh = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Acme',
+        scope: 'acme',
+        secret: 'ghp_secret',
+      );
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList('github_repos', [
+        jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': gh.id}),
+      ]);
+
+      final client = MockClient((request) async {
+        if (request.url.path == '/repos/acme/api/events') {
+          return http.Response('forbidden', 403);
+        }
+        // Actions runs succeed but are empty.
+        return http.Response(jsonEncode({'workflow_runs': []}), 200);
+      });
+
+      final result = await ActivityFeedService.computeAll(
+        client: client,
+        now: DateTime.parse('2026-07-15T12:00:00Z'),
+      );
+
+      expect(result.events, isEmpty);
+      expect(result.failedSources, greaterThanOrEqualTo(1));
+    });
+  });
+}

--- a/test/activity_feed_service_test.dart
+++ b/test/activity_feed_service_test.dart
@@ -149,6 +149,28 @@ void main() {
       expect(events.single.type, ActivityType.prClosed);
       expect(events.single.title, 'alice closed PR #8');
     });
+
+    test(
+      'push with a missing ref omits the branch suffix and trailing slash',
+      () {
+        final events = ActivityFeedService.githubEventsToActivity(
+          repoDisplay: repoDisplay,
+          repoKey: repoKey,
+          events: [
+            {
+              'id': '10',
+              'type': 'PushEvent',
+              'actor': {'login': 'alice'},
+              'created_at': '2026-07-14T10:00:00Z',
+              'payload': {'size': 2},
+            },
+          ],
+        );
+        expect(events.single.type, ActivityType.push);
+        expect(events.single.title, 'alice pushed 2 commits');
+        expect(events.single.url, 'https://github.com/acme/api/commits');
+      },
+    );
   });
 
   group('githubRunsToActivity', () {

--- a/test/activity_feed_service_test.dart
+++ b/test/activity_feed_service_test.dart
@@ -499,5 +499,83 @@ void main() {
       expect(result.events, isEmpty);
       expect(result.failedSources, greaterThanOrEqualTo(1));
     });
+
+    test('flags truncated when a full page stays within the window', () async {
+      final gh = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Acme',
+        scope: 'acme',
+        secret: 'ghp_secret',
+      );
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList('github_repos', [
+        jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': gh.id}),
+      ]);
+      // A full page (100) of in-window events => older ones may be omitted.
+      final fullPage = List.generate(
+        100,
+        (i) => {
+          'id': '$i',
+          'type': 'PushEvent',
+          'actor': {'login': 'alice'},
+          'created_at': '2026-07-14T10:00:00Z',
+          'payload': {'ref': 'refs/heads/main', 'size': 1},
+        },
+      );
+      final client = MockClient((request) async {
+        if (request.url.path == '/repos/acme/api/events') {
+          return http.Response(jsonEncode(fullPage), 200);
+        }
+        return http.Response(jsonEncode({'workflow_runs': []}), 200);
+      });
+
+      final result = await ActivityFeedService.computeAll(
+        client: client,
+        now: DateTime.parse('2026-07-15T12:00:00Z'),
+      );
+      expect(result.truncated, isTrue);
+    });
+
+    test(
+      'no truncation when the full page already predates the window',
+      () async {
+        final gh = await TokenStore.addToken(
+          provider: TokenStore.providerGithub,
+          label: 'Acme',
+          scope: 'acme',
+          secret: 'ghp_secret',
+        );
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setStringList('github_repos', [
+          jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': gh.id}),
+        ]);
+        // A full page whose oldest event predates `since` fully covers the
+        // window, so nothing in-window was omitted.
+        final fullPage = List.generate(
+          100,
+          (i) => {
+            'id': '$i',
+            'type': 'PushEvent',
+            'actor': {'login': 'alice'},
+            'created_at': i == 99
+                ? '2026-06-01T10:00:00Z'
+                : '2026-07-14T10:00:00Z',
+            'payload': {'ref': 'refs/heads/main', 'size': 1},
+          },
+        );
+        final client = MockClient((request) async {
+          if (request.url.path == '/repos/acme/api/events') {
+            return http.Response(jsonEncode(fullPage), 200);
+          }
+          return http.Response(jsonEncode({'workflow_runs': []}), 200);
+        });
+
+        final result = await ActivityFeedService.computeAll(
+          client: client,
+          now: DateTime.parse('2026-07-15T12:00:00Z'),
+        );
+        expect(result.truncated, isFalse);
+      },
+    );
   });
 }

--- a/test/activity_feed_service_test.dart
+++ b/test/activity_feed_service_test.dart
@@ -482,5 +482,22 @@ void main() {
       expect(result.events, isEmpty);
       expect(result.failedSources, greaterThanOrEqualTo(1));
     });
+
+    test('counts a repo with no resolvable token as a failed source', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList('github_repos', [
+        jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': 'missing'}),
+      ]);
+      // No tokens added, so the secret can't be resolved and no request runs.
+      final client = MockClient((_) async => http.Response('{}', 200));
+
+      final result = await ActivityFeedService.computeAll(
+        client: client,
+        now: DateTime.parse('2026-07-15T12:00:00Z'),
+      );
+
+      expect(result.events, isEmpty);
+      expect(result.failedSources, greaterThanOrEqualTo(1));
+    });
   });
 }

--- a/test/activity_feed_service_test.dart
+++ b/test/activity_feed_service_test.dart
@@ -211,6 +211,26 @@ void main() {
       expect(events.single.title, 'CI failed: CI on main');
       expect(events.single.isMine, isTrue);
     });
+
+    test('omits the branch suffix when head_branch is empty', () {
+      final events = ActivityFeedService.githubRunsToActivity(
+        repoDisplay: repoDisplay,
+        repoKey: repoKey,
+        body: {
+          'workflow_runs': [
+            {
+              'id': 201,
+              'name': 'CI',
+              'status': 'completed',
+              'conclusion': 'failure',
+              'head_branch': '',
+              'updated_at': '2026-07-14T09:00:00Z',
+            },
+          ],
+        },
+      );
+      expect(events.single.title, 'CI failed: CI');
+    });
   });
 
   group('adoPrsToActivity', () {


### PR DESCRIPTION
## What

Adds an **Activity Feed** — a reverse-chronological, provider-agnostic stream of activity across all monitored repos, reached via a new **Activity** AppBar action (next to Attention).

- **Events:** PR opened / merged / closed, review submitted (approved / changes-requested / commented), push, release, CI-failed.
- **Sources:** GitHub `/events` + Actions `/actions/runs`; Azure DevOps PRs (`status=all`) + pushes + repo-scoped failed builds — all normalized to one `ActivityEvent`.
- **`lib/activity_feed_service.dart`:** pure per-source normalizers + `computeAll()` fanning out with bounded concurrency through the shared ETag-caching client (`AppHttp.client`); per-source failures isolated; de-duped by id; windowed to 14 days; returns `ActivityFeedResult{events, failedSources, truncated}`.
- **`lib/activity_feed_page.dart`:** day-grouped list (Today / Yesterday / date), filter chips (PRs / Reviews / CI / Releases / Pushes), team dropdown, "Mine" toggle, pull-to-refresh, tap-to-open, and a partial/truncation notice so failed sources aren't mistaken for "no activity".

## Notes

- Single-page fetch per source (100 GitHub events / 50 ADO PRs / 30 runs/pushes/builds) over a 14-day window; busy repos surface the truncation notice rather than full pagination (a possible follow-up).
- GitHub `/events` only exposes activity the token can read; inaccessible sources are counted in `failedSources` and shown in the notice.

## Validation

`flutter analyze --fatal-infos` clean, `dart format` clean, **94 tests pass** (9 new). Reviewed with code-review + rubber-duck; their feedback (silent-failure surfacing, ADO closedBy attribution, DST-safe day headers, concurrent-load guard) is already implemented. Deployed to device for hands-on testing.
