### PR TITLE
Person & Team detail drill-downs

### DIFF
--- a/lib/activity_event_list.dart
+++ b/lib/activity_event_list.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'activity_event.dart';
+
+/// Relative "…ago" label shared by the feed and detail views.
+String activityRelativeTime(DateTime value) {
+  final diff = DateTime.now().difference(value);
+  if (diff.isNegative || diff.inSeconds < 45) return 'just now';
+  if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+  if (diff.inHours < 24) return '${diff.inHours}h ago';
+  return '${diff.inDays}d ago';
+}
+
+/// A compact amber notice shown when some feed sources failed to load or the
+/// page was truncated. Returns null when there is nothing to warn about, so
+/// callers can conditionally include it. Shared by the feed and detail views.
+Widget? activitySourceNotice({
+  required int failedSources,
+  bool truncated = false,
+}) {
+  if (failedSources <= 0 && !truncated) return null;
+  final parts = <String>[];
+  if (failedSources > 0) {
+    parts.add(
+      '$failedSources source${failedSources == 1 ? '' : 's'} '
+      'couldn\'t be loaded',
+    );
+  }
+  if (truncated) parts.add('older items may be omitted');
+  // Retrying only helps when a source actually failed.
+  final suffix = failedSources > 0 ? ' Pull to retry.' : '';
+  return Container(
+    width: double.infinity,
+    color: Colors.amber.shade100,
+    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+    child: Row(
+      children: [
+        Icon(Icons.info_outline, size: 16, color: Colors.amber.shade900),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            '${parts.join(' · ')}.$suffix',
+            style: TextStyle(fontSize: 12, color: Colors.amber.shade900),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+/// A reverse-chronological, day-grouped list of [ActivityEvent]s with
+/// tap-to-open behaviour. Shared by the Activity Feed and the Person/Team
+/// detail views so event rendering stays consistent.
+///
+/// The caller supplies an already-filtered, already-sorted (newest-first) list
+/// and typically wraps this in a `RefreshIndicator`.
+class ActivityEventList extends StatelessWidget {
+  const ActivityEventList({
+    super.key,
+    required this.events,
+    this.padding = EdgeInsets.zero,
+  });
+
+  final List<ActivityEvent> events;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = _buildRows(events);
+    return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: padding,
+      itemCount: rows.length,
+      itemBuilder: (context, index) {
+        final row = rows[index];
+        if (row.header != null) return _dayHeader(row.header!);
+        return _eventTile(context, row.event!);
+      },
+    );
+  }
+
+  List<_Row> _buildRows(List<ActivityEvent> events) {
+    final rows = <_Row>[];
+    String? currentDay;
+    for (final event in events) {
+      final day = _dayLabel(event.occurredAt.toLocal());
+      if (day != currentDay) {
+        currentDay = day;
+        rows.add(_Row.header(day));
+      }
+      rows.add(_Row.event(event));
+    }
+    return rows;
+  }
+
+  Widget _dayHeader(String label) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
+      child: Builder(
+        builder: (context) => Text(
+          label,
+          style: TextStyle(
+            color: Colors.grey[600],
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _eventTile(BuildContext context, ActivityEvent event) {
+    final visual = _visualFor(event.type);
+    return ListTile(
+      leading: Icon(visual.icon, color: visual.color),
+      title: Text(event.title),
+      subtitle: Text(
+        '${event.subtitle} · ${activityRelativeTime(event.occurredAt.toLocal())}',
+      ),
+      trailing: event.url != null
+          ? const Icon(Icons.open_in_new, size: 16)
+          : null,
+      onTap: event.url == null ? null : () => _open(context, event.url!),
+    );
+  }
+
+  ({IconData icon, Color color}) _visualFor(String type) {
+    switch (type) {
+      case ActivityType.prOpened:
+        return (icon: Icons.merge_type, color: Colors.green);
+      case ActivityType.prMerged:
+        return (icon: Icons.merge, color: Colors.purple);
+      case ActivityType.prClosed:
+        return (icon: Icons.cancel_outlined, color: Colors.blueGrey);
+      case ActivityType.reviewSubmitted:
+        return (icon: Icons.rate_review, color: Colors.orange);
+      case ActivityType.push:
+        return (icon: Icons.commit, color: Colors.blue);
+      case ActivityType.release:
+        return (icon: Icons.rocket_launch, color: Colors.teal);
+      case ActivityType.ciFailed:
+        return (icon: Icons.error_outline, color: Colors.red);
+      default:
+        return (icon: Icons.circle_notifications, color: Colors.grey);
+    }
+  }
+
+  /// "Today" / "Yesterday" / "Mon, Jul 14". Uses UTC-midnight anchors so
+  /// calendar-day math stays exact across DST transitions.
+  String _dayLabel(DateTime local) {
+    final now = DateTime.now();
+    final today = DateTime.utc(now.year, now.month, now.day);
+    final that = DateTime.utc(local.year, local.month, local.day);
+    final diff = today.difference(that).inDays;
+    if (diff == 0) return 'Today';
+    if (diff == 1) return 'Yesterday';
+    const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    final weekday = weekdays[local.weekday - 1];
+    final month = months[local.month - 1];
+    return '$weekday, $month ${local.day}';
+  }
+
+  Future<void> _open(BuildContext context, String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      _showOpenError(context, url);
+      return;
+    }
+    final canLaunch = await canLaunchUrl(uri);
+    if (!context.mounted) return;
+    if (!canLaunch) {
+      _showOpenError(context, url);
+      return;
+    }
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!context.mounted) return;
+    if (!launched) _showOpenError(context, url);
+  }
+
+  void _showOpenError(BuildContext context, String url) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Could not open $url')));
+  }
+}
+
+/// A row in the flattened list: either a day header or an event.
+class _Row {
+  const _Row.header(this.header) : event = null;
+  const _Row.event(this.event) : header = null;
+
+  final String? header;
+  final ActivityEvent? event;
+}

--- a/lib/activity_event_list.dart
+++ b/lib/activity_event_list.dart
@@ -13,13 +13,13 @@ String activityRelativeTime(DateTime value) {
 }
 
 /// A compact amber notice shown when some feed sources failed to load or the
-/// page was truncated. Returns null when there is nothing to warn about, so
-/// callers can conditionally include it. Shared by the feed and detail views.
-Widget? activitySourceNotice({
+/// page was truncated. Returns an empty widget when there is nothing to warn
+/// about. Shared by the feed and detail views.
+Widget activitySourceNotice({
   required int failedSources,
   bool truncated = false,
 }) {
-  if (failedSources <= 0 && !truncated) return null;
+  if (failedSources <= 0 && !truncated) return const SizedBox.shrink();
   final parts = <String>[];
   if (failedSources > 0) {
     parts.add(

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -131,7 +131,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
           _buildFilterBar(),
           const Divider(height: 1),
           if (!_loading && _error == null)
-            ?activitySourceNotice(
+            activitySourceNotice(
               failedSources: _failedSources,
               truncated: _truncated,
             ),

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'activity_event.dart';
+import 'activity_event_list.dart';
 import 'activity_feed_service.dart';
 import 'app_http.dart';
 import 'identity_store.dart';
@@ -130,43 +130,15 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
         children: [
           _buildFilterBar(),
           const Divider(height: 1),
-          if (!_loading && _error == null && (_failedSources > 0 || _truncated))
-            _buildNotice(),
+          if (!_loading && _error == null)
+            ?activitySourceNotice(
+              failedSources: _failedSources,
+              truncated: _truncated,
+            ),
           Expanded(
             child: _loading
                 ? const Center(child: CircularProgressIndicator())
                 : RefreshIndicator(onRefresh: _load, child: _buildContent()),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildNotice() {
-    final parts = <String>[];
-    if (_failedSources > 0) {
-      parts.add(
-        '$_failedSources source${_failedSources == 1 ? '' : 's'} '
-        'couldn\'t be loaded',
-      );
-    }
-    if (_truncated) parts.add('older items may be omitted');
-    // Retrying only helps when a source actually failed; truncation won't
-    // change on refresh.
-    final suffix = _failedSources > 0 ? ' Pull to retry.' : '';
-    return Container(
-      width: double.infinity,
-      color: Colors.amber.shade100,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Row(
-        children: [
-          Icon(Icons.info_outline, size: 16, color: Colors.amber.shade900),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              '${parts.join(' · ')}.$suffix',
-              style: TextStyle(fontSize: 12, color: Colors.amber.shade900),
-            ),
           ),
         ],
       ),
@@ -255,16 +227,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
     final visible = _visibleEvents;
     if (visible.isEmpty) return _buildEmptyState();
 
-    final rows = _buildRows(visible);
-    return ListView.builder(
-      physics: const AlwaysScrollableScrollPhysics(),
-      itemCount: rows.length,
-      itemBuilder: (context, index) {
-        final row = rows[index];
-        if (row.header != null) return _buildDayHeader(row.header!);
-        return _buildEventTile(row.event!);
-      },
-    );
+    return ActivityEventList(events: visible);
   }
 
   Widget _buildEmptyState() {
@@ -291,146 +254,11 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
           child: Text(
             _lastChecked == null
                 ? 'Pull down to refresh.'
-                : 'Checked ${_relativeTime(_lastChecked!)} · pull down to refresh.',
+                : 'Checked ${activityRelativeTime(_lastChecked!)} · pull down to refresh.',
             style: TextStyle(color: Colors.grey[600], fontSize: 12),
           ),
         ),
       ],
     );
   }
-
-  List<_FeedRow> _buildRows(List<ActivityEvent> events) {
-    final rows = <_FeedRow>[];
-    String? currentDay;
-    for (final event in events) {
-      final day = _dayLabel(event.occurredAt.toLocal());
-      if (day != currentDay) {
-        currentDay = day;
-        rows.add(_FeedRow.header(day));
-      }
-      rows.add(_FeedRow.event(event));
-    }
-    return rows;
-  }
-
-  Widget _buildDayHeader(String label) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
-      child: Text(
-        label,
-        style: TextStyle(
-          color: Colors.grey[600],
-          fontSize: 12,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildEventTile(ActivityEvent event) {
-    final visual = _visualFor(event.type);
-    return ListTile(
-      leading: Icon(visual.icon, color: visual.color),
-      title: Text(event.title),
-      subtitle: Text(
-        '${event.subtitle} · ${_relativeTime(event.occurredAt.toLocal())}',
-      ),
-      trailing: event.url != null
-          ? const Icon(Icons.open_in_new, size: 16)
-          : null,
-      onTap: event.url == null ? null : () => _open(event.url!),
-    );
-  }
-
-  ({IconData icon, Color color}) _visualFor(String type) {
-    switch (type) {
-      case ActivityType.prOpened:
-        return (icon: Icons.merge_type, color: Colors.green);
-      case ActivityType.prMerged:
-        return (icon: Icons.merge, color: Colors.purple);
-      case ActivityType.prClosed:
-        return (icon: Icons.cancel_outlined, color: Colors.blueGrey);
-      case ActivityType.reviewSubmitted:
-        return (icon: Icons.rate_review, color: Colors.orange);
-      case ActivityType.push:
-        return (icon: Icons.commit, color: Colors.blue);
-      case ActivityType.release:
-        return (icon: Icons.rocket_launch, color: Colors.teal);
-      case ActivityType.ciFailed:
-        return (icon: Icons.error_outline, color: Colors.red);
-      default:
-        return (icon: Icons.circle_notifications, color: Colors.grey);
-    }
-  }
-
-  /// "Today" / "Yesterday" / "Mon, Jul 14".
-  String _dayLabel(DateTime local) {
-    final now = DateTime.now();
-    // Compare via UTC-midnight anchors so calendar-day math stays exact across
-    // DST transitions (local midnights can be 23/25h apart).
-    final today = DateTime.utc(now.year, now.month, now.day);
-    final that = DateTime.utc(local.year, local.month, local.day);
-    final diff = today.difference(that).inDays;
-    if (diff == 0) return 'Today';
-    if (diff == 1) return 'Yesterday';
-    const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-    const months = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    final weekday = weekdays[local.weekday - 1];
-    final month = months[local.month - 1];
-    return '$weekday, $month ${local.day}';
-  }
-
-  String _relativeTime(DateTime value) {
-    final diff = DateTime.now().difference(value);
-    if (diff.isNegative) return 'just now';
-    if (diff.inSeconds < 45) return 'just now';
-    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
-    if (diff.inHours < 24) return '${diff.inHours}h ago';
-    return '${diff.inDays}d ago';
-  }
-
-  Future<void> _open(String url) async {
-    final uri = Uri.tryParse(url);
-    if (uri == null) {
-      _showOpenError(url);
-      return;
-    }
-    final canLaunch = await canLaunchUrl(uri);
-    if (!mounted) return;
-    if (!canLaunch) {
-      _showOpenError(url);
-      return;
-    }
-    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
-    if (!mounted) return;
-    if (!launched) _showOpenError(url);
-  }
-
-  void _showOpenError(String url) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text('Could not open $url')));
-  }
-}
-
-/// A row in the flattened feed: either a day header or an event.
-class _FeedRow {
-  const _FeedRow.header(this.header) : event = null;
-  const _FeedRow.event(this.event) : header = null;
-
-  final String? header;
-  final ActivityEvent? event;
 }

--- a/lib/activity_feed_service.dart
+++ b/lib/activity_feed_service.dart
@@ -410,6 +410,34 @@ class ActivityFeedService {
     return result;
   }
 
+  /// Filters [events] to those authored by a person with the given provider
+  /// identities (GitHub logins matched case-insensitively; ADO display names
+  /// matched case-insensitively/trimmed).
+  static List<ActivityEvent> eventsForActor(
+    List<ActivityEvent> events, {
+    Set<String> githubLogins = const {},
+    Set<String> adoNames = const {},
+  }) {
+    final gh = githubLogins.map((e) => e.trim().toLowerCase()).toSet();
+    final ado = adoNames.map((e) => e.trim().toLowerCase()).toSet();
+    return events.where((event) {
+      final actor = event.actor.trim().toLowerCase();
+      if (actor.isEmpty) return false;
+      if (event.provider == 'github') return gh.contains(actor);
+      if (event.provider == 'ado') return ado.contains(actor);
+      return false;
+    }).toList();
+  }
+
+  /// Filters [events] to those in any of the given repository [repoKeys].
+  static List<ActivityEvent> eventsForRepoKeys(
+    List<ActivityEvent> events,
+    Set<String> repoKeys,
+  ) {
+    if (repoKeys.isEmpty) return const [];
+    return events.where((event) => repoKeys.contains(event.repoKey)).toList();
+  }
+
   /// Sorts newest-first, de-duplicates by id, and keeps only events at or after
   /// [since] (capped at [maxEvents]).
   static List<ActivityEvent> mergeAndWindow(
@@ -441,6 +469,9 @@ class ActivityFeedService {
     Duration lookback = defaultLookback,
     Set<String> selfGithubLogins = const {},
     Set<String> selfAdoNames = const {},
+    Set<String>? onlyRepoKeys,
+    Set<String> actorGithubLogins = const {},
+    Set<String> actorAdoNames = const {},
   }) async {
     final httpClient = client ?? http.Client();
     final effectiveNow = (now ?? DateTime.now()).toUtc();
@@ -460,6 +491,12 @@ class ActivityFeedService {
         final owner = _str(map, 'owner');
         final name = _str(map, 'repoName');
         if (owner == null || name == null) continue;
+        if (onlyRepoKeys != null &&
+            !onlyRepoKeys.contains(
+              RepoDiscoveryService.githubKey(owner, name),
+            )) {
+          continue;
+        }
         final tokenId = _str(map, 'tokenId');
         tasks.add(
           () => _githubRepoEvents(
@@ -480,6 +517,12 @@ class ActivityFeedService {
         final project = _str(map, 'project');
         final name = _str(map, 'repoName');
         if (organization == null || project == null || name == null) continue;
+        if (onlyRepoKeys != null &&
+            !onlyRepoKeys.contains(
+              RepoDiscoveryService.adoKey(organization, project, name),
+            )) {
+          continue;
+        }
         final tokenId = _str(map, 'tokenId');
         tasks.add(
           () => _adoRepoEvents(
@@ -496,8 +539,21 @@ class ActivityFeedService {
 
       final outcomes = await _runBounded(tasks, concurrency);
       final combined = _FetchOutcome.merge(outcomes);
+      // Apply person/repo scoping BEFORE the maxEvents cap so a quiet person or
+      // team can't be evicted by unrelated high-volume repositories.
+      var events = combined.events;
+      if (actorGithubLogins.isNotEmpty || actorAdoNames.isNotEmpty) {
+        events = eventsForActor(
+          events,
+          githubLogins: actorGithubLogins,
+          adoNames: actorAdoNames,
+        );
+      }
+      if (onlyRepoKeys != null) {
+        events = eventsForRepoKeys(events, onlyRepoKeys);
+      }
       return ActivityFeedResult(
-        events: mergeAndWindow(combined.events, since),
+        events: mergeAndWindow(events, since),
         failedSources: combined.failedCount,
         truncated: combined.truncated,
       );

--- a/lib/activity_service.dart
+++ b/lib/activity_service.dart
@@ -465,6 +465,7 @@ class ActivityService {
   static Future<List<RepoActivity>> computeAll({
     http.Client? client,
     int concurrency = 5,
+    Set<String>? onlyRepoKeys,
   }) async {
     final httpClient = client ?? http.Client();
     try {
@@ -485,6 +486,7 @@ class ActivityService {
           final name = _stringValue(decoded, 'repoName');
           if (owner == null || name == null) continue;
           final repoKey = RepoDiscoveryService.githubKey(owner, name);
+          if (onlyRepoKeys != null && !onlyRepoKeys.contains(repoKey)) continue;
           final tokenId = _stringValue(decoded, 'tokenId');
           tasks.add(() async {
             try {
@@ -528,6 +530,7 @@ class ActivityService {
             project,
             name,
           );
+          if (onlyRepoKeys != null && !onlyRepoKeys.contains(repoKey)) continue;
           final tokenId = _stringValue(decoded, 'tokenId');
           tasks.add(() async {
             try {

--- a/lib/people_page.dart
+++ b/lib/people_page.dart
@@ -5,6 +5,7 @@ import 'identity_service.dart';
 import 'identity_store.dart';
 import 'people_service.dart';
 import 'person.dart';
+import 'person_detail_page.dart';
 
 class PeoplePage extends StatefulWidget {
   const PeoplePage({super.key});
@@ -245,6 +246,14 @@ class _PeoplePageState extends State<PeoplePage> {
         final person = _people[index];
         return ListTile(
           leading: CircleAvatar(child: Text(_initials(person.displayName))),
+          onTap: () async {
+            await Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => PersonDetailPage(person: person),
+              ),
+            );
+          },
           title: Row(
             children: [
               Expanded(child: Text(person.displayName)),

--- a/lib/person_detail_page.dart
+++ b/lib/person_detail_page.dart
@@ -80,7 +80,7 @@ class _PersonDetailPageState extends State<PersonDetailPage> {
         children: [
           _buildHeader(),
           const Divider(height: 1),
-          if (!_loading)
+          if (!_loading && _error == null)
             ?activitySourceNotice(
               failedSources: _failedSources,
               truncated: _truncated,

--- a/lib/person_detail_page.dart
+++ b/lib/person_detail_page.dart
@@ -96,7 +96,10 @@ class _PersonDetailPageState extends State<PersonDetailPage> {
   }
 
   Widget _buildHeader() {
-    final identities = [..._person.githubLogins, ..._person.adoNames];
+    final identities = [
+      ...(_person.githubLogins.toList()..sort()),
+      ...(_person.adoNames.toList()..sort()),
+    ];
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
       child: Column(

--- a/lib/person_detail_page.dart
+++ b/lib/person_detail_page.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+
+import 'activity_event.dart';
+import 'activity_event_list.dart';
+import 'activity_feed_service.dart';
+import 'app_http.dart';
+import 'person.dart';
+
+/// Drill-down for a single [Person]: their identities and PR/review summary,
+/// plus their recent activity across all monitored repositories.
+class PersonDetailPage extends StatefulWidget {
+  const PersonDetailPage({super.key, required this.person});
+
+  final Person person;
+
+  @override
+  State<PersonDetailPage> createState() => _PersonDetailPageState();
+}
+
+class _PersonDetailPageState extends State<PersonDetailPage> {
+  List<ActivityEvent> _events = const [];
+  bool _loading = true;
+  int _failedSources = 0;
+  bool _truncated = false;
+  String? _error;
+  DateTime? _lastChecked;
+
+  Person get _person => widget.person;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final result = await ActivityFeedService.computeAll(
+        client: AppHttp.client,
+        actorGithubLogins: _person.githubLogins,
+        actorAdoNames: _person.adoNames,
+      );
+      if (!mounted) return;
+      setState(() {
+        _events = result.events;
+        _failedSources = result.failedSources;
+        _truncated = result.truncated;
+        _lastChecked = DateTime.now();
+        _loading = false;
+      });
+    } catch (e) {
+      debugPrint('PersonDetail failed to load: $e');
+      if (!mounted) return;
+      setState(() {
+        _error =
+            'Something went wrong while loading this person. Pull to retry.';
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_person.displayName),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: _loading ? null : _load,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _buildHeader(),
+          const Divider(height: 1),
+          if (!_loading)
+            ?activitySourceNotice(
+              failedSources: _failedSources,
+              truncated: _truncated,
+            ),
+          Expanded(
+            child: _loading
+                ? const Center(child: CircularProgressIndicator())
+                : RefreshIndicator(onRefresh: _load, child: _buildContent()),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    final identities = [..._person.githubLogins, ..._person.adoNames];
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              CircleAvatar(child: Text(_initials(_person.displayName))),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            _person.displayName,
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                        ),
+                        if (_person.isSelf) ...[
+                          const SizedBox(width: 8),
+                          const Chip(
+                            label: Text('You'),
+                            visualDensity: VisualDensity.compact,
+                            materialTapTargetSize:
+                                MaterialTapTargetSize.shrinkWrap,
+                            padding: EdgeInsets.zero,
+                          ),
+                        ],
+                      ],
+                    ),
+                    Text(
+                      '${_person.authoredOpenPrs} open PR'
+                      '${_person.authoredOpenPrs == 1 ? '' : 's'} · '
+                      '${_person.reviewRequests} review request'
+                      '${_person.reviewRequests == 1 ? '' : 's'}',
+                      style: TextStyle(color: Colors.grey[600], fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (identities.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: [
+                for (final id in identities)
+                  Chip(
+                    label: Text(id),
+                    visualDensity: VisualDensity.compact,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    if (_error != null) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 120),
+          Center(
+            child: Text(_error!, style: const TextStyle(color: Colors.red)),
+          ),
+        ],
+      );
+    }
+    if (_events.isEmpty) {
+      final days = ActivityFeedService.defaultLookback.inDays;
+      final message = _failedSources > 0
+          ? 'Couldn\'t load activity right now. Pull down to retry.'
+          : 'No recent activity found for ${_person.displayName} in the '
+                'last $days days.';
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 120),
+          Center(
+            child: Icon(Icons.timeline, size: 56, color: Colors.grey[400]),
+          ),
+          const SizedBox(height: 12),
+          Center(child: Text(message, textAlign: TextAlign.center)),
+          const SizedBox(height: 6),
+          Center(
+            child: Text(
+              _lastChecked == null
+                  ? 'Pull down to refresh.'
+                  : 'Checked ${activityRelativeTime(_lastChecked!)} · pull down to refresh.',
+              style: TextStyle(color: Colors.grey[600], fontSize: 12),
+            ),
+          ),
+        ],
+      );
+    }
+    return ActivityEventList(events: _events);
+  }
+
+  String _initials(String name) {
+    final parts = name.trim().split(RegExp(r'\s+')).where((p) => p.isNotEmpty);
+    final initials = parts.take(2).map((part) => part[0].toUpperCase()).join();
+    return initials.isEmpty ? '?' : initials;
+  }
+}

--- a/lib/person_detail_page.dart
+++ b/lib/person_detail_page.dart
@@ -81,7 +81,7 @@ class _PersonDetailPageState extends State<PersonDetailPage> {
           _buildHeader(),
           const Divider(height: 1),
           if (!_loading && _error == null)
-            ?activitySourceNotice(
+            activitySourceNotice(
               failedSources: _failedSources,
               truncated: _truncated,
             ),

--- a/lib/team_detail_page.dart
+++ b/lib/team_detail_page.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'activity_event.dart';
+import 'activity_event_list.dart';
+import 'activity_feed_service.dart';
+import 'activity_service.dart';
+import 'app_http.dart';
+import 'team.dart';
+import 'team_service.dart';
+
+/// Drill-down for a single [Team]: a rollup header plus two tabs — the team's
+/// repositories (with per-repo activity) and a feed of recent activity across
+/// those repositories.
+class TeamDetailPage extends StatefulWidget {
+  const TeamDetailPage({super.key, required this.team});
+
+  final Team team;
+
+  @override
+  State<TeamDetailPage> createState() => _TeamDetailPageState();
+}
+
+class _TeamDetailPageState extends State<TeamDetailPage> {
+  List<RepoActivity> _repos = const [];
+  List<ActivityEvent> _events = const [];
+  TeamRollup? _rollup;
+  bool _loading = true;
+  int _failedSources = 0;
+  bool _truncated = false;
+  String? _error;
+
+  Team get _team => widget.team;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      // Fetch repo activity and the (team-scoped) feed concurrently.
+      final activitiesFuture = ActivityService.computeAll(
+        client: AppHttp.client,
+      );
+      final feedFuture = ActivityFeedService.computeAll(
+        client: AppHttp.client,
+        onlyRepoKeys: _team.repoKeys,
+      );
+      final activities = await activitiesFuture;
+      final feed = await feedFuture;
+      final repos =
+          activities.where((a) => _team.repoKeys.contains(a.repoKey)).toList()
+            ..sort((a, b) {
+              final byScore = b.activityScore.compareTo(a.activityScore);
+              return byScore != 0
+                  ? byScore
+                  : a.displayName.compareTo(b.displayName);
+            });
+      if (!mounted) return;
+      setState(() {
+        _repos = repos;
+        _events = feed.events;
+        _failedSources = feed.failedSources;
+        _truncated = feed.truncated;
+        _rollup = TeamService.rollup(_team, activities);
+        _loading = false;
+      });
+    } catch (e) {
+      debugPrint('TeamDetail failed to load: $e');
+      if (!mounted) return;
+      setState(() {
+        _error = 'Something went wrong while loading this team. Pull to retry.';
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(_team.name),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: 'Refresh',
+              onPressed: _loading ? null : _load,
+            ),
+          ],
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Repositories'),
+              Tab(text: 'Activity'),
+            ],
+          ),
+        ),
+        body: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : Column(
+                children: [
+                  _buildHeader(),
+                  const Divider(height: 1),
+                  ?activitySourceNotice(
+                    failedSources: _failedSources,
+                    truncated: _truncated,
+                  ),
+                  Expanded(
+                    child: TabBarView(
+                      children: [_buildReposTab(), _buildActivityTab()],
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    final rollup = _rollup;
+    if (rollup == null || _team.repoKeys.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 8,
+        children: [
+          _metric(Icons.folder, '${rollup.repoCount} repos'),
+          _metric(Icons.merge_type, '${rollup.openPrs} open PRs'),
+          _metric(Icons.rate_review, '${rollup.needsReview} need review'),
+          _metric(Icons.people, '${rollup.contributors.length} contributors'),
+          _metric(Icons.update, _relativeTime(rollup.lastActivity)),
+          if (rollup.oldestOpenPrAgeDays != null)
+            _metric(Icons.schedule, 'oldest ${rollup.oldestOpenPrAgeDays}d'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildReposTab() {
+    if (_error != null) return _errorList();
+    if (_team.repoKeys.isEmpty) {
+      return _centeredMessage('No repositories assigned to this team.');
+    }
+    if (_repos.isEmpty) {
+      return _centeredMessage(
+        'No data yet — assigned repos are loading or failed to fetch.',
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.separated(
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: _repos.length,
+        separatorBuilder: (_, _) => const Divider(height: 1),
+        itemBuilder: (context, index) => _repoTile(_repos[index]),
+      ),
+    );
+  }
+
+  Widget _buildActivityTab() {
+    if (_error != null) return _errorList();
+    if (_events.isEmpty) {
+      final days = ActivityFeedService.defaultLookback.inDays;
+      final message = _failedSources > 0
+          ? 'Couldn\'t load activity right now. Pull down to retry.'
+          : 'No activity in this team\'s repos in the last $days days.';
+      return _centeredMessage(message);
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ActivityEventList(events: _events),
+    );
+  }
+
+  Widget _repoTile(RepoActivity repo) {
+    final ci = _ciVisual(repo.ciStatus);
+    final subtitle = repo.error != null
+        ? repo.error!
+        : '${repo.openPrCount} open · ${repo.needsReviewCount} need review · '
+              'active ${_relativeTime(repo.lastActivity)}';
+    return ListTile(
+      leading: Icon(ci.icon, color: ci.color),
+      title: Text(repo.displayName),
+      subtitle: Text(
+        subtitle,
+        style: TextStyle(
+          color: repo.error != null ? Colors.red : Colors.grey[600],
+          fontSize: 12,
+        ),
+      ),
+      trailing: const Icon(Icons.open_in_new, size: 16),
+      onTap: () => _open(repo.url),
+    );
+  }
+
+  ({IconData icon, Color color}) _ciVisual(String status) {
+    switch (status) {
+      case 'success':
+        return (icon: Icons.check_circle, color: Colors.green);
+      case 'failure':
+        return (icon: Icons.error, color: Colors.red);
+      case 'pending':
+        return (icon: Icons.hourglass_empty, color: Colors.orange);
+      default:
+        return (icon: Icons.help_outline, color: Colors.grey);
+    }
+  }
+
+  Widget _metric(IconData icon, String text) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: Colors.grey[600]),
+        const SizedBox(width: 4),
+        Text(text, style: const TextStyle(fontSize: 12)),
+      ],
+    );
+  }
+
+  Widget _centeredMessage(String message) {
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 140),
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Text(message, textAlign: TextAlign.center),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _errorList() {
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 140),
+          Center(
+            child: Text(_error!, style: const TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _relativeTime(DateTime? value) {
+    if (value == null) return 'no activity';
+    return activityRelativeTime(value);
+  }
+
+  Future<void> _open(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      _showOpenError(url);
+      return;
+    }
+    final canLaunch = await canLaunchUrl(uri);
+    if (!mounted) return;
+    if (!canLaunch) {
+      _showOpenError(url);
+      return;
+    }
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!mounted) return;
+    if (!launched) _showOpenError(url);
+  }
+
+  void _showOpenError(String url) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Could not open $url')));
+  }
+}

--- a/lib/team_detail_page.dart
+++ b/lib/team_detail_page.dart
@@ -45,17 +45,20 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
     });
     try {
       // Fetch repo activity and the feed concurrently, both scoped to the
-      // team's repositories.
-      final activitiesFuture = ActivityService.computeAll(
-        client: AppHttp.client,
-        onlyRepoKeys: _team.repoKeys,
-      );
-      final feedFuture = ActivityFeedService.computeAll(
-        client: AppHttp.client,
-        onlyRepoKeys: _team.repoKeys,
-      );
-      final activities = await activitiesFuture;
-      final feed = await feedFuture;
+      // team's repositories. Future.wait ensures both are awaited even if one
+      // fails (no unhandled async error).
+      final results = await Future.wait([
+        ActivityService.computeAll(
+          client: AppHttp.client,
+          onlyRepoKeys: _team.repoKeys,
+        ),
+        ActivityFeedService.computeAll(
+          client: AppHttp.client,
+          onlyRepoKeys: _team.repoKeys,
+        ),
+      ]);
+      final activities = results[0] as List<RepoActivity>;
+      final feed = results[1] as ActivityFeedResult;
       final repos =
           activities.where((a) => _team.repoKeys.contains(a.repoKey)).toList()
             ..sort((a, b) {
@@ -113,7 +116,7 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
                   _buildHeader(),
                   const Divider(height: 1),
                   if (_error == null)
-                    ?activitySourceNotice(
+                    activitySourceNotice(
                       failedSources: _failedSources,
                       truncated: _truncated,
                     ),

--- a/lib/team_detail_page.dart
+++ b/lib/team_detail_page.dart
@@ -45,9 +45,8 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
     });
     try {
       // Fetch repo activity and the feed concurrently, both scoped to the
-      // team's repositories. Future.wait attaches error handlers to both
-      // futures, so a failure in either is caught here rather than surfacing as
-      // an unhandled async error.
+      // team's repositories. The awaited Future.wait sits inside the try/catch,
+      // so a failure in either fetch is handled here.
       final results = await Future.wait([
         ActivityService.computeAll(
           client: AppHttp.client,

--- a/lib/team_detail_page.dart
+++ b/lib/team_detail_page.dart
@@ -45,8 +45,9 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
     });
     try {
       // Fetch repo activity and the feed concurrently, both scoped to the
-      // team's repositories. Future.wait ensures both are awaited even if one
-      // fails (no unhandled async error).
+      // team's repositories. Future.wait attaches error handlers to both
+      // futures, so a failure in either is caught here rather than surfacing as
+      // an unhandled async error.
       final results = await Future.wait([
         ActivityService.computeAll(
           client: AppHttp.client,
@@ -177,6 +178,9 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
 
   Widget _buildActivityTab() {
     if (_error != null) return _errorList();
+    if (_team.repoKeys.isEmpty) {
+      return _centeredMessage('No repositories assigned to this team.');
+    }
     if (_events.isEmpty) {
       final days = ActivityFeedService.defaultLookback.inDays;
       final message = _failedSources > 0

--- a/lib/team_detail_page.dart
+++ b/lib/team_detail_page.dart
@@ -44,9 +44,11 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
       _error = null;
     });
     try {
-      // Fetch repo activity and the (team-scoped) feed concurrently.
+      // Fetch repo activity and the feed concurrently, both scoped to the
+      // team's repositories.
       final activitiesFuture = ActivityService.computeAll(
         client: AppHttp.client,
+        onlyRepoKeys: _team.repoKeys,
       );
       final feedFuture = ActivityFeedService.computeAll(
         client: AppHttp.client,
@@ -60,7 +62,9 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
               final byScore = b.activityScore.compareTo(a.activityScore);
               return byScore != 0
                   ? byScore
-                  : a.displayName.compareTo(b.displayName);
+                  : a.displayName.toLowerCase().compareTo(
+                      b.displayName.toLowerCase(),
+                    );
             });
       if (!mounted) return;
       setState(() {
@@ -108,10 +112,11 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
                 children: [
                   _buildHeader(),
                   const Divider(height: 1),
-                  ?activitySourceNotice(
-                    failedSources: _failedSources,
-                    truncated: _truncated,
-                  ),
+                  if (_error == null)
+                    ?activitySourceNotice(
+                      failedSources: _failedSources,
+                      truncated: _truncated,
+                    ),
                   Expanded(
                     child: TabBarView(
                       children: [_buildReposTab(), _buildActivityTab()],

--- a/lib/team_detail_page.dart
+++ b/lib/team_detail_page.dart
@@ -220,7 +220,7 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
         return (icon: Icons.check_circle, color: Colors.green);
       case 'failure':
         return (icon: Icons.error, color: Colors.red);
-      case 'pending':
+      case 'running':
         return (icon: Icons.hourglass_empty, color: Colors.orange);
       default:
         return (icon: Icons.help_outline, color: Colors.grey);

--- a/lib/teams_page.dart
+++ b/lib/teams_page.dart
@@ -8,6 +8,7 @@ import 'metric_snapshot.dart';
 import 'metric_store.dart';
 import 'sparkline.dart';
 import 'team.dart';
+import 'team_detail_page.dart';
 import 'team_service.dart';
 import 'team_store.dart';
 
@@ -173,58 +174,67 @@ class _TeamsPageState extends State<TeamsPage> {
         final team = _teams[index];
         final rollup = _rollups[team.id];
         return Card(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        team.name,
-                        style: Theme.of(context).textTheme.titleMedium,
-                      ),
-                    ),
-                    Sparkline(values: _series[team.id] ?? const []),
-                  ],
-                ),
-                const SizedBox(height: 8),
-                if (team.repoKeys.isEmpty)
-                  Text(
-                    'No repositories assigned yet.',
-                    style: Theme.of(context).textTheme.bodySmall,
-                  )
-                else if (rollup == null || rollup.repoCount == 0)
-                  Text(
-                    'No data yet — assigned repos are loading or failed to '
-                    'fetch.',
-                    style: Theme.of(context).textTheme.bodySmall,
-                  )
-                else
-                  Wrap(
-                    spacing: 12,
-                    runSpacing: 8,
+          child: InkWell(
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => TeamDetailPage(team: team)),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
                     children: [
-                      _metric(Icons.folder, '${rollup.repoCount} repos'),
-                      _metric(Icons.merge_type, '${rollup.openPrs} open PRs'),
-                      _metric(
-                        Icons.rate_review,
-                        '${rollup.needsReview} review requested',
-                      ),
-                      _metric(
-                        Icons.people,
-                        '${rollup.contributors.length} contributors',
-                      ),
-                      _metric(Icons.update, _relativeTime(rollup.lastActivity)),
-                      if (rollup.oldestOpenPrAgeDays != null)
-                        _metric(
-                          Icons.schedule,
-                          'oldest ${rollup.oldestOpenPrAgeDays}d',
+                      Expanded(
+                        child: Text(
+                          team.name,
+                          style: Theme.of(context).textTheme.titleMedium,
                         ),
+                      ),
+                      Sparkline(values: _series[team.id] ?? const []),
                     ],
                   ),
-              ],
+                  const SizedBox(height: 8),
+                  if (team.repoKeys.isEmpty)
+                    Text(
+                      'No repositories assigned yet.',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    )
+                  else if (rollup == null || rollup.repoCount == 0)
+                    Text(
+                      'No data yet — assigned repos are loading or failed to '
+                      'fetch.',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    )
+                  else
+                    Wrap(
+                      spacing: 12,
+                      runSpacing: 8,
+                      children: [
+                        _metric(Icons.folder, '${rollup.repoCount} repos'),
+                        _metric(Icons.merge_type, '${rollup.openPrs} open PRs'),
+                        _metric(
+                          Icons.rate_review,
+                          '${rollup.needsReview} review requested',
+                        ),
+                        _metric(
+                          Icons.people,
+                          '${rollup.contributors.length} contributors',
+                        ),
+                        _metric(
+                          Icons.update,
+                          _relativeTime(rollup.lastActivity),
+                        ),
+                        if (rollup.oldestOpenPrAgeDays != null)
+                          _metric(
+                            Icons.schedule,
+                            'oldest ${rollup.oldestOpenPrAgeDays}d',
+                          ),
+                      ],
+                    ),
+                ],
+              ),
             ),
           ),
         );

--- a/lib/teams_page.dart
+++ b/lib/teams_page.dart
@@ -174,6 +174,7 @@ class _TeamsPageState extends State<TeamsPage> {
         final team = _teams[index];
         final rollup = _rollups[team.id];
         return Card(
+          clipBehavior: Clip.antiAlias,
           child: InkWell(
             onTap: () => Navigator.push(
               context,

--- a/test/activity_feed_service_test.dart
+++ b/test/activity_feed_service_test.dart
@@ -359,6 +359,51 @@ void main() {
     });
   });
 
+  group('eventsForActor / eventsForRepoKeys', () {
+    ActivityEvent ev(String id, String provider, String actor, String rk) =>
+        ActivityEvent(
+          id: id,
+          type: ActivityType.push,
+          provider: provider,
+          repoKey: rk,
+          repoDisplay: rk,
+          actor: actor,
+          title: 't',
+          subtitle: 's',
+          occurredAt: DateTime.parse('2026-07-14T00:00:00Z'),
+        );
+
+    test('eventsForActor matches provider identities case-insensitively', () {
+      final events = [
+        ev('1', 'github', 'OctoCat', 'github:acme/api'),
+        ev('2', 'github', 'someoneelse', 'github:acme/api'),
+        ev('3', 'ado', 'Jane Doe', 'ado:contoso/web/site'),
+        ev('4', 'ado', 'Other Person', 'ado:contoso/web/site'),
+        ev('5', 'github', '', 'github:acme/api'),
+      ];
+      final mine = ActivityFeedService.eventsForActor(
+        events,
+        githubLogins: {'octocat'},
+        adoNames: {'jane doe'},
+      );
+      expect(mine.map((e) => e.id).toList(), ['1', '3']);
+    });
+
+    test('eventsForRepoKeys filters by repo key; empty set yields nothing', () {
+      final events = [
+        ev('1', 'github', 'a', 'github:acme/api'),
+        ev('2', 'github', 'b', 'github:acme/web'),
+        ev('3', 'ado', 'c', 'ado:contoso/web/site'),
+      ];
+      final teamEvents = ActivityFeedService.eventsForRepoKeys(events, {
+        'github:acme/api',
+        'ado:contoso/web/site',
+      });
+      expect(teamEvents.map((e) => e.id).toList(), ['1', '3']);
+      expect(ActivityFeedService.eventsForRepoKeys(events, {}), isEmpty);
+    });
+  });
+
   group('computeAll', () {
     setUp(() {
       TestWidgetsFlutterBinding.ensureInitialized();
@@ -597,5 +642,108 @@ void main() {
         expect(result.truncated, isFalse);
       },
     );
+
+    test('actorGithubLogins scopes the feed to a person', () async {
+      final gh = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Acme',
+        scope: 'acme',
+        secret: 'ghp_secret',
+      );
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList('github_repos', [
+        jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': gh.id}),
+        jsonEncode({'owner': 'acme', 'repoName': 'web', 'tokenId': gh.id}),
+      ]);
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (path == '/repos/acme/api/events') {
+          return http.Response(
+            jsonEncode([
+              {
+                'id': '1',
+                'type': 'PullRequestEvent',
+                'actor': {'login': 'alice'},
+                'created_at': '2026-07-14T11:00:00Z',
+                'payload': {
+                  'action': 'opened',
+                  'pull_request': {'number': 1, 'title': 'A'},
+                },
+              },
+            ]),
+            200,
+          );
+        }
+        if (path == '/repos/acme/web/events') {
+          return http.Response(
+            jsonEncode([
+              {
+                'id': '2',
+                'type': 'PullRequestEvent',
+                'actor': {'login': 'bob'},
+                'created_at': '2026-07-14T12:00:00Z',
+                'payload': {
+                  'action': 'opened',
+                  'pull_request': {'number': 2, 'title': 'B'},
+                },
+              },
+            ]),
+            200,
+          );
+        }
+        return http.Response(jsonEncode({'workflow_runs': []}), 200);
+      });
+
+      final result = await ActivityFeedService.computeAll(
+        client: client,
+        now: DateTime.parse('2026-07-15T12:00:00Z'),
+        actorGithubLogins: {'alice'},
+      );
+      expect(result.events, isNotEmpty);
+      expect(result.events.map((e) => e.actor).toSet(), {'alice'});
+    });
+
+    test('onlyRepoKeys scopes the feed to selected repositories', () async {
+      final gh = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Acme',
+        scope: 'acme',
+        secret: 'ghp_secret',
+      );
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList('github_repos', [
+        jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': gh.id}),
+        jsonEncode({'owner': 'acme', 'repoName': 'web', 'tokenId': gh.id}),
+      ]);
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (path == '/repos/acme/api/events') {
+          return http.Response(
+            jsonEncode([
+              {
+                'id': '1',
+                'type': 'PushEvent',
+                'actor': {'login': 'alice'},
+                'created_at': '2026-07-14T11:00:00Z',
+                'payload': {'ref': 'refs/heads/main', 'size': 1},
+              },
+            ]),
+            200,
+          );
+        }
+        return http.Response(jsonEncode({'workflow_runs': []}), 200);
+      });
+
+      final result = await ActivityFeedService.computeAll(
+        client: client,
+        now: DateTime.parse('2026-07-15T12:00:00Z'),
+        onlyRepoKeys: {'github:acme/api'},
+      );
+      expect(result.events, isNotEmpty);
+      expect(
+        result.events.every((e) => e.repoKey == 'github:acme/api'),
+        isTrue,
+      );
+    });
   });
 }

--- a/test/activity_service_test.dart
+++ b/test/activity_service_test.dart
@@ -1,9 +1,12 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:kode_radar/activity_service.dart';
+import 'package:kode_radar/token_store.dart';
 
 void main() {
   test('extractPrAuthorsGithub dedupes authors', () {
@@ -228,5 +231,45 @@ void main() {
     expect(activity.contributors, ['alice']);
     expect(activity.ciStatus, 'success');
     expect(activity.error, isNull);
+  });
+
+  group('computeAll onlyRepoKeys', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      FlutterSecureStorage.setMockInitialValues({});
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('fetches only the requested repositories', () async {
+      final gh = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Acme',
+        scope: 'acme',
+        secret: 'ghp_secret',
+      );
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList('github_repos', [
+        jsonEncode({'owner': 'acme', 'repoName': 'api', 'tokenId': gh.id}),
+        jsonEncode({'owner': 'acme', 'repoName': 'web', 'tokenId': gh.id}),
+      ]);
+      final client = MockClient((request) async {
+        if (request.url.path.endsWith('/actions/runs')) {
+          return http.Response(jsonEncode({'workflow_runs': []}), 200);
+        }
+        return http.Response('[]', 200);
+      });
+
+      final scoped = await ActivityService.computeAll(
+        client: client,
+        onlyRepoKeys: {'github:acme/api'},
+      );
+      expect(scoped.map((a) => a.repoKey).toList(), ['github:acme/api']);
+
+      final none = await ActivityService.computeAll(
+        client: client,
+        onlyRepoKeys: {},
+      );
+      expect(none, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## What

**Person & Team detail drill-downs** — tap a person in People or a team in Teams to open a detail screen.

- **`lib/person_detail_page.dart`** — `PersonDetailPage`: identity chips + PR/review summary, and the person's recent activity across all repos.
- **`lib/team_detail_page.dart`** — `TeamDetailPage`: a rollup header + two tabs — **Repositories** (per-repo activity, CI status, tap-to-open) and **Activity** (recent events in the team's repos).
- **`lib/activity_event_list.dart`** (new) — shared `ActivityEventList` widget (day-grouped tiles + tap-to-open) and `activitySourceNotice()`, extracted from the feed so all three screens render identically.
- **`lib/activity_feed_service.dart`** — pure `eventsForActor`/`eventsForRepoKeys`; `computeAll` gains `onlyRepoKeys` + actor scoping applied **before** the `maxEvents` cap so a quiet person/team can't be evicted by busy unrelated repos.
- People/Teams pages wire taps into the detail pages; the feed page reuses the shared widget/notice.

## Review

code-review + rubber-duck. Their feedback is implemented: filter/scope before the global cap (not after), surface `failedSources` in detail empty states (no false "no activity"), team feed scoped + loaded concurrently, deterministic repo sort tie-breaker.

Known/acknowledged limitations (pre-existing, not introduced here): ADO identities are matched by display name (app-wide), and activity reflects the triggering actor (bot-pushed commits may not appear).

## Validation

`flutter analyze --fatal-infos` clean, `dart format` clean, **103 tests pass** (+4). Deployed to device for hands-on testing.
