### PR TITLE
Per-repository detail drill-down

### DIFF
--- a/lib/radar_page.dart
+++ b/lib/radar_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'activity_service.dart';
 import 'app_http.dart';
 import 'metric_store.dart';
+import 'repo_detail_page.dart';
 import 'sparkline.dart';
 
 class RadarPage extends StatefulWidget {
@@ -179,8 +179,11 @@ class _RadarPageState extends State<RadarPage> {
                 ],
               ),
             ),
-            trailing: const Icon(Icons.open_in_new),
-            onTap: () => _openRepo(activity),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => RepoDetailPage(repo: activity)),
+            ),
           ),
         );
       },
@@ -272,27 +275,5 @@ class _RadarPageState extends State<RadarPage> {
     final text = shown.join(', ');
     if (extra <= 0) return text;
     return '$text, +$extra';
-  }
-
-  Future<void> _openRepo(RepoActivity activity) async {
-    final uri = Uri.tryParse(activity.url);
-    if (uri == null) return;
-
-    final canLaunch = await canLaunchUrl(uri);
-    if (!mounted) return;
-    if (!canLaunch) {
-      _showLaunchError(activity.displayName);
-      return;
-    }
-
-    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
-    if (!mounted) return;
-    if (!launched) _showLaunchError(activity.displayName);
-  }
-
-  void _showLaunchError(String displayName) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text('Could not open $displayName')));
   }
 }

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -72,14 +72,19 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
     }
   }
 
