### PR TITLE
Lifecycle-aware polling to save battery and API rate limit

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'identity_store.dart';
 import 'snooze_store.dart';
 import 'notification_service.dart';
 import 'config_revision.dart';
+import 'polling_lifecycle.dart';
 import 'dart:async'; // Import for Timer
 import 'package:tray_manager/tray_manager.dart'; // Import tray_manager package
 import 'package:window_manager/window_manager.dart'; // Import window_manager package
@@ -143,7 +144,7 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
+class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   /// The selected primary tab: 0 Attention, 1 Radar, 2 Activity, 3 Search.
   /// Radar is the default landing.
   int _selectedIndex = 1;
@@ -158,25 +159,47 @@ class _MyHomePageState extends State<MyHomePage> {
   Timer? _autoAddInitialTimer; // One-shot startup auto-add pass.
   bool _autoAddRunning = false; // Guards against overlapping auto-add passes.
 
+  late final PollingLifecyclePolicy _lifecyclePolicy = PollingLifecyclePolicy(
+    keepPollingInBackground: _isDesktopPlatform,
+  );
+  bool _backgrounded = false; // True while the app is backgrounded.
+  DateTime? _backgroundedAt; // When we entered the background, for catch-up.
+
   @override
   void initState() {
     super.initState();
-    _pollAttention(); // Seed the notification baseline and do the first poll.
-    _startLiveUpdates(); // Start periodic updates
-    _startAutoAdd(); // Start periodic auto-add of new repositories
+    WidgetsBinding.instance.addObserver(this); // Observe app lifecycle.
+    final initialState = WidgetsBinding.instance.lifecycleState;
+    if (initialState != null && _lifecyclePolicy.isBackground(initialState)) {
+      // Launched directly into the background. Record the state; on desktop keep
+      // polling at the slow cadence, on mobile wait for the first resume.
+      _backgrounded = true;
+      _backgroundedAt = DateTime.now();
+      if (!_lifecyclePolicy.suspendsInBackground) {
+        _pollAttention(); // Seed the notification baseline.
+        _startLiveUpdates(foreground: false);
+        _startAutoAdd();
+      }
+    } else {
+      _pollAttention(); // Seed the notification baseline and do the first poll.
+      _startLiveUpdates(); // Start periodic updates
+      _startAutoAdd(); // Start periodic auto-add of new repositories
+    }
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _updateTimer?.cancel(); // Cancel the timer when the widget is disposed
     _autoAddTimer?.cancel();
     _autoAddInitialTimer?.cancel();
     super.dispose();
   }
 
-  void _startLiveUpdates() {
+  void _startLiveUpdates({bool foreground = true}) {
+    _updateTimer?.cancel();
     _updateTimer = Timer.periodic(
-      const Duration(seconds: 15),
+      _lifecyclePolicy.pollInterval(foreground: foreground),
       (_) => _pollAttention(),
     );
   }
@@ -185,10 +208,76 @@ class _MyHomePageState extends State<MyHomePage> {
     // Run shortly after startup (once the initial load has settled), then on a
     // longer interval than the live-data poll.
     _autoAddInitialTimer = Timer(const Duration(seconds: 8), _runAutoAdd);
+    _startAutoAddPeriodic();
+  }
+
+  void _startAutoAddPeriodic() {
+    _autoAddTimer?.cancel();
     _autoAddTimer = Timer.periodic(
-      const Duration(minutes: 10),
+      _lifecyclePolicy.autoAddInterval,
       (_) => _runAutoAdd(),
     );
+  }
+
+  /// Adjusts polling to the app's foreground/background state so we stop (or
+  /// slow) hitting the network — saving battery and API rate limit — while
+  /// backgrounded, then refresh promptly on return. The decisions live in
+  /// [PollingLifecyclePolicy]: mobile suspends entirely (the OS pauses us
+  /// anyway); a desktop tray app keeps polling at a slower cadence so
+  /// notifications still arrive.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (_lifecyclePolicy.isBackground(state)) {
+      _enterBackground();
+    } else if (_lifecyclePolicy.isForeground(state)) {
+      _enterForeground();
+    }
+  }
+
+  void _enterBackground() {
+    if (_backgrounded) return;
+    _backgrounded = true;
+    _backgroundedAt = DateTime.now();
+    if (_lifecyclePolicy.suspendsInBackground) {
+      // Mobile: the OS suspends the process, so stop all polling (including the
+      // one-shot startup discovery). We refresh deliberately on resume instead.
+      _updateTimer?.cancel();
+      _updateTimer = null;
+      _autoAddInitialTimer?.cancel();
+      _autoAddInitialTimer = null;
+      _autoAddTimer?.cancel();
+      _autoAddTimer = null;
+    } else {
+      // Desktop tray app: keep delivering notifications, but slow the attention
+      // poll to the background cadence to spare the API rate limit. Auto-add
+      // (the startup one-shot and the periodic timer) keeps running.
+      _startLiveUpdates(foreground: false);
+    }
+  }
+
+  void _enterForeground() {
+    if (!_backgrounded) return;
+    _backgrounded = false;
+    final backgroundedFor = _backgroundedAt == null
+        ? Duration.zero
+        : DateTime.now().difference(_backgroundedAt!);
+    _backgroundedAt = null;
+
+    // Restore the fast foreground cadence and refresh immediately so the UI is
+    // not left showing stale data while it waits for the next tick.
+    _startLiveUpdates();
+    _pollAttention();
+
+    // If discovery was fully suspended (mobile), the timer was cancelled;
+    // restart it and run a catch-up pass if we were away long enough to have
+    // missed one. On desktop it kept running, so leave it untouched.
+    if (_autoAddTimer == null) {
+      _startAutoAddPeriodic();
+      if (_lifecyclePolicy.shouldRunAutoAddOnResume(backgroundedFor)) {
+        _runAutoAdd();
+      }
+    }
   }
 
   Future<void> _runAutoAdd() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -158,7 +158,8 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   Timer? _autoAddTimer; // Timer for the auto-add discovery pass.
   Timer? _autoAddInitialTimer; // One-shot startup auto-add pass.
   bool _autoAddRunning = false; // Guards against overlapping auto-add passes.
