### PR TITLE
Prune trend history and team assignments when a repo is removed

### DIFF
--- a/lib/digest_page.dart
+++ b/lib/digest_page.dart
@@ -37,7 +37,7 @@ class _DigestPageState extends State<DigestPage> {
       );
       // Record a trend snapshot from this load too (deduped ~1/day) before
       // reading history, so the digest reflects the latest observation.
-      await MetricStore.capture(activities);
+      await MetricStore.capture(activities, restrictToMonitored: true);
       final history = await MetricStore.all();
       final digest = DigestService.buildDigest(
         teams: teams,

--- a/lib/manage_repos_page.dart
+++ b/lib/manage_repos_page.dart
@@ -7,9 +7,12 @@ import 'register_github_repo.dart';
 import 'register_ado_repo.dart';
 import 'ignore_store.dart';
 import 'manage_ignored_page.dart';
+import 'metric_store.dart';
+import 'monitored_repos.dart';
 import 'repo_discovery_page.dart';
 import 'repo_discovery_service.dart';
 import 'repo_store.dart';
+import 'team_store.dart';
 import 'token_store.dart';
 
 enum _DeleteChoice { cancel, remove, removeAndIgnore }
@@ -99,7 +102,12 @@ class _ManageReposPageState extends State<ManageReposPage> {
     await _loadRepos();
   }
 
-  String? _ignoreKeyFor(bool github, Map<String, String> repo) {
+  /// The canonical key for a repo, in the shared `github:owner/name` /
+  /// `ado:org/project/name` form produced by [RepoDiscoveryService]. It matches
+  /// the ignore-list key as well as the `RepoActivity` / `MetricStore` / team
+  /// repo key, so it is reused both to ignore a repo and to prune its derived
+  /// data on delete. Returns null for invalid/incomplete entries.
+  String? _repoKeyFor(bool github, Map<String, String> repo) {
     if (repo.containsKey('_invalid')) return null;
     if (github) {
       final owner = repo['owner'];
@@ -173,13 +181,26 @@ class _ManageReposPageState extends State<ManageReposPage> {
     required bool github,
     required Map<String, String> repo,
   }) async {
-    final ignoreKey = _ignoreKeyFor(github, repo);
-    final choice = await _confirmDelete(label, canIgnore: ignoreKey != null);
+    final repoKey = _repoKeyFor(github, repo);
+    final choice = await _confirmDelete(label, canIgnore: repoKey != null);
     if (choice == _DeleteChoice.cancel) return;
-    if (choice == _DeleteChoice.removeAndIgnore && ignoreKey != null) {
-      await _removeAndIgnore(storageKey, index, ignoreKey);
+    if (choice == _DeleteChoice.removeAndIgnore && repoKey != null) {
+      await _removeAndIgnore(storageKey, index, repoKey);
     } else {
       await _deleteRepoAt(storageKey, index);
+    }
+    // Prune data derived from this repo so a removed repo doesn't linger in
+    // trend history or team assignments as a stale, otherwise-unbounded key.
+    // Skip pruning when a duplicate entry still resolves to the same canonical
+    // key, so shared data isn't removed out from under the surviving entry.
+    if (repoKey != null) {
+      final stillMonitored = (await listMonitoredRepos()).any(
+        (monitored) => monitored.repoKey == repoKey,
+      );
+      if (!stillMonitored) {
+        await MetricStore.removeRepo(repoKey);
+        await TeamStore.removeRepoFromAll(repoKey);
+      }
     }
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/metric_store.dart
+++ b/lib/metric_store.dart
@@ -5,6 +5,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'activity_service.dart';
 import 'metric_snapshot.dart';
+import 'monitored_repos.dart';
+import 'repo_store.dart';
 
 class MetricStore {
   MetricStore._();
@@ -25,15 +27,37 @@ class MetricStore {
   static bool shouldCapture(DateTime? lastAt, DateTime now) =>
       lastAt == null || now.difference(lastAt) >= minCaptureInterval;
 
-  static Future<void> capture(List<RepoActivity> activities, {DateTime? now}) {
+  /// Appends one snapshot per repo in [activities] (deduped to ~1/day).
+  ///
+  /// When [restrictToMonitored] is true, the currently-persisted repo lists are
+  /// re-read inside the lock and any activity whose repo is no longer monitored
+  /// is skipped. This closes a race where a screen's in-flight fetch (computed
+  /// before the user removed a repo) would otherwise re-insert the just-pruned
+  /// history key. It is safe in the normal case because `activities` is itself
+  /// derived from the monitored repos.
+  static Future<void> capture(
+    List<RepoActivity> activities, {
+    DateTime? now,
+    bool restrictToMonitored = false,
+  }) {
     final capturedAt = (now ?? DateTime.now()).toUtc();
     return runLocked(() async {
       final prefs = await SharedPreferences.getInstance();
       final histories = _readFrom(prefs);
       var changed = false;
 
+      final Set<String>? monitored = restrictToMonitored
+          ? parseMonitoredRepos(
+              prefs.getStringList(RepoStore.githubKey) ?? const <String>[],
+              prefs.getStringList(RepoStore.adoKey) ?? const <String>[],
+            ).map((repo) => repo.repoKey).toSet()
+          : null;
+
       for (final activity in activities) {
         if (activity.error != null) {
+          continue;
+        }
+        if (monitored != null && !monitored.contains(activity.repoKey)) {
           continue;
         }
 
@@ -61,6 +85,21 @@ class MetricStore {
       }
 
       if (changed) {
+        await _writeTo(prefs, histories);
+      }
+    });
+  }
+
+  /// Drops all captured history for [repoKey] (e.g. after the repo is removed
+  /// from monitoring) so deleted repos don't linger as unbounded stale keys.
+  /// Only writes when a history actually existed for the key.
+  static Future<void> removeRepo(String repoKey) {
+    final key = repoKey.trim();
+    if (key.isEmpty) return Future<void>.value();
+    return runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final histories = _readFrom(prefs);
+      if (histories.remove(key) != null) {
         await _writeTo(prefs, histories);
       }
     });

--- a/lib/radar_page.dart
+++ b/lib/radar_page.dart
@@ -56,7 +56,7 @@ class _RadarPageState extends State<RadarPage> {
       );
       if (!mounted || seq != _loadSeq) return;
       // Record a trend snapshot (deduped ~1/day), then load per-repo series.
-      await MetricStore.capture(activities);
+      await MetricStore.capture(activities, restrictToMonitored: true);
       final history = await MetricStore.all();
       if (!mounted || seq != _loadSeq) return;
       setState(() {

--- a/lib/team_store.dart
+++ b/lib/team_store.dart
@@ -79,6 +79,27 @@ class TeamStore {
     });
   }
 
+  /// Removes [repoKey] from every team's repo set (e.g. after the repo is
+  /// removed from monitoring) so deleted repos don't linger in team
+  /// assignments. Only writes when something actually changed.
+  static Future<void> removeRepoFromAll(String repoKey) {
+    final key = repoKey.trim();
+    if (key.isEmpty) return Future<void>.value();
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final teams = _readFrom(prefs);
+      var changed = false;
+      for (var index = 0; index < teams.length; index++) {
+        if (!teams[index].repoKeys.contains(key)) continue;
+        teams[index] = teams[index].copyWith(
+          repoKeys: teams[index].repoKeys.where((k) => k != key).toSet(),
+        );
+        changed = true;
+      }
+      if (changed) await _writeTo(prefs, teams);
+    });
+  }
+
   static List<Team> _readFrom(SharedPreferences prefs) {
     final raw = prefs.getString(_teamsKey);
     if (raw == null || raw.trim().isEmpty) return <Team>[];

--- a/lib/teams_page.dart
+++ b/lib/teams_page.dart
@@ -45,7 +45,7 @@ class _TeamsPageState extends State<TeamsPage> {
         client: AppHttp.client,
       );
       // Record a trend snapshot from this load too (deduped ~1/day).
-      await MetricStore.capture(activities);
+      await MetricStore.capture(activities, restrictToMonitored: true);
       final rollups = TeamService.rollupAll(teams, activities);
       final history = await MetricStore.all();
       final series = <String, List<num>>{

--- a/test/manage_repos_test.dart
+++ b/test/manage_repos_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:kode_radar/manage_repos_page.dart';
+import 'package:kode_radar/metric_store.dart';
+import 'package:kode_radar/team_store.dart';
 
 void main() {
   setUp(() {
@@ -34,14 +36,26 @@ void main() {
     expect(find.text('org/proj/repo'), findsOneWidget);
   });
 
-  testWidgets('deletes a repository after confirmation', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('deletes a repository after confirmation and prunes its derived '
+      'data', (WidgetTester tester) async {
+    const repoKey = 'github:flutter/flutter';
     SharedPreferences.setMockInitialValues({
       'github_repos': [
         jsonEncode({'owner': 'flutter', 'repoName': 'flutter'}),
       ],
       'ado_repos': <String>[],
+      'metric_history': jsonEncode({
+        repoKey: [
+          {'at': 0, 'openPrs': 1, 'needsReview': 0, 'activityScore': 1},
+        ],
+      }),
+      'teams': jsonEncode([
+        {
+          'id': 'team-1',
+          'name': 'Platform',
+          'repoKeys': [repoKey],
+        },
+      ]),
     });
 
     await tester.pumpWidget(const MaterialApp(home: ManageReposPage()));
@@ -61,6 +75,10 @@ void main() {
     expect(find.text('flutter/flutter'), findsNothing);
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getStringList('github_repos'), isEmpty);
+
+    // Its derived trend history and team assignment should be pruned too.
+    expect((await MetricStore.all()).containsKey(repoKey), isFalse);
+    expect((await TeamStore.list()).single.repoKeys, isEmpty);
   });
 
   testWidgets('shows an empty state when no repositories are tracked', (

--- a/test/metric_store_test.dart
+++ b/test/metric_store_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kode_radar/activity_service.dart';
 import 'package:kode_radar/metric_store.dart';
@@ -127,6 +129,57 @@ void main() {
     );
     expect(await MetricStore.seriesFor('github:owner/repo'), [3.5, 6.5]);
   });
+
+  test('removeRepo drops history for the given repo only', () async {
+    final now = DateTime.utc(2026, 1, 1, 12);
+
+    await MetricStore.capture([
+      _activity('github:owner/one', openPrCount: 1),
+      _activity('github:owner/two', openPrCount: 2),
+    ], now: now);
+
+    await MetricStore.removeRepo('github:owner/one');
+
+    final all = await MetricStore.all();
+    expect(all.keys, {'github:owner/two'});
+    expect(await MetricStore.historyFor('github:owner/one'), isEmpty);
+  });
+
+  test('removeRepo is a no-op for unknown or blank keys', () async {
+    final now = DateTime.utc(2026, 1, 1, 12);
+    await MetricStore.capture([_activity('github:owner/one')], now: now);
+
+    await MetricStore.removeRepo('github:owner/missing');
+    await MetricStore.removeRepo('  ');
+
+    expect((await MetricStore.all()).keys, {'github:owner/one'});
+  });
+
+  test(
+    'capture with restrictToMonitored skips repos no longer monitored',
+    () async {
+      final now = DateTime.utc(2026, 1, 1, 12);
+      SharedPreferences.setMockInitialValues({
+        'github_repos': [
+          jsonEncode({'owner': 'owner', 'repoName': 'one'}),
+        ],
+      });
+
+      // Simulates an in-flight fetch (computed before a repo was removed) trying
+      // to re-insert history for a repo that is no longer monitored.
+      await MetricStore.capture(
+        [
+          _activity('github:owner/one', openPrCount: 1),
+          _activity('github:owner/gone', openPrCount: 2),
+        ],
+        now: now,
+        restrictToMonitored: true,
+      );
+
+      final all = await MetricStore.all();
+      expect(all.keys, {'github:owner/one'});
+    },
+  );
 }
 
 RepoActivity _activity(

--- a/test/team_store_test.dart
+++ b/test/team_store_test.dart
@@ -30,4 +30,32 @@ void main() {
     await TeamStore.delete(team.id);
     expect(await TeamStore.list(), isEmpty);
   });
+
+  test('removeRepoFromAll strips a repo key from every team', () async {
+    final platform = await TeamStore.add('Platform');
+    final infra = await TeamStore.add('Infra');
+    await TeamStore.setRepos(platform.id, {
+      'github:owner/repo',
+      'ado:org/project/repo',
+    });
+    await TeamStore.setRepos(infra.id, {'github:owner/repo'});
+
+    await TeamStore.removeRepoFromAll('github:owner/repo');
+
+    final teams = await TeamStore.list();
+    final updatedPlatform = teams.firstWhere((t) => t.id == platform.id);
+    final updatedInfra = teams.firstWhere((t) => t.id == infra.id);
+    expect(updatedPlatform.repoKeys, {'ado:org/project/repo'});
+    expect(updatedInfra.repoKeys, isEmpty);
+  });
+
+  test('removeRepoFromAll ignores unknown or blank keys', () async {
+    final team = await TeamStore.add('Platform');
+    await TeamStore.setRepos(team.id, {'github:owner/repo'});
+
+    await TeamStore.removeRepoFromAll('github:owner/missing');
+    await TeamStore.removeRepoFromAll('   ');
+
+    expect((await TeamStore.list()).single.repoKeys, {'github:owner/repo'});
+  });
 }


### PR DESCRIPTION
## What

Removing a repository from monitoring previously left its `MetricStore` trend history and any team assignments behind as stale, otherwise-unbounded keys — a documented follow-up in `designs/monitoring-m4.md` ("Removed repos retain history").

Deleting a repo from the **Manage Repositories** screen now prunes both, keyed by the canonical `github:owner/name` / `ado:org/project/name` repo key shared by the ignore list, `RepoActivity`, `MetricStore`, and teams.

## Changes

- **`MetricStore.removeRepo(repoKey)`** — drops the repo's history under the store lock, writing only when a history existed.
- **`TeamStore.removeRepoFromAll(repoKey)`** — strips the key from every team's repo set, writing only on change.
- **`_handleDelete`** (`manage_repos_page.dart`) — prunes on both the *Remove* and *Remove & ignore* paths; renamed `_ignoreKeyFor` → `_repoKeyFor` since the key is shared. Skips pruning when a duplicate entry still resolves to the same canonical key, so shared data isn't removed out from under a surviving entry.
- **`MetricStore.capture(..., restrictToMonitored)`** — re-reads the monitored repo lists inside its lock and skips repos no longer monitored, closing a race where a screen's in-flight fetch (computed before the delete) could re-insert a just-pruned key. Radar, Digest, and Teams pages opt in.

## Review

Ran the repo's review gate before opening:
- **code-review**: no high-confidence issues.
- **rubber-duck**: flagged the in-flight-`capture` re-add race (addressed via `restrictToMonitored`), the duplicate-key delete case (addressed via the still-monitored guard), and untested UI wiring (addressed by extending the delete widget test).

Out of scope (separately-tracked deferrals): key leak on repo *rename/edit* ("stable repo IDs across renames"), and inert `SnoozeStore` attention IDs for deleted repos.

## Tests

- `test/metric_store_test.dart` — `removeRepo` (incl. no-op/blank-key) and `capture` `restrictToMonitored` filtering.
- `test/team_store_test.dart` — `removeRepoFromAll` (incl. unknown/blank-key).
- `test/manage_repos_test.dart` — extended the delete test to assert history + team assignment are pruned.

**Verification:** `flutter analyze --fatal-infos` clean · `dart format --set-exit-if-changed` clean · all 215 tests pass.