-  int get _tabCount => _data.releasesSupported ? 4 : 3;
+  int get _tabCount => _releasesSupported ? 4 : 3;
+
+  /// Releases exist only for GitHub. Derive from the known provider (not the
+  /// async-loaded data) so the tab set is correct immediately and TabBar and
+  /// TabBarView never desync.
+  bool get _releasesSupported => _repo.provider == 'github';
 
   @override
   Widget build(BuildContext context) {
     final tabs = <Tab>[
       const Tab(text: 'Pull requests'),
       const Tab(text: 'CI'),
-      if (_data.releasesSupported) const Tab(text: 'Releases'),
+      if (_releasesSupported) const Tab(text: 'Releases'),
       const Tab(text: 'Activity'),
     ];
     return DefaultTabController(
@@ -117,7 +122,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
                       children: [
                         _buildPullsTab(),
                         _buildCiTab(),
-                        if (_data.releasesSupported) _buildReleasesTab(),
+                        if (_releasesSupported) _buildReleasesTab(),
                         _buildActivityTab(),
                       ],
                     ),

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -1,0 +1,439 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'activity_event.dart';
+import 'activity_event_list.dart';
+import 'activity_feed_service.dart';
+import 'activity_service.dart';
+import 'app_http.dart';
+import 'repo_detail_service.dart';
+
+/// Per-repository drill-down: open pull requests (with review state), CI
+/// history, releases, and a recent-activity timeline, plus contributors.
+class RepoDetailPage extends StatefulWidget {
+  const RepoDetailPage({super.key, required this.repo});
+
+  final RepoActivity repo;
+
+  @override
+  State<RepoDetailPage> createState() => _RepoDetailPageState();
+}
+
+class _RepoDetailPageState extends State<RepoDetailPage> {
+  RepoDetailData _data = const RepoDetailData();
+  List<ActivityEvent> _events = const [];
+  int _feedFailed = 0;
+  bool _feedTruncated = false;
+  bool _loading = true;
+  String? _error;
+
+  RepoActivity get _repo => widget.repo;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final detailFuture = RepoDetailService.load(
+        repoKey: _repo.repoKey,
+        provider: _repo.provider,
+        client: AppHttp.client,
+      );
+      final feedFuture = ActivityFeedService.computeAll(
+        client: AppHttp.client,
+        onlyRepoKeys: {_repo.repoKey},
+      );
+      final results = await Future.wait([detailFuture, feedFuture]);
+      if (!mounted) return;
+      setState(() {
+        _data = results[0] as RepoDetailData;
+        final feed = results[1] as ActivityFeedResult;
+        _events = feed.events;
+        _feedFailed = feed.failedSources;
+        _feedTruncated = feed.truncated;
+        _loading = false;
+      });
+    } catch (e) {
+      debugPrint('RepoDetail failed to load: $e');
+      if (!mounted) return;
+      setState(() {
+        _error =
+            'Something went wrong while loading this repository. '
+            'Pull to retry.';
+        _loading = false;
+      });
+    }
+  }
+
+  int get _tabCount => _data.releasesSupported ? 4 : 3;
+
+  @override
+  Widget build(BuildContext context) {
+    final tabs = <Tab>[
+      const Tab(text: 'Pull requests'),
+      const Tab(text: 'CI'),
+      if (_data.releasesSupported) const Tab(text: 'Releases'),
+      const Tab(text: 'Activity'),
+    ];
+    return DefaultTabController(
+      length: _tabCount,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(_repo.displayName),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.open_in_new),
+              tooltip: 'Open in browser',
+              onPressed: () => _open(_repo.url),
+            ),
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: 'Refresh',
+              onPressed: _loading ? null : _load,
+            ),
+          ],
+          bottom: TabBar(isScrollable: true, tabs: tabs),
+        ),
+        body: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : Column(
+                children: [
+                  _buildHeader(),
+                  const Divider(height: 1),
+                  if (_error == null)
+                    activitySourceNotice(
+                      failedSources: _data.failedSources + _feedFailed,
+                      truncated: _feedTruncated,
+                    ),
+                  Expanded(
+                    child: TabBarView(
+                      children: [
+                        _buildPullsTab(),
+                        _buildCiTab(),
+                        if (_data.releasesSupported) _buildReleasesTab(),
+                        _buildActivityTab(),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
+      child: Row(
+        children: [
+          Icon(
+            Icons.people,
+            size: 16,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              _repo.contributors.isEmpty
+                  ? 'No recent contributors'
+                  : _repo.contributors.take(6).join(', '),
+              style: const TextStyle(fontSize: 12),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPullsTab() {
+    if (_error != null) return _errorList();
+    final pulls = _data.pulls;
+    if (pulls.isEmpty) {
+      return _centeredMessage(
+        _data.pullsFailed
+            ? 'Couldn\'t load pull requests. Pull to retry.'
+            : 'No open pull requests.',
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.separated(
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: pulls.length,
+        separatorBuilder: (_, _) => const Divider(height: 1),
+        itemBuilder: (context, index) => _prTile(pulls[index]),
+      ),
+    );
+  }
+
+  Widget _prTile(RepoPr pr) {
+    final review = _reviewVisual(pr.reviewState);
+    return ListTile(
+      leading: Icon(review.icon, color: review.color),
+      title: Row(
+        children: [
+          Flexible(child: Text('${pr.label}: ${pr.title}')),
+          if (pr.draft) ...[
+            const SizedBox(width: 6),
+            const _MiniChip(label: 'Draft'),
+          ],
+        ],
+      ),
+      subtitle: Text(
+        'by ${pr.author} · ${_ageText(pr.ageDays)} · ${review.label}',
+        style: TextStyle(color: Colors.grey[600], fontSize: 12),
+      ),
+      trailing: pr.url != null ? const Icon(Icons.open_in_new, size: 16) : null,
+      onTap: pr.url == null ? null : () => _open(pr.url!),
+    );
+  }
+
+  Widget _buildCiTab() {
+    if (_error != null) return _errorList();
+    final ci = _data.ci;
+    if (ci.isEmpty) {
+      return _centeredMessage(
+        _data.ciFailed
+            ? 'Couldn\'t load CI runs. Pull to retry.'
+            : 'No recent CI runs.',
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.separated(
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: ci.length,
+        separatorBuilder: (_, _) => const Divider(height: 1),
+        itemBuilder: (context, index) => _ciTile(ci[index]),
+      ),
+    );
+  }
+
+  Widget _ciTile(RepoRun run) {
+    final visual = _ciVisual(run);
+    final branch = (run.branch == null || run.branch!.isEmpty)
+        ? ''
+        : ' · ${run.branch}';
+    return ListTile(
+      leading: Icon(visual.icon, color: visual.color),
+      title: Text(run.name),
+      subtitle: Text(
+        '${visual.label}$branch · ${_finishedText(run.finishedAt)}',
+        style: TextStyle(color: Colors.grey[600], fontSize: 12),
+      ),
+      trailing: run.url != null
+          ? const Icon(Icons.open_in_new, size: 16)
+          : null,
+      onTap: run.url == null ? null : () => _open(run.url!),
+    );
+  }
+
+  Widget _buildReleasesTab() {
+    if (_error != null) return _errorList();
+    final releases = _data.releases;
+    if (releases.isEmpty) {
+      return _centeredMessage(
+        _data.releasesFailed
+            ? 'Couldn\'t load releases. Pull to retry.'
+            : 'No releases yet.',
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.separated(
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: releases.length,
+        separatorBuilder: (_, _) => const Divider(height: 1),
+        itemBuilder: (context, index) => _releaseTile(releases[index]),
+      ),
+    );
+  }
+
+  Widget _releaseTile(RepoRelease release) {
+    final name = release.name == null || release.name!.isEmpty
+        ? release.tag
+        : '${release.tag} · ${release.name}';
+    final by = release.author == null ? '' : 'by ${release.author} · ';
+    return ListTile(
+      leading: const Icon(Icons.rocket_launch, color: Colors.teal),
+      title: Text(name),
+      subtitle: Text(
+        '$by${_finishedText(release.publishedAt)}',
+        style: TextStyle(color: Colors.grey[600], fontSize: 12),
+      ),
+      trailing: release.url != null
+          ? const Icon(Icons.open_in_new, size: 16)
+          : null,
+      onTap: release.url == null ? null : () => _open(release.url!),
+    );
+  }
+
+  Widget _buildActivityTab() {
+    if (_error != null) return _errorList();
+    if (_events.isEmpty) {
+      final days = ActivityFeedService.defaultLookback.inDays;
+      return _centeredMessage(
+        _feedFailed > 0
+            ? 'Couldn\'t load activity. Pull to retry.'
+            : 'No activity in this repository in the last $days days.',
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ActivityEventList(events: _events),
+    );
+  }
+
+  ({IconData icon, Color color, String label}) _reviewVisual(String state) {
+    switch (state) {
+      case PrReviewState.approved:
+        return (
+          icon: Icons.check_circle,
+          color: Colors.green,
+          label: 'Approved',
+        );
+      case PrReviewState.changesRequested:
+        return (
+          icon: Icons.edit_note,
+          color: Colors.red,
+          label: 'Changes requested',
+        );
+      case PrReviewState.waiting:
+        return (
+          icon: Icons.rate_review,
+          color: Colors.orange,
+          label: 'Waiting on review',
+        );
+      default:
+        return (
+          icon: Icons.merge_type,
+          color: Colors.blueGrey,
+          label: 'No review requested',
+        );
+    }
+  }
+
+  ({IconData icon, Color color, String label}) _ciVisual(RepoRun run) {
+    // GitHub uses 'completed'; ADO uses 'completed' too, but in-progress ADO
+    // builds report status 'inProgress'/'notStarted'.
+    final done = run.status == 'completed';
+    if (!done) {
+      return (
+        icon: Icons.hourglass_empty,
+        color: Colors.orange,
+        label: 'In progress',
+      );
+    }
+    switch (run.conclusion) {
+      case 'success':
+      case 'succeeded':
+        return (icon: Icons.check_circle, color: Colors.green, label: 'Passed');
+      case 'failure':
+      case 'failed':
+        return (icon: Icons.cancel, color: Colors.red, label: 'Failed');
+      case 'cancelled':
+      case 'canceled':
+        return (icon: Icons.block, color: Colors.grey, label: 'Cancelled');
+      default:
+        return (
+          icon: Icons.help_outline,
+          color: Colors.grey,
+          label: run.conclusion.isEmpty ? 'Completed' : run.conclusion,
+        );
+    }
+  }
+
+  String _ageText(int? ageDays) {
+    if (ageDays == null) return 'opened recently';
+    if (ageDays <= 0) return 'opened today';
+    if (ageDays == 1) return 'opened 1 day ago';
+    return 'opened $ageDays days ago';
+  }
+
+  String _finishedText(DateTime? value) {
+    if (value == null) return 'unknown time';
+    return activityRelativeTime(value.toLocal());
+  }
+
+  Widget _centeredMessage(String message) {
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 140),
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Text(message, textAlign: TextAlign.center),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _errorList() {
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 140),
+          Center(
+            child: Text(_error!, style: const TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _open(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      _showOpenError(url);
+      return;
+    }
+    final canLaunch = await canLaunchUrl(uri);
+    if (!mounted) return;
+    if (!canLaunch) {
+      _showOpenError(url);
+      return;
+    }
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!mounted) return;
+    if (!launched) _showOpenError(url);
+  }
+
+  void _showOpenError(String url) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('Could not open $url')));
+  }
+}
+
+class _MiniChip extends StatelessWidget {
+  const _MiniChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(label, style: const TextStyle(fontSize: 10)),
+    );
+  }
+}

--- a/lib/repo_detail_service.dart
+++ b/lib/repo_detail_service.dart
@@ -127,6 +127,7 @@ class RepoDetailService {
     for (final pr in data) {
       if (pr is! Map) continue;
       final number = pr['number'];
+      if (number is! int) continue; // skip malformed entries (no "PR #null")
       final title = _str(pr, 'title') ?? 'Untitled PR';
       final author = _nested(pr['user'], 'login') ?? 'unknown';
       final url = _str(pr, 'html_url');
@@ -164,13 +165,13 @@ class RepoDetailService {
     for (final pr in data) {
       if (pr is! Map) continue;
       final id = pr['pullRequestId'];
+      if (id is! int) continue; // skip malformed entries (no "PR #null")
       final title = _str(pr, 'title') ?? 'Untitled PR';
       final author = _nested(pr['createdBy'], 'displayName') ?? 'unknown';
       final draft = pr['isDraft'] == true;
-      final url = id == null
-          ? null
-          : 'https://dev.azure.com/$organization/$project/_git/$name/'
-                'pullrequest/$id';
+      final url =
+          'https://dev.azure.com/$organization/$project/_git/$name/'
+          'pullrequest/$id';
       final reviewers = pr['reviewers'];
       final votes = <int>[];
       if (reviewers is List) {
@@ -300,29 +301,38 @@ class RepoDetailService {
         releasesFailed: true,
       );
     }
-    for (final raw in prefs.getStringList(RepoStore.adoKey) ?? const []) {
-      final map = _decode(raw);
-      if (map == null) continue;
-      final organization = _str(map, 'organization');
-      final project = _str(map, 'project');
-      final name = _str(map, 'repoName');
-      if (organization == null || project == null || name == null) continue;
-      if (RepoDiscoveryService.adoKey(organization, project, name) != repoKey) {
-        continue;
+    if (provider == 'ado') {
+      for (final raw in prefs.getStringList(RepoStore.adoKey) ?? const []) {
+        final map = _decode(raw);
+        if (map == null) continue;
+        final organization = _str(map, 'organization');
+        final project = _str(map, 'project');
+        final name = _str(map, 'repoName');
+        if (organization == null || project == null || name == null) continue;
+        if (RepoDiscoveryService.adoKey(organization, project, name) !=
+            repoKey) {
+          continue;
+        }
+        return loadAdo(
+          organization: organization,
+          project: project,
+          name: name,
+          tokenId: _str(map, 'tokenId'),
+          client: client,
+          now: now,
+        );
       }
-      return loadAdo(
-        organization: organization,
-        project: project,
-        name: name,
-        tokenId: _str(map, 'tokenId'),
-        client: client,
-        now: now,
+      return const RepoDetailData(
+        releasesSupported: false,
+        pullsFailed: true,
+        ciFailed: true,
       );
     }
+    // Unknown provider — surface as a failure rather than guessing.
     return const RepoDetailData(
-      releasesSupported: false,
       pullsFailed: true,
       ciFailed: true,
+      releasesFailed: true,
     );
   }
 

--- a/lib/repo_detail_service.dart
+++ b/lib/repo_detail_service.dart
@@ -482,7 +482,9 @@ class RepoDetailService {
           if (repoResp.statusCode != 200) return null;
           final decoded = jsonDecode(repoResp.body);
           final repositoryId = decoded is Map ? _str(decoded, 'id') : null;
-          if (repositoryId == null) return const <RepoRun>[];
+          // A repo we can't resolve to a GUID means CI couldn't be scoped —
+          // treat it as a failure, not "no runs".
+          if (repositoryId == null) return null;
           final response = await httpClient
               .get(
                 Uri.https(

--- a/lib/repo_detail_service.dart
+++ b/lib/repo_detail_service.dart
@@ -1,0 +1,576 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'repo_discovery_service.dart';
+import 'repo_store.dart';
+import 'token_store.dart';
+
+/// Review state of an open pull request, provider-normalized.
+abstract final class PrReviewState {
+  static const String waiting = 'waiting';
+  static const String approved = 'approved';
+  static const String changesRequested = 'changesRequested';
+  static const String none = 'none';
+}
+
+/// An open pull request shown on the repo detail screen.
+class RepoPr {
+  const RepoPr({
+    required this.label,
+    required this.title,
+    required this.author,
+    required this.reviewState,
+    this.ageDays,
+    this.draft = false,
+    this.url,
+  });
+
+  final String label; // e.g. "PR #7"
+  final String title;
+  final String author;
+  final String reviewState; // one of PrReviewState
+  final int? ageDays;
+  final bool draft;
+  final String? url;
+}
+
+/// A CI run/build for the repo.
+class RepoRun {
+  const RepoRun({
+    required this.name,
+    required this.status,
+    required this.conclusion,
+    this.branch,
+    this.finishedAt,
+    this.url,
+  });
+
+  final String name;
+
+  /// Provider status, e.g. `completed`/`in_progress` (GitHub) or
+  /// `completed`/`inProgress` (ADO).
+  final String status;
+
+  /// Outcome when finished: `success`/`failure`/`cancelled`/... or '' when the
+  /// run is still in progress.
+  final String conclusion;
+  final String? branch;
+  final DateTime? finishedAt;
+  final String? url;
+}
+
+/// A published release/tag.
+class RepoRelease {
+  const RepoRelease({
+    required this.tag,
+    this.name,
+    this.author,
+    this.publishedAt,
+    this.url,
+  });
+
+  final String tag;
+  final String? name;
+  final String? author;
+  final DateTime? publishedAt;
+  final String? url;
+}
+
+/// Everything the repo detail screen renders (besides the reused activity feed).
+class RepoDetailData {
+  const RepoDetailData({
+    this.pulls = const [],
+    this.ci = const [],
+    this.releases = const [],
+    this.releasesSupported = true,
+    this.pullsFailed = false,
+    this.ciFailed = false,
+    this.releasesFailed = false,
+  });
+
+  final List<RepoPr> pulls;
+  final List<RepoRun> ci;
+  final List<RepoRelease> releases;
+
+  /// False for providers without a releases concept (Azure DevOps).
+  final bool releasesSupported;
+
+  /// Per-source load failures so each tab can distinguish "empty" from "failed".
+  final bool pullsFailed;
+  final bool ciFailed;
+  final bool releasesFailed;
+
+  /// Number of sources that errored or returned a non-200 status.
+  int get failedSources =>
+      (pullsFailed ? 1 : 0) + (ciFailed ? 1 : 0) + (releasesFailed ? 1 : 0);
+}
+
+/// Fetches per-repository detail — open pull requests (with review state), CI
+/// history, and releases — for the repo detail screen. Per-source failures are
+/// isolated. The activity timeline is sourced separately via
+/// `ActivityFeedService`.
+class RepoDetailService {
+  RepoDetailService._();
+
+  static const Duration _requestTimeout = Duration(seconds: 20);
+
+  // ---- Pure, testable normalizers ------------------------------------------
+
+  /// Normalizes a GitHub open-PR list. GitHub approved/changes-requested state
+  /// needs the per-PR reviews API (a later milestone), so review state here is
+  /// `waiting` (reviewers still requested) or `none`.
+  static List<RepoPr> parseGithubPulls(List<dynamic> data, DateTime now) {
+    final result = <RepoPr>[];
+    for (final pr in data) {
+      if (pr is! Map) continue;
+      final number = pr['number'];
+      final title = _str(pr, 'title') ?? 'Untitled PR';
+      final author = _nested(pr['user'], 'login') ?? 'unknown';
+      final url = _str(pr, 'html_url');
+      final draft = pr['draft'] == true;
+      final reviewers = pr['requested_reviewers'];
+      final teams = pr['requested_teams'];
+      final waiting =
+          (reviewers is List && reviewers.isNotEmpty) ||
+          (teams is List && teams.isNotEmpty);
+      result.add(
+        RepoPr(
+          label: 'PR #$number',
+          title: title,
+          author: author,
+          reviewState: waiting ? PrReviewState.waiting : PrReviewState.none,
+          ageDays: _ageDays(pr['created_at'], now),
+          draft: draft,
+          url: url,
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// Normalizes an Azure DevOps active-PR list; reviewer votes map to review
+  /// state (10/5 approved, <0 changes requested, 0 waiting).
+  static List<RepoPr> parseAdoPulls(
+    List<dynamic> data,
+    DateTime now, {
+    required String organization,
+    required String project,
+    required String name,
+  }) {
+    final result = <RepoPr>[];
+    for (final pr in data) {
+      if (pr is! Map) continue;
+      final id = pr['pullRequestId'];
+      final title = _str(pr, 'title') ?? 'Untitled PR';
+      final author = _nested(pr['createdBy'], 'displayName') ?? 'unknown';
+      final draft = pr['isDraft'] == true;
+      final url = id == null
+          ? null
+          : 'https://dev.azure.com/$organization/$project/_git/$name/'
+                'pullrequest/$id';
+      final reviewers = pr['reviewers'];
+      final votes = <int>[];
+      if (reviewers is List) {
+        for (final r in reviewers) {
+          if (r is Map && r['vote'] is int) votes.add(r['vote'] as int);
+        }
+      }
+      final String state;
+      if (votes.any((v) => v < 0)) {
+        state = PrReviewState.changesRequested;
+      } else if (votes.any((v) => v == 0)) {
+        // A pending (0) vote outranks approvals: the PR still needs review.
+        state = PrReviewState.waiting;
+      } else if (votes.any((v) => v > 0)) {
+        state = PrReviewState.approved;
+      } else {
+        state = PrReviewState.none;
+      }
+      result.add(
+        RepoPr(
+          label: 'PR #$id',
+          title: title,
+          author: author,
+          reviewState: state,
+          ageDays: _ageDays(pr['creationDate'], now),
+          draft: draft,
+          url: url,
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// Normalizes a GitHub Actions `/actions/runs` response into CI runs.
+  static List<RepoRun> parseGithubRuns(dynamic body) {
+    final runs = body is Map ? body['workflow_runs'] : null;
+    if (runs is! List) return const [];
+    final result = <RepoRun>[];
+    for (final run in runs) {
+      if (run is! Map) continue;
+      result.add(
+        RepoRun(
+          name: _str(run, 'name') ?? _str(run, 'display_title') ?? 'Workflow',
+          status: _str(run, 'status') ?? 'unknown',
+          conclusion: _str(run, 'conclusion') ?? '',
+          branch: _str(run, 'head_branch'),
+          finishedAt: _parseDate(run['updated_at']),
+          url: _str(run, 'html_url'),
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// Normalizes an Azure DevOps builds response into CI runs.
+  static List<RepoRun> parseAdoBuilds(dynamic body) {
+    final builds = body is Map ? body['value'] : body;
+    if (builds is! List) return const [];
+    final result = <RepoRun>[];
+    for (final build in builds) {
+      if (build is! Map) continue;
+      result.add(
+        RepoRun(
+          name: _nested(build['definition'], 'name') ?? 'Build',
+          status: _str(build, 'status') ?? 'unknown',
+          conclusion: _str(build, 'result') ?? '',
+          branch: _branchFromRef(_str(build, 'sourceBranch')),
+          finishedAt: _parseDate(build['finishTime']),
+          url: _nested(_nested2(build['_links'], 'web'), 'href'),
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// Normalizes a GitHub `/releases` response.
+  static List<RepoRelease> parseGithubReleases(List<dynamic> data) {
+    final result = <RepoRelease>[];
+    for (final release in data) {
+      if (release is! Map) continue;
+      final tag = _str(release, 'tag_name');
+      if (tag == null || tag.isEmpty) continue;
+      result.add(
+        RepoRelease(
+          tag: tag,
+          name: _str(release, 'name'),
+          author: _nested(release['author'], 'login'),
+          publishedAt: _parseDate(release['published_at']),
+          url: _str(release, 'html_url'),
+        ),
+      );
+    }
+    return result;
+  }
+
+  // ---- Fetching ------------------------------------------------------------
+
+  /// Resolves the persisted repo record for [repoKey] (so the repo's own
+  /// `tokenId` and structured identity are used, not a scope-guessed fallback)
+  /// and loads its detail. [provider] is `github` or `ado`.
+  static Future<RepoDetailData> load({
+    required String repoKey,
+    required String provider,
+    http.Client? client,
+    DateTime? now,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (provider == 'github') {
+      for (final raw in prefs.getStringList(RepoStore.githubKey) ?? const []) {
+        final map = _decode(raw);
+        if (map == null) continue;
+        final owner = _str(map, 'owner');
+        final name = _str(map, 'repoName');
+        if (owner == null || name == null) continue;
+        if (RepoDiscoveryService.githubKey(owner, name) != repoKey) continue;
+        return loadGithub(
+          owner: owner,
+          name: name,
+          tokenId: _str(map, 'tokenId'),
+          client: client,
+          now: now,
+        );
+      }
+      return const RepoDetailData(
+        pullsFailed: true,
+        ciFailed: true,
+        releasesFailed: true,
+      );
+    }
+    for (final raw in prefs.getStringList(RepoStore.adoKey) ?? const []) {
+      final map = _decode(raw);
+      if (map == null) continue;
+      final organization = _str(map, 'organization');
+      final project = _str(map, 'project');
+      final name = _str(map, 'repoName');
+      if (organization == null || project == null || name == null) continue;
+      if (RepoDiscoveryService.adoKey(organization, project, name) != repoKey) {
+        continue;
+      }
+      return loadAdo(
+        organization: organization,
+        project: project,
+        name: name,
+        tokenId: _str(map, 'tokenId'),
+        client: client,
+        now: now,
+      );
+    }
+    return const RepoDetailData(
+      releasesSupported: false,
+      pullsFailed: true,
+      ciFailed: true,
+    );
+  }
+
+  static Future<RepoDetailData> loadGithub({
+    required String owner,
+    required String name,
+    String? tokenId,
+    http.Client? client,
+    DateTime? now,
+  }) async {
+    final httpClient = client ?? http.Client();
+    final effectiveNow = now ?? DateTime.now();
+    try {
+      final secret = (await TokenStore.resolveGithubSecret(
+        owner,
+        tokenId: tokenId,
+      ))?.trim();
+      if (secret == null || secret.isEmpty) {
+        return const RepoDetailData(
+          pullsFailed: true,
+          ciFailed: true,
+          releasesFailed: true,
+        );
+      }
+      final headers = {
+        'Authorization': 'Bearer $secret',
+        'Accept': 'application/vnd.github+json',
+      };
+
+      final results = await Future.wait([
+        _guard('GitHub pulls', () async {
+          final response = await httpClient
+              .get(
+                Uri.https('api.github.com', '/repos/$owner/$name/pulls', {
+                  'state': 'open',
+                  'per_page': '50',
+                }),
+                headers: headers,
+              )
+              .timeout(_requestTimeout);
+          if (response.statusCode != 200) return null;
+          final body = jsonDecode(response.body);
+          return body is List ? parseGithubPulls(body, effectiveNow) : null;
+        }),
+        _guard('GitHub runs', () async {
+          final response = await httpClient
+              .get(
+                Uri.https(
+                  'api.github.com',
+                  '/repos/$owner/$name/actions/runs',
+                  {'per_page': '15'},
+                ),
+                headers: headers,
+              )
+              .timeout(_requestTimeout);
+          if (response.statusCode != 200) return null;
+          return parseGithubRuns(jsonDecode(response.body));
+        }),
+        _guard('GitHub releases', () async {
+          final response = await httpClient
+              .get(
+                Uri.https('api.github.com', '/repos/$owner/$name/releases', {
+                  'per_page': '10',
+                }),
+                headers: headers,
+              )
+              .timeout(_requestTimeout);
+          if (response.statusCode != 200) return null;
+          final body = jsonDecode(response.body);
+          return body is List ? parseGithubReleases(body) : null;
+        }),
+      ]);
+      final pulls = results[0] as List<RepoPr>?;
+      final ci = results[1] as List<RepoRun>?;
+      final releases = results[2] as List<RepoRelease>?;
+
+      return RepoDetailData(
+        pulls: pulls ?? const [],
+        ci: ci ?? const [],
+        releases: releases ?? const [],
+        pullsFailed: pulls == null,
+        ciFailed: ci == null,
+        releasesFailed: releases == null,
+      );
+    } finally {
+      if (client == null) httpClient.close();
+    }
+  }
+
+  static Future<RepoDetailData> loadAdo({
+    required String organization,
+    required String project,
+    required String name,
+    String? tokenId,
+    http.Client? client,
+    DateTime? now,
+  }) async {
+    final httpClient = client ?? http.Client();
+    final effectiveNow = now ?? DateTime.now();
+    try {
+      final secret = (await TokenStore.resolveAdoSecret(
+        organization,
+        tokenId: tokenId,
+      ))?.trim();
+      if (secret == null || secret.isEmpty) {
+        return const RepoDetailData(
+          releasesSupported: false,
+          pullsFailed: true,
+          ciFailed: true,
+        );
+      }
+      final headers = {
+        'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
+      };
+
+      final results = await Future.wait([
+        _guard('ADO pulls', () async {
+          final response = await httpClient
+              .get(
+                Uri.https(
+                  'dev.azure.com',
+                  '/$organization/$project/_apis/git/repositories/$name/pullrequests',
+                  {
+                    'searchCriteria.status': 'active',
+                    r'$top': '50',
+                    'api-version': '6.0',
+                  },
+                ),
+                headers: headers,
+              )
+              .timeout(_requestTimeout);
+          if (response.statusCode != 200) return null;
+          final body = jsonDecode(response.body);
+          final value = body is Map ? body['value'] : body;
+          return value is List
+              ? parseAdoPulls(
+                  value,
+                  effectiveNow,
+                  organization: organization,
+                  project: project,
+                  name: name,
+                )
+              : null;
+        }),
+        _guard('ADO builds', () async {
+          // Builds are project-wide; scope to THIS repo by resolving its GUID.
+          final repoResp = await httpClient
+              .get(
+                Uri.https(
+                  'dev.azure.com',
+                  '/$organization/$project/_apis/git/repositories/$name',
+                  {'api-version': '6.0'},
+                ),
+                headers: headers,
+              )
+              .timeout(_requestTimeout);
+          if (repoResp.statusCode != 200) return null;
+          final decoded = jsonDecode(repoResp.body);
+          final repositoryId = decoded is Map ? _str(decoded, 'id') : null;
+          if (repositoryId == null) return const <RepoRun>[];
+          final response = await httpClient
+              .get(
+                Uri.https(
+                  'dev.azure.com',
+                  '/$organization/$project/_apis/build/builds',
+                  {
+                    'repositoryId': repositoryId,
+                    'repositoryType': 'TfsGit',
+                    r'$top': '15',
+                    'api-version': '6.0',
+                  },
+                ),
+                headers: headers,
+              )
+              .timeout(_requestTimeout);
+          if (response.statusCode != 200) return null;
+          return parseAdoBuilds(jsonDecode(response.body));
+        }),
+      ]);
+      final pulls = results[0] as List<RepoPr>?;
+      final ci = results[1] as List<RepoRun>?;
+
+      return RepoDetailData(
+        pulls: pulls ?? const [],
+        ci: ci ?? const [],
+        releasesSupported: false,
+        pullsFailed: pulls == null,
+        ciFailed: ci == null,
+      );
+    } finally {
+      if (client == null) httpClient.close();
+    }
+  }
+
+  // ---- Helpers -------------------------------------------------------------
+
+  static Future<T?> _guard<T>(
+    String source,
+    Future<T?> Function() action,
+  ) async {
+    try {
+      return await action();
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('RepoDetailService: $source failed: $e');
+      }
+      return null;
+    }
+  }
+
+  static int? _ageDays(dynamic isoDate, DateTime now) {
+    final parsed = _parseDate(isoDate);
+    if (parsed == null) return null;
+    final diff = now.toUtc().difference(parsed).inDays;
+    return diff < 0 ? 0 : diff;
+  }
+
+  static DateTime? _parseDate(dynamic value) {
+    if (value is! String || value.isEmpty) return null;
+    return DateTime.tryParse(value)?.toUtc();
+  }
+
+  static String _branchFromRef(String? ref) {
+    if (ref == null || ref.isEmpty) return '';
+    const prefixes = ['refs/heads/', 'refs/tags/'];
+    for (final prefix in prefixes) {
+      if (ref.startsWith(prefix)) return ref.substring(prefix.length);
+    }
+    return ref;
+  }
+
+  static String? _str(Map map, String key) {
+    final value = map[key];
+    return value is String ? value : null;
+  }
+
+  static Map<String, dynamic>? _decode(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      return decoded is Map ? Map<String, dynamic>.from(decoded) : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static String? _nested(dynamic map, String key) =>
+      map is Map && map[key] is String ? map[key] as String : null;
+
+  static dynamic _nested2(dynamic map, String key) =>
+      map is Map ? map[key] : null;
+}

--- a/lib/team_detail_page.dart
+++ b/lib/team_detail_page.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'activity_event.dart';
 import 'activity_event_list.dart';
 import 'activity_feed_service.dart';
 import 'activity_service.dart';
 import 'app_http.dart';
+import 'repo_detail_page.dart';
 import 'team.dart';
 import 'team_service.dart';
 
@@ -209,8 +209,11 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
           fontSize: 12,
         ),
       ),
-      trailing: const Icon(Icons.open_in_new, size: 16),
-      onTap: () => _open(repo.url),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => RepoDetailPage(repo: repo)),
+      ),
     );
   }
 
@@ -274,28 +277,5 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
   String _relativeTime(DateTime? value) {
     if (value == null) return 'no activity';
     return activityRelativeTime(value);
-  }
-
-  Future<void> _open(String url) async {
-    final uri = Uri.tryParse(url);
-    if (uri == null) {
-      _showOpenError(url);
-      return;
-    }
-    final canLaunch = await canLaunchUrl(uri);
-    if (!mounted) return;
-    if (!canLaunch) {
-      _showOpenError(url);
-      return;
-    }
-    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
-    if (!mounted) return;
-    if (!launched) _showOpenError(url);
-  }
-
-  void _showOpenError(String url) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text('Could not open $url')));
   }
 }

--- a/test/repo_detail_service_test.dart
+++ b/test/repo_detail_service_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/repo_detail_service.dart';
+
+void main() {
+  final now = DateTime.parse('2026-07-15T12:00:00Z');
+
+  group('parseGithubPulls', () {
+    test(
+      'maps requested reviewers to waiting, else none; parses age/draft',
+      () {
+        final pulls = RepoDetailService.parseGithubPulls([
+          {
+            'number': 7,
+            'title': 'Add feature',
+            'user': {'login': 'alice'},
+            'created_at': '2026-07-13T12:00:00Z',
+            'html_url': 'https://github.com/acme/api/pull/7',
+            'requested_reviewers': [
+              {'login': 'bob'},
+            ],
+          },
+          {
+            'number': 8,
+            'title': 'WIP',
+            'user': {'login': 'carol'},
+            'created_at': '2026-07-15T00:00:00Z',
+            'draft': true,
+            'requested_reviewers': [],
+          },
+        ], now);
+
+        expect(pulls, hasLength(2));
+        expect(pulls[0].label, 'PR #7');
+        expect(pulls[0].reviewState, PrReviewState.waiting);
+        expect(pulls[0].ageDays, 2);
+        expect(pulls[0].draft, isFalse);
+        expect(pulls[1].reviewState, PrReviewState.none);
+        expect(pulls[1].draft, isTrue);
+      },
+    );
+  });
+
+  group('parseAdoPulls', () {
+    test('derives review state from reviewer votes and builds the URL', () {
+      List<RepoPr> parse(List<int> votes) => RepoDetailService.parseAdoPulls(
+        [
+          {
+            'pullRequestId': 12,
+            'title': 'Ship',
+            'createdBy': {'displayName': 'Jane Doe'},
+            'creationDate': '2026-07-14T12:00:00Z',
+            'reviewers': [
+              for (final v in votes) {'vote': v},
+            ],
+          },
+        ],
+        now,
+        organization: 'contoso',
+        project: 'web',
+        name: 'site',
+      );
+
+      expect(parse([-5]).single.reviewState, PrReviewState.changesRequested);
+      expect(parse([10]).single.reviewState, PrReviewState.approved);
+      expect(parse([0]).single.reviewState, PrReviewState.waiting);
+      // A pending (0) vote outranks an approval: still needs review.
+      expect(parse([10, 0]).single.reviewState, PrReviewState.waiting);
+      // A rejection outranks everything.
+      expect(
+        parse([10, -5, 0]).single.reviewState,
+        PrReviewState.changesRequested,
+      );
+      expect(parse(const []).single.reviewState, PrReviewState.none);
+      expect(
+        parse([10]).single.url,
+        'https://dev.azure.com/contoso/web/_git/site/pullrequest/12',
+      );
+    });
+  });
+
+  group('parseGithubRuns / parseAdoBuilds', () {
+    test('parseGithubRuns extracts name/status/conclusion/branch', () {
+      final runs = RepoDetailService.parseGithubRuns({
+        'workflow_runs': [
+          {
+            'name': 'CI',
+            'status': 'completed',
+            'conclusion': 'failure',
+            'head_branch': 'main',
+            'updated_at': '2026-07-14T10:00:00Z',
+            'html_url': 'https://github.com/acme/api/actions/runs/1',
+          },
+        ],
+      });
+      expect(runs.single.name, 'CI');
+      expect(runs.single.status, 'completed');
+      expect(runs.single.conclusion, 'failure');
+      expect(runs.single.branch, 'main');
+    });
+
+    test('parseAdoBuilds strips the ref prefix and reads result', () {
+      final runs = RepoDetailService.parseAdoBuilds({
+        'value': [
+          {
+            'definition': {'name': 'Nightly'},
+            'status': 'completed',
+            'result': 'succeeded',
+            'sourceBranch': 'refs/heads/main',
+            'finishTime': '2026-07-14T06:00:00Z',
+            '_links': {
+              'web': {'href': 'https://dev.azure.com/contoso/web/_build/1'},
+            },
+          },
+        ],
+      });
+      expect(runs.single.name, 'Nightly');
+      expect(runs.single.conclusion, 'succeeded');
+      expect(runs.single.branch, 'main');
+      expect(runs.single.url, 'https://dev.azure.com/contoso/web/_build/1');
+    });
+  });
+
+  group('parseGithubReleases', () {
+    test('parses releases and skips entries without a tag', () {
+      final releases = RepoDetailService.parseGithubReleases([
+        {
+          'tag_name': 'v1.2.0',
+          'name': 'Big release',
+          'author': {'login': 'octocat'},
+          'published_at': '2026-07-10T09:00:00Z',
+          'html_url': 'https://github.com/acme/api/releases/v1.2.0',
+        },
+        {'name': 'no tag'},
+      ]);
+      expect(releases, hasLength(1));
+      expect(releases.single.tag, 'v1.2.0');
+      expect(releases.single.name, 'Big release');
+      expect(releases.single.author, 'octocat');
+    });
+  });
+}

--- a/test/repo_detail_service_test.dart
+++ b/test/repo_detail_service_test.dart
@@ -1,5 +1,12 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:kode_radar/repo_detail_service.dart';
+import 'package:kode_radar/token_store.dart';
 
 void main() {
   final now = DateTime.parse('2026-07-15T12:00:00Z');
@@ -136,6 +143,72 @@ void main() {
       expect(releases.single.tag, 'v1.2.0');
       expect(releases.single.name, 'Big release');
       expect(releases.single.author, 'octocat');
+    });
+  });
+
+  group('load', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      FlutterSecureStorage.setMockInitialValues({});
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('resolves the repo record and honors its explicit tokenId', () async {
+      // A same-scope default token and the repo's explicitly assigned token.
+      await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Default',
+        scope: 'acme',
+        secret: 'ghp_default',
+      );
+      final assigned = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'Assigned',
+        scope: 'other',
+        secret: 'ghp_assigned',
+      );
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList('github_repos', [
+        jsonEncode({
+          'owner': 'acme',
+          'repoName': 'api',
+          'tokenId': assigned.id,
+        }),
+      ]);
+
+      String? capturedAuth;
+      final client = MockClient((request) async {
+        if (request.url.path == '/repos/acme/api/pulls') {
+          capturedAuth =
+              request.headers['authorization'] ??
+              request.headers['Authorization'];
+          return http.Response('[]', 200);
+        }
+        if (request.url.path == '/repos/acme/api/actions/runs') {
+          return http.Response(jsonEncode({'workflow_runs': []}), 200);
+        }
+        return http.Response('[]', 200);
+      });
+
+      final data = await RepoDetailService.load(
+        repoKey: 'github:acme/api',
+        provider: 'github',
+        client: client,
+        now: now,
+      );
+
+      expect(data.failedSources, 0);
+      // The repo's own token (not the scope-default) must be used.
+      expect(capturedAuth, contains('ghp_assigned'));
+    });
+
+    test('reports failure when the repo record is not found', () async {
+      final data = await RepoDetailService.load(
+        repoKey: 'github:missing/repo',
+        provider: 'github',
+        now: now,
+      );
+      expect(data.failedSources, greaterThan(0));
     });
   });
 }


### PR DESCRIPTION
## What

A **per-repository detail drill-down**. Tapping a repo (Radar page, or a team's Repositories tab) now opens `RepoDetailPage` instead of jumping straight to the browser.

- **`lib/repo_detail_page.dart`** — tabbed drill-down: **Pull requests** (open PRs with review state + age), **CI** (recent runs/builds), **Releases** (GitHub only), and **Activity** (recent events, reusing `ActivityFeedService` scoped to the repo + the shared `ActivityEventList`). Contributors header, open-in-browser action, and per-tab empty-vs-failed states.
- **`lib/repo_detail_service.dart`** — models + pure normalizers (`parseGithubPulls`/`parseAdoPulls`/`parseGithubRuns`/`parseAdoBuilds`/`parseGithubReleases`) and `load(repoKey, provider)`, which resolves the persisted repo record (so the repo's own `tokenId` + structured identity are used, not a scope-guessed fallback) then fetches sources **concurrently** with per-source failure isolation.
- **`lib/radar_page.dart`, `lib/team_detail_page.dart`** — open `RepoDetailPage` on tap (removed the now-dead url-launch code).

## Notes

- GitHub review state is `waiting`/`none` (approved/changes-requested needs the per-PR reviews API — a later milestone); ADO uses reviewer votes for full state.
- ADO has no releases concept, so that tab is hidden for ADO repos.

## Validation

`flutter analyze --fatal-infos` clean, `dart format` clean, **109 tests pass** (+5). Reviewed with code-review + rubber-duck; their feedback (resolve the repo's own tokenId by repoKey, ADO mixed-vote precedence, per-tab failure states, concurrent fetches) is implemented. Deployed to device for hands-on testing.