-  bool _didInitialAutoAdd = false; // Whether the startup discovery has run.
+  bool _hasCompletedAutoAdd =
+      false; // Whether at least one auto-add pass has completed.
 
   static const Duration _autoAddStartupDelay = Duration(seconds: 8);
 
@@ -297,10 +298,11 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
       _startAutoAddPeriodic();
       if (_lifecyclePolicy.shouldRunAutoAddOnResume(backgroundedFor)) {
         _runAutoAdd();
-      } else if (!_didInitialAutoAdd) {
-        // We backgrounded before the startup discovery ran (e.g. within the
-        // first few seconds of launch); re-arm it so discovery isn't deferred
-        // to the next periodic tick.
+      } else if (!_hasCompletedAutoAdd) {
+        // Mobile only (the timers were cancelled above): no discovery has
+        // completed yet — e.g. we backgrounded within the first seconds of
+        // launch — so re-arm the startup one-shot rather than waiting for the
+        // next periodic tick.
         _scheduleInitialAutoAdd();
       }
     }
@@ -311,10 +313,11 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
     _autoAddRunning = true;
     try {
       final added = await AutoAddService.run();
-      // Mark the startup discovery done only once a pass actually completes, so
-      // a failed pass still re-arms the one-shot startup discovery on the next
-      // resume rather than deferring to the periodic tick.
-      _didInitialAutoAdd = true;
+      // Record that a pass completed (only after run() succeeds). After a mobile
+      // suspension this stops us re-arming the startup one-shot once discovery
+      // has run at least once; a failed pass leaves it false so it retries on
+      // the next resume.
+      _hasCompletedAutoAdd = true;
       if (added > 0 && mounted) {
         // Newly discovered repos: refresh the surfaces now; the next poll
         // picks up any attention items they contain.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -193,10 +193,17 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    _updateTimer?.cancel(); // Cancel the timer when the widget is disposed
-    _autoAddTimer?.cancel();
-    _autoAddInitialTimer?.cancel();
+    _cancelPollingTimers(); // Stop all polling when the widget is disposed.
     super.dispose();
+  }
+
+  void _cancelPollingTimers() {
+    _updateTimer?.cancel();
+    _updateTimer = null;
+    _autoAddInitialTimer?.cancel();
+    _autoAddInitialTimer = null;
+    _autoAddTimer?.cancel();
+    _autoAddTimer = null;
   }
 
   void _startLiveUpdates({bool foreground = true}) {
@@ -236,11 +243,22 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
-    if (_lifecyclePolicy.isBackground(state)) {
+    if (state == AppLifecycleState.detached) {
+      _enterDetached();
+    } else if (_lifecyclePolicy.isBackground(state)) {
       _enterBackground();
     } else if (_lifecyclePolicy.isForeground(state)) {
       _enterForeground();
     }
+  }
+
+  void _enterDetached() {
+    // The engine detached the view (app terminating, or before the first frame
+    // at launch). Stop all network activity regardless of platform, and mark
+    // the app backgrounded so a later resume restarts polling.
+    _backgrounded = true;
+    _backgroundedAt ??= DateTime.now();
+    _cancelPollingTimers();
   }
 
   void _enterBackground() {
@@ -250,12 +268,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
     if (_lifecyclePolicy.suspendsInBackground) {
       // Mobile: the OS suspends the process, so stop all polling (including the
       // one-shot startup discovery). We refresh deliberately on resume instead.
-      _updateTimer?.cancel();
-      _updateTimer = null;
-      _autoAddInitialTimer?.cancel();
-      _autoAddInitialTimer = null;
-      _autoAddTimer?.cancel();
-      _autoAddTimer = null;
+      _cancelPollingTimers();
     } else {
       // Desktop tray app: keep delivering notifications, but slow the attention
       // poll to the background cadence to spare the API rate limit. Auto-add
@@ -296,9 +309,12 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   Future<void> _runAutoAdd() async {
     if (_autoAddRunning) return; // Skip if a pass is already in flight.
     _autoAddRunning = true;
-    _didInitialAutoAdd = true;
     try {
       final added = await AutoAddService.run();
+      // Mark the startup discovery done only once a pass actually completes, so
+      // a failed pass still re-arms the one-shot startup discovery on the next
+      // resume rather than deferring to the periodic tick.
+      _didInitialAutoAdd = true;
       if (added > 0 && mounted) {
         // Newly discovered repos: refresh the surfaces now; the next poll
         // picks up any attention items they contain.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:tray_manager/tray_manager.dart';
+import 'package:window_manager/window_manager.dart';
+
 import 'radar_page.dart';
 import 'attention_inbox_page.dart';
 import 'activity_feed_page.dart';
@@ -15,9 +19,6 @@ import 'snooze_store.dart';
 import 'notification_service.dart';
 import 'config_revision.dart';
 import 'polling_lifecycle.dart';
-import 'dart:async'; // Import for Timer
-import 'package:tray_manager/tray_manager.dart'; // Import tray_manager package
-import 'package:window_manager/window_manager.dart'; // Import window_manager package
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -158,6 +158,9 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   Timer? _autoAddTimer; // Timer for the auto-add discovery pass.
   Timer? _autoAddInitialTimer; // One-shot startup auto-add pass.
   bool _autoAddRunning = false; // Guards against overlapping auto-add passes.
+  bool _didInitialAutoAdd = false; // Whether the startup discovery has run.
+
+  static const Duration _autoAddStartupDelay = Duration(seconds: 8);
 
   late final PollingLifecyclePolicy _lifecyclePolicy = PollingLifecyclePolicy(
     keepPollingInBackground: _isDesktopPlatform,
@@ -207,8 +210,13 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   void _startAutoAdd() {
     // Run shortly after startup (once the initial load has settled), then on a
     // longer interval than the live-data poll.
-    _autoAddInitialTimer = Timer(const Duration(seconds: 8), _runAutoAdd);
+    _scheduleInitialAutoAdd();
     _startAutoAddPeriodic();
+  }
+
+  void _scheduleInitialAutoAdd() {
+    _autoAddInitialTimer?.cancel();
+    _autoAddInitialTimer = Timer(_autoAddStartupDelay, _runAutoAdd);
   }
 
   void _startAutoAddPeriodic() {
@@ -276,6 +284,11 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
       _startAutoAddPeriodic();
       if (_lifecyclePolicy.shouldRunAutoAddOnResume(backgroundedFor)) {
         _runAutoAdd();
+      } else if (!_didInitialAutoAdd) {
+        // We backgrounded before the startup discovery ran (e.g. within the
+        // first few seconds of launch); re-arm it so discovery isn't deferred
+        // to the next periodic tick.
+        _scheduleInitialAutoAdd();
       }
     }
   }
@@ -283,6 +296,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   Future<void> _runAutoAdd() async {
     if (_autoAddRunning) return; // Skip if a pass is already in flight.
     _autoAddRunning = true;
+    _didInitialAutoAdd = true;
     try {
       final added = await AutoAddService.run();
       if (added > 0 && mounted) {

--- a/lib/polling_lifecycle.dart
+++ b/lib/polling_lifecycle.dart
@@ -34,7 +34,6 @@ class PollingLifecyclePolicy {
   /// OS suspends the process, so polling is fully paused.
   final bool keepPollingInBackground;
 
-  /// Whether [state] means the app is effectively backgrounded and polling
   /// Whether [state] means the app is backgrounded (not visible) and polling
   /// should be suspended or slowed.
   ///

--- a/lib/polling_lifecycle.dart
+++ b/lib/polling_lifecycle.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/widgets.dart';
+
+/// Decides how the home shell's periodic polling should react to app lifecycle
+/// transitions, so we stop hitting the network — draining battery and burning
+/// GitHub / Azure DevOps API rate limit — while the app is backgrounded, and
+/// refresh promptly when it returns to the foreground.
+///
+/// This is deliberately pure (no timers, no I/O) so it can be unit tested; the
+/// widget owns the actual timers and network calls and delegates the decisions
+/// here.
+class PollingLifecyclePolicy {
+  const PollingLifecyclePolicy({
+    this.foregroundPollInterval = const Duration(seconds: 15),
+    this.backgroundPollInterval = const Duration(minutes: 2),
+    this.autoAddInterval = const Duration(minutes: 10),
+    this.keepPollingInBackground = false,
+  });
+
+  /// Attention poll cadence while the app is in the foreground.
+  final Duration foregroundPollInterval;
+
+  /// Attention poll cadence while the app is backgrounded but still running
+  /// (desktop tray). Only used when [keepPollingInBackground] is true.
+  final Duration backgroundPollInterval;
+
+  /// Foreground cadence of the auto-add discovery pass; also the threshold for
+  /// running a catch-up pass on resume.
+  final Duration autoAddInterval;
+
+  /// Whether the app keeps running — and should keep delivering notifications —
+  /// while backgrounded. True on desktop, where the window hides to the system
+  /// tray but the process keeps running, so polling continues at the slower
+  /// [backgroundPollInterval] instead of stopping. False on mobile, where the
+  /// OS suspends the process, so polling is fully paused.
+  final bool keepPollingInBackground;
+
+  /// Whether [state] means the app is effectively backgrounded and polling
+  /// Whether [state] means the app is backgrounded (not visible) and polling
+  /// should be suspended or slowed.
+  ///
+  /// True for [AppLifecycleState.paused] (mobile background) and
+  /// [AppLifecycleState.hidden] (e.g. a minimized/tray desktop window), but not
+  /// for [AppLifecycleState.inactive] — that also fires for a merely-unfocused
+  /// but still-visible desktop window or a transient iOS app-switcher peek,
+  /// where the foreground cadence should continue (see [isForeground]).
+  bool isBackground(AppLifecycleState state) =>
+      state == AppLifecycleState.paused || state == AppLifecycleState.hidden;
+
+  /// Whether [state] means the app is at least visible (foreground), so polling
+  /// should run at the foreground cadence.
+  ///
+  /// True for [AppLifecycleState.resumed] and [AppLifecycleState.inactive].
+  /// Including `inactive` matters on the way back from the background: the
+  /// lifecycle ladder is paused↔hidden↔inactive↔resumed, so a returning app
+  /// always passes through `inactive`, and a desktop window shown without focus
+  /// may settle on `inactive` without ever reaching `resumed`. Resuming there
+  /// too avoids getting stuck at the slow background cadence while visible.
+  bool isForeground(AppLifecycleState state) =>
+      state == AppLifecycleState.resumed || state == AppLifecycleState.inactive;
+
+  /// Whether polling should be fully suspended while backgrounded (mobile),
+  /// rather than continuing at [backgroundPollInterval] (desktop tray app).
+  bool get suspendsInBackground => !keepPollingInBackground;
+
+  /// The attention poll cadence for the given foreground state.
+  Duration pollInterval({required bool foreground}) =>
+      foreground ? foregroundPollInterval : backgroundPollInterval;
+
+  /// Whether a resume after being backgrounded for [backgroundedFor] should run
+  /// an immediate auto-add discovery pass. True once the background duration
+  /// reaches [autoAddInterval], since by then at least one scheduled pass was
+  /// skipped.
+  bool shouldRunAutoAddOnResume(Duration backgroundedFor) =>
+      backgroundedFor >= autoAddInterval;
+}

--- a/test/polling_lifecycle_test.dart
+++ b/test/polling_lifecycle_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/polling_lifecycle.dart';
+
+void main() {
+  const policy = PollingLifecyclePolicy(autoAddInterval: Duration(minutes: 10));
+
+  group('isBackground', () {
+    test('suspends polling when paused or hidden', () {
+      expect(policy.isBackground(AppLifecycleState.paused), isTrue);
+      expect(policy.isBackground(AppLifecycleState.hidden), isTrue);
+    });
+
+    test('keeps polling when resumed, inactive, or detached', () {
+      expect(policy.isBackground(AppLifecycleState.resumed), isFalse);
+      expect(policy.isBackground(AppLifecycleState.inactive), isFalse);
+      expect(policy.isBackground(AppLifecycleState.detached), isFalse);
+    });
+  });
+
+  group('isForeground', () {
+    test('true when the app is visible (resumed or inactive)', () {
+      expect(policy.isForeground(AppLifecycleState.resumed), isTrue);
+      expect(policy.isForeground(AppLifecycleState.inactive), isTrue);
+    });
+
+    test('false when hidden, paused, or detached', () {
+      for (final state in const [
+        AppLifecycleState.hidden,
+        AppLifecycleState.paused,
+        AppLifecycleState.detached,
+      ]) {
+        expect(policy.isForeground(state), isFalse, reason: '$state');
+      }
+    });
+
+    test('inactive resumes without being treated as background', () {
+      // On the way back from the background (paused→hidden→inactive→resumed) the
+      // app can settle on inactive; it must count as foreground, not background.
+      expect(policy.isBackground(AppLifecycleState.inactive), isFalse);
+      expect(policy.isForeground(AppLifecycleState.inactive), isTrue);
+    });
+  });
+
+  group('shouldRunAutoAddOnResume', () {
+    test('runs once the background duration reaches the auto-add interval', () {
+      expect(
+        policy.shouldRunAutoAddOnResume(const Duration(minutes: 10)),
+        isTrue,
+      );
+      expect(
+        policy.shouldRunAutoAddOnResume(const Duration(minutes: 25)),
+        isTrue,
+      );
+    });
+
+    test('does not run for short background stints', () {
+      expect(policy.shouldRunAutoAddOnResume(Duration.zero), isFalse);
+      expect(
+        policy.shouldRunAutoAddOnResume(
+          const Duration(minutes: 9, seconds: 59),
+        ),
+        isFalse,
+      );
+    });
+
+    test('honors a custom interval', () {
+      const custom = PollingLifecyclePolicy(
+        autoAddInterval: Duration(minutes: 2),
+      );
+      expect(
+        custom.shouldRunAutoAddOnResume(const Duration(minutes: 2)),
+        isTrue,
+      );
+      expect(
+        custom.shouldRunAutoAddOnResume(const Duration(minutes: 1)),
+        isFalse,
+      );
+    });
+  });
+
+  group('suspendsInBackground', () {
+    test('mobile (default) fully suspends while backgrounded', () {
+      expect(policy.suspendsInBackground, isTrue);
+    });
+
+    test('desktop tray app keeps polling in the background', () {
+      const desktop = PollingLifecyclePolicy(keepPollingInBackground: true);
+      expect(desktop.suspendsInBackground, isFalse);
+    });
+  });
+
+  group('pollInterval', () {
+    test('uses the foreground cadence in the foreground', () {
+      expect(
+        policy.pollInterval(foreground: true),
+        const Duration(seconds: 15),
+      );
+    });
+
+    test('uses the slower background cadence in the background', () {
+      expect(
+        policy.pollInterval(foreground: false),
+        const Duration(minutes: 2),
+      );
+    });
+
+    test('honors custom cadences', () {
+      const custom = PollingLifecyclePolicy(
+        foregroundPollInterval: Duration(seconds: 5),
+        backgroundPollInterval: Duration(minutes: 5),
+      );
+      expect(custom.pollInterval(foreground: true), const Duration(seconds: 5));
+      expect(
+        custom.pollInterval(foreground: false),
+        const Duration(minutes: 5),
+      );
+    });
+  });
+
+  test('defaults: 15s foreground, 2m background, 10m auto-add, suspends', () {
+    const defaults = PollingLifecyclePolicy();
+    expect(defaults.foregroundPollInterval, const Duration(seconds: 15));
+    expect(defaults.backgroundPollInterval, const Duration(minutes: 2));
+    expect(defaults.autoAddInterval, const Duration(minutes: 10));
+    expect(defaults.keepPollingInBackground, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

The home shell drove two always-on timers — a **15s attention/notification poll** and a **10min repo auto-discovery pass** — that kept hitting GitHub / Azure DevOps regardless of whether the app was in use, wasting battery and API rate limit while backgrounded.

This makes polling **lifecycle-aware** via a new pure `PollingLifecyclePolicy` and a `WidgetsBindingObserver` on the home shell, with a platform split that respects how the app actually runs on each platform.

## Behavior

- **Mobile** (`keepPollingInBackground: false`): the OS suspends the process when backgrounded, so all timers are cancelled on background. On resume it restarts at the foreground cadence, does an immediate refresh, and runs a **catch-up discovery pass** if it was away at least the auto-add interval.
- **Desktop** (`keepPollingInBackground: true`): the app keeps running in the **system tray** and must keep delivering notifications, so instead of stopping it **backs the attention poll off to 2min** (from 15s) and leaves discovery running — cutting request volume ~8× while still notifying.

## Lifecycle mapping

- Background = `paused` / `hidden`; foreground = `resumed` / `inactive`.
- `inactive` counts as **foreground** on purpose: the lifecycle ladder is `paused↔hidden↔inactive↔resumed`, so a returning (or shown-but-unfocused) desktop window can settle on `inactive` without ever reaching `resumed` — treating it as background would strand it at the slow cadence while visible.
- The initial lifecycle state is honored at launch in case the app starts backgrounded.
- Timer re-arming cancels before scheduling; `_pollAttention`/`_runAutoAdd` keep their existing re-entrancy guards, so rapid background↔foreground toggling can't leak or overlap.

## Tests

- New `test/polling_lifecycle_test.dart` unit-tests the pure policy (state classification, cadence selection, suspend-vs-keep-alive, catch-up threshold, defaults).
- Full suite: **210 passing**. `flutter analyze --fatal-infos` and `dart format` clean.
