### PR TITLE
Add an Insights gallery: 17 alternative data views

### DIFF
--- a/lib/home_menu.dart
+++ b/lib/home_menu.dart
@@ -10,6 +10,7 @@ import 'teams_page.dart';
 import 'preferences_page.dart';
 import 'theme_controller.dart';
 import 'config_revision.dart';
+import 'views/insights_hub_page.dart';
 
 /// The shared "more" overflow menu shown on every home surface's app bar. It
 /// reaches the secondary destinations — work items, people, teams, repository
@@ -24,6 +25,7 @@ class HomeMenuButton extends StatelessWidget {
       tooltip: 'More',
       onSelected: (value) => _onSelected(context, value),
       itemBuilder: (context) => const [
+        PopupMenuItem(value: 'insights', child: Text('Insights (views)')),
         PopupMenuItem(value: 'work', child: Text('Assigned to you')),
         PopupMenuItem(value: 'people', child: Text('People')),
         PopupMenuItem(value: 'teams', child: Text('Teams')),
@@ -40,7 +42,11 @@ class HomeMenuButton extends StatelessWidget {
 
   void _onSelected(BuildContext context, String value) {
     final navigator = Navigator.of(context);
-    if (value == 'work') {
+    if (value == 'insights') {
+      navigator.push(
+        MaterialPageRoute(builder: (_) => const InsightsHubPage()),
+      );
+    } else if (value == 'work') {
       navigator.push(MaterialPageRoute(builder: (_) => const WorkItemsPage()));
     } else if (value == 'people') {
       _pushThenRefresh(navigator, const PeoplePage());

--- a/lib/views/age_histogram_view.dart
+++ b/lib/views/age_histogram_view.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import 'views_common.dart';
+
+/// A histogram bucketing repos by the age of their oldest open PR, so review
+/// backlog by staleness is visible at a glance.
+class AgeHistogramView extends StatelessWidget {
+  const AgeHistogramView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final withPrs = data.healthy
+        .where((a) => (a.oldestOpenPrAgeDays ?? -1) >= 0 && a.openPrCount > 0)
+        .toList();
+
+    // Count of repos per bucket, and total open PRs per bucket.
+    final repoCounts = <int, int>{};
+    final prCounts = <int, int>{};
+    for (final a in withPrs) {
+      final age = a.oldestOpenPrAgeDays ?? 0;
+      for (var i = 0; i < ageBuckets.length; i++) {
+        if (ageBuckets[i].contains(age)) {
+          repoCounts[i] = (repoCounts[i] ?? 0) + 1;
+          prCounts[i] = (prCounts[i] ?? 0) + a.openPrCount;
+          break;
+        }
+      }
+    }
+    final maxRepo = repoCounts.values.fold<int>(1, (m, v) => v > m ? v : m);
+
+    return ViewScaffold(
+      title: 'PR age',
+      loadedAt: data.loadedAt,
+      child: withPrs.isEmpty
+          ? const ViewEmpty(message: 'No open PRs to bucket by age.')
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Repos by age of their oldest open PR',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 24),
+                  Expanded(
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        for (var i = 0; i < ageBuckets.length; i++)
+                          Expanded(
+                            child: _bar(
+                              context,
+                              bucket: ageBuckets[i],
+                              repos: repoCounts[i] ?? 0,
+                              prs: prCounts[i] ?? 0,
+                              fraction: (repoCounts[i] ?? 0) / maxRepo,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+
+  Widget _bar(
+    BuildContext context, {
+    required AgeBucket bucket,
+    required int repos,
+    required int prs,
+    required double fraction,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 6),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          Text(
+            '$repos',
+            style: Theme.of(
+              context,
+            ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 4),
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, c) => Align(
+                alignment: Alignment.bottomCenter,
+                child: Container(
+                  height: repos == 0
+                      ? 2
+                      : (c.maxHeight * fraction).clamp(6.0, c.maxHeight),
+                  decoration: BoxDecoration(
+                    color: bucket.color.withValues(alpha: 0.85),
+                    borderRadius: const BorderRadius.vertical(
+                      top: Radius.circular(6),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(bucket.label, style: Theme.of(context).textTheme.labelMedium),
+          Text(
+            '$prs PRs',
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/age_histogram_view.dart
+++ b/lib/views/age_histogram_view.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import 'views_common.dart';
@@ -15,15 +17,13 @@ class AgeHistogramView extends StatelessWidget {
         .where((a) => (a.oldestOpenPrAgeDays ?? -1) >= 0 && a.openPrCount > 0)
         .toList();
 
-    // Count of repos per bucket, and total open PRs per bucket.
+    // Count of repos whose OLDEST open PR falls in each age bucket.
     final repoCounts = <int, int>{};
-    final prCounts = <int, int>{};
     for (final a in withPrs) {
       final age = a.oldestOpenPrAgeDays ?? 0;
       for (var i = 0; i < ageBuckets.length; i++) {
         if (ageBuckets[i].contains(age)) {
           repoCounts[i] = (repoCounts[i] ?? 0) + 1;
-          prCounts[i] = (prCounts[i] ?? 0) + a.openPrCount;
           break;
         }
       }
@@ -35,35 +35,46 @@ class AgeHistogramView extends StatelessWidget {
       loadedAt: data.loadedAt,
       child: withPrs.isEmpty
           ? const ViewEmpty(message: 'No open PRs to bucket by age.')
-          : Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Repos by age of their oldest open PR',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 24),
-                  Expanded(
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        for (var i = 0; i < ageBuckets.length; i++)
+          : LayoutBuilder(
+              builder: (context, c) {
+                // Keep a usable minimum chart height; scroll if the surface is
+                // shorter (e.g. a short desktop window) rather than overflowing.
+                final chartHeight = math.max(160.0, c.maxHeight);
+                return SingleChildScrollView(
+                  child: SizedBox(
+                    height: chartHeight,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Repos by age of their oldest open PR',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 24),
                           Expanded(
-                            child: _bar(
-                              context,
-                              bucket: ageBuckets[i],
-                              repos: repoCounts[i] ?? 0,
-                              prs: prCounts[i] ?? 0,
-                              fraction: (repoCounts[i] ?? 0) / maxRepo,
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.end,
+                              children: [
+                                for (var i = 0; i < ageBuckets.length; i++)
+                                  Expanded(
+                                    child: _bar(
+                                      context,
+                                      bucket: ageBuckets[i],
+                                      repos: repoCounts[i] ?? 0,
+                                      fraction: (repoCounts[i] ?? 0) / maxRepo,
+                                    ),
+                                  ),
+                              ],
                             ),
                           ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
-                ],
-              ),
+                );
+              },
             ),
     );
   }
@@ -72,7 +83,6 @@ class AgeHistogramView extends StatelessWidget {
     BuildContext context, {
     required AgeBucket bucket,
     required int repos,
-    required int prs,
     required double fraction,
   }) {
     return Padding(
@@ -89,30 +99,31 @@ class AgeHistogramView extends StatelessWidget {
           const SizedBox(height: 4),
           Expanded(
             child: LayoutBuilder(
-              builder: (context, c) => Align(
-                alignment: Alignment.bottomCenter,
-                child: Container(
-                  height: repos == 0
-                      ? 2
-                      : (c.maxHeight * fraction).clamp(6.0, c.maxHeight),
-                  decoration: BoxDecoration(
-                    color: bucket.color.withValues(alpha: 0.85),
-                    borderRadius: const BorderRadius.vertical(
-                      top: Radius.circular(6),
+              builder: (context, c) {
+                // Guard clamp: on a very short surface c.maxHeight can be < the
+                // 6px min, which would make clamp(min, max) throw.
+                final maxH = c.maxHeight;
+                final minVisible = math.min(6.0, maxH);
+                final height = repos == 0
+                    ? math.min(2.0, maxH)
+                    : (maxH * fraction).clamp(minVisible, maxH);
+                return Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Container(
+                    height: height,
+                    decoration: BoxDecoration(
+                      color: bucket.color.withValues(alpha: 0.85),
+                      borderRadius: const BorderRadius.vertical(
+                        top: Radius.circular(6),
+                      ),
                     ),
                   ),
-                ),
-              ),
+                );
+              },
             ),
           ),
           const SizedBox(height: 6),
           Text(bucket.label, style: Theme.of(context).textTheme.labelMedium),
-          Text(
-            '$prs PRs',
-            style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
         ],
       ),
     );

--- a/lib/views/bubble_view.dart
+++ b/lib/views/bubble_view.dart
@@ -1,0 +1,192 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../activity_service.dart';
+import 'views_common.dart';
+
+/// A scatter plot positioning each repo by oldest-open-PR age (x) and open PR
+/// count (y), sized by activity and colored by CI. Repos drifting up-and-right
+/// are the ones piling up work.
+class BubbleView extends StatelessWidget {
+  const BubbleView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final repos = data.healthy
+        .where((a) => a.openPrCount > 0 || (a.oldestOpenPrAgeDays ?? 0) > 0)
+        .toList();
+
+    return ViewScaffold(
+      title: 'Bubble chart',
+      loadedAt: data.loadedAt,
+      child: repos.isEmpty
+          ? const ViewEmpty(message: 'No open PRs to plot.')
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                  child: Text(
+                    'X: oldest open PR age  ·  Y: open PR count  ·  size: activity  ·  color: CI',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: LayoutBuilder(
+                      builder: (context, constraints) => CustomPaint(
+                        size: Size(constraints.maxWidth, constraints.maxHeight),
+                        painter: _BubblePainter(
+                          repos: repos,
+                          labelColor: Theme.of(context).colorScheme.onSurface,
+                          axisColor: Theme.of(context).colorScheme.outline,
+                          gridColor: Theme.of(
+                            context,
+                          ).colorScheme.outlineVariant,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}
+
+class _BubblePainter extends CustomPainter {
+  _BubblePainter({
+    required this.repos,
+    required this.labelColor,
+    required this.axisColor,
+    required this.gridColor,
+  });
+
+  final List<RepoActivity> repos;
+  final Color labelColor;
+  final Color axisColor;
+  final Color gridColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const padL = 34.0, padB = 26.0, padT = 8.0, padR = 8.0;
+    final plot = Rect.fromLTRB(
+      padL,
+      padT,
+      size.width - padR,
+      size.height - padB,
+    );
+    if (plot.width <= 0 || plot.height <= 0) return;
+
+    final maxX = math.max(
+      1,
+      repos.map((r) => r.oldestOpenPrAgeDays ?? 0).fold<int>(1, math.max),
+    );
+    final maxY = math.max(
+      1,
+      repos.map((r) => r.openPrCount).fold<int>(1, math.max),
+    );
+    final maxScore = repos
+        .map((r) => r.activityScore.toDouble())
+        .fold<double>(1, math.max);
+
+    final axisPaint = Paint()
+      ..color = axisColor
+      ..strokeWidth = 1;
+    final gridPaint = Paint()
+      ..color = gridColor
+      ..strokeWidth = 0.5;
+
+    // Axes.
+    canvas.drawLine(plot.bottomLeft, plot.bottomRight, axisPaint);
+    canvas.drawLine(plot.topLeft, plot.bottomLeft, axisPaint);
+
+    // Gridlines + ticks (4 divisions each).
+    for (var i = 1; i <= 4; i++) {
+      final gx = plot.left + plot.width * i / 4;
+      canvas.drawLine(Offset(gx, plot.top), Offset(gx, plot.bottom), gridPaint);
+      _text(
+        canvas,
+        '${(maxX * i / 4).round()}',
+        Offset(gx, plot.bottom + 4),
+        labelColor,
+        9,
+        TextAlign.center,
+      );
+      final gy = plot.bottom - plot.height * i / 4;
+      canvas.drawLine(Offset(plot.left, gy), Offset(plot.right, gy), gridPaint);
+      _text(
+        canvas,
+        '${(maxY * i / 4).round()}',
+        Offset(plot.left - 4, gy - 5),
+        labelColor,
+        9,
+        TextAlign.right,
+      );
+    }
+
+    // Bubbles (largest first so small ones stay clickable/visible on top).
+    final sorted = [...repos]
+      ..sort((a, b) => b.activityScore.compareTo(a.activityScore));
+    for (final r in sorted) {
+      final x = plot.left + plot.width * ((r.oldestOpenPrAgeDays ?? 0) / maxX);
+      final y = plot.bottom - plot.height * (r.openPrCount / maxY);
+      final t = maxScore == 0 ? 0.0 : r.activityScore.toDouble() / maxScore;
+      final radius = 5.0 + 18.0 * math.sqrt(t.clamp(0, 1));
+      final color = ciColor(r.ciStatus);
+      canvas.drawCircle(
+        Offset(x, y),
+        radius,
+        Paint()..color = color.withValues(alpha: 0.45),
+      );
+      canvas.drawCircle(
+        Offset(x, y),
+        radius,
+        Paint()
+          ..color = color
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1.5,
+      );
+    }
+
+    // Label only the top few by activity to avoid clutter.
+    for (final r in sorted.take(5)) {
+      final x = plot.left + plot.width * ((r.oldestOpenPrAgeDays ?? 0) / maxX);
+      final y = plot.bottom - plot.height * (r.openPrCount / maxY);
+      final name = r.displayName.split('/').last;
+      _text(canvas, name, Offset(x + 6, y - 6), labelColor, 10, TextAlign.left);
+    }
+  }
+
+  void _text(
+    Canvas canvas,
+    String text,
+    Offset at,
+    Color color,
+    double size,
+    TextAlign align,
+  ) {
+    final tp = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(color: color, fontSize: size),
+      ),
+      textAlign: align,
+      textDirection: TextDirection.ltr,
+    )..layout(maxWidth: 120);
+    final dx = switch (align) {
+      TextAlign.center => at.dx - tp.width / 2,
+      TextAlign.right => at.dx - tp.width,
+      _ => at.dx,
+    };
+    tp.paint(canvas, Offset(dx, at.dy));
+  }
+
+  @override
+  bool shouldRepaint(covariant _BubblePainter old) => old.repos != repos;
+}

--- a/lib/views/ci_grid_view.dart
+++ b/lib/views/ci_grid_view.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+
+import '../activity_service.dart';
+import 'views_common.dart';
+
+/// A status board: one tile per repo, colored by CI state, grouped
+/// failing → running → unknown → passing so problems surface first.
+class CiGridView extends StatelessWidget {
+  const CiGridView({super.key, required this.data});
+
+  final InsightsData data;
+
+  static int _rank(String status) => switch (status) {
+    'failure' => 0,
+    'running' => 1,
+    'unknown' => 2,
+    _ => 3,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final repos = [...data.healthy]
+      ..sort((a, b) {
+        final r = _rank(a.ciStatus).compareTo(_rank(b.ciStatus));
+        return r != 0 ? r : a.displayName.compareTo(b.displayName);
+      });
+
+    final counts = <String, int>{};
+    for (final a in repos) {
+      counts[a.ciStatus] = (counts[a.ciStatus] ?? 0) + 1;
+    }
+
+    return ViewScaffold(
+      title: 'CI health',
+      loadedAt: data.loadedAt,
+      child: repos.isEmpty
+          ? const ViewEmpty(message: 'No CI status to show yet.')
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+                  child: Wrap(
+                    spacing: 12,
+                    runSpacing: 6,
+                    children: [
+                      for (final status in const [
+                        'failure',
+                        'running',
+                        'unknown',
+                        'success',
+                      ])
+                        if ((counts[status] ?? 0) > 0)
+                          _legend(status, counts[status]!),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: GridView.builder(
+                    padding: const EdgeInsets.all(12),
+                    gridDelegate:
+                        const SliverGridDelegateWithMaxCrossAxisExtent(
+                          maxCrossAxisExtent: 190,
+                          mainAxisSpacing: 8,
+                          crossAxisSpacing: 8,
+                          childAspectRatio: 1.7,
+                        ),
+                    itemCount: repos.length,
+                    itemBuilder: (context, i) => _tile(context, repos[i]),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+
+  Widget _legend(String status, int count) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(ciIcon(status), size: 14, color: ciColor(status)),
+        const SizedBox(width: 4),
+        Text('${ciLabel(status)} · $count'),
+      ],
+    );
+  }
+
+  Widget _tile(BuildContext context, RepoActivity a) {
+    final color = ciColor(a.ciStatus);
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: () => openUrl(a.url),
+      child: Container(
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.16),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: color.withValues(alpha: 0.5)),
+        ),
+        padding: const EdgeInsets.all(10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(ciIcon(a.ciStatus), size: 16, color: color),
+                const Spacer(),
+                if (a.openPrCount > 0)
+                  Text(
+                    '${a.openPrCount} PR',
+                    style: Theme.of(context).textTheme.labelSmall,
+                  ),
+              ],
+            ),
+            const Spacer(),
+            Text(
+              a.displayName,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/contributor_cloud_view.dart
+++ b/lib/views/contributor_cloud_view.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import 'views_common.dart';
+
+/// A word-cloud of open-PR authors across all repos, sized by how many repos
+/// they're active in. Framed as collaboration/awareness — who's moving things —
+/// not a performance ranking.
+class ContributorCloudView extends StatelessWidget {
+  const ContributorCloudView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    // Count in how many repos each contributor appears.
+    final counts = <String, int>{};
+    for (final a in data.healthy) {
+      for (final c in a.contributors) {
+        final name = c.trim();
+        if (name.isEmpty) continue;
+        counts[name] = (counts[name] ?? 0) + 1;
+      }
+    }
+    final entries = counts.entries.toList()
+      ..sort((a, b) {
+        final byCount = b.value.compareTo(a.value);
+        return byCount != 0 ? byCount : a.key.compareTo(b.key);
+      });
+    final maxCount = entries.isEmpty ? 1 : entries.first.value;
+
+    final scheme = Theme.of(context).colorScheme;
+
+    return ViewScaffold(
+      title: 'Contributors',
+      loadedAt: data.loadedAt,
+      child: entries.isEmpty
+          ? const ViewEmpty(
+              message:
+                  'No open-PR authors to show. Framed as collaboration, '
+                  'not a leaderboard.',
+            )
+          : SingleChildScrollView(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Active across repos (${entries.length} people)',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 10,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      for (final e in entries)
+                        _chip(context, e.key, e.value, maxCount),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+
+  Widget _chip(BuildContext context, String name, int count, int maxCount) {
+    final t = maxCount <= 1 ? 1.0 : count / maxCount;
+    final fontSize = 13.0 + 20.0 * t;
+    final color = heatColor(0.25 + 0.55 * t);
+    return Tooltip(
+      message: 'in $count ${count == 1 ? 'repo' : 'repos'}',
+      child: Text(
+        name,
+        style: TextStyle(
+          fontSize: fontSize,
+          color: color,
+          fontWeight: t > 0.6 ? FontWeight.bold : FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/contributor_cloud_view.dart
+++ b/lib/views/contributor_cloud_view.dart
@@ -45,7 +45,9 @@ class ContributorCloudView extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    'Active across repos (${entries.length} people)',
+                    'Open-PR authors, sized by how many repos they appear in '
+                    '(up to 5 tracked per repo). Collaboration signal — not a '
+                    'leaderboard. ${entries.length} people.',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: scheme.onSurfaceVariant,
                     ),

--- a/lib/views/donut_view.dart
+++ b/lib/views/donut_view.dart
@@ -1,0 +1,164 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import 'views_common.dart';
+
+/// A donut breaking down where the open PRs live: the biggest slices are the
+/// repos carrying the most in-flight work.
+class DonutView extends StatelessWidget {
+  const DonutView({super.key, required this.data});
+
+  final InsightsData data;
+
+  static const _palette = <Color>[
+    Color(0xFF1565C0),
+    Color(0xFFC62828),
+    Color(0xFF2E7D32),
+    Color(0xFF6A1B9A),
+    Color(0xFFEF6C00),
+    Color(0xFF00838F),
+    Color(0xFFAD1457),
+    Color(0xFF558B2F),
+    Color(0xFF5D4037),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final repos = data.healthy.where((a) => a.openPrCount > 0).toList()
+      ..sort((a, b) => b.openPrCount.compareTo(a.openPrCount));
+
+    // Top slices, then aggregate the rest into "other".
+    final slices = <_Slice>[];
+    const maxSlices = 8;
+    for (var i = 0; i < repos.length && i < maxSlices; i++) {
+      slices.add(
+        _Slice(
+          repos[i].displayName.split('/').last,
+          repos[i].openPrCount,
+          _palette[i % _palette.length],
+        ),
+      );
+    }
+    if (repos.length > maxSlices) {
+      final rest = repos
+          .skip(maxSlices)
+          .fold<int>(0, (s, a) => s + a.openPrCount);
+      if (rest > 0) {
+        slices.add(_Slice('other', rest, const Color(0xFF9E9E9E)));
+      }
+    }
+    final total = slices.fold<int>(0, (s, x) => s + x.value);
+
+    return ViewScaffold(
+      title: 'Open PR split',
+      loadedAt: data.loadedAt,
+      child: slices.isEmpty
+          ? const ViewEmpty(message: 'No open PRs to break down.')
+          : Column(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: CustomPaint(
+                      size: Size.infinite,
+                      painter: _DonutPainter(
+                        slices: slices,
+                        total: total,
+                        centerColor: Theme.of(context).colorScheme.surface,
+                        labelColor: Theme.of(context).colorScheme.onSurface,
+                        totalLabel: '$total\nPRs',
+                      ),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
+                  child: Wrap(
+                    spacing: 12,
+                    runSpacing: 6,
+                    children: [
+                      for (final s in slices)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Container(width: 12, height: 12, color: s.color),
+                            const SizedBox(width: 5),
+                            Text(
+                              '${s.name} (${s.value})',
+                              style: Theme.of(context).textTheme.labelSmall,
+                            ),
+                          ],
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}
+
+class _Slice {
+  const _Slice(this.name, this.value, this.color);
+  final String name;
+  final int value;
+  final Color color;
+}
+
+class _DonutPainter extends CustomPainter {
+  _DonutPainter({
+    required this.slices,
+    required this.total,
+    required this.centerColor,
+    required this.labelColor,
+    required this.totalLabel,
+  });
+
+  final List<_Slice> slices;
+  final int total;
+  final Color centerColor;
+  final Color labelColor;
+  final String totalLabel;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (total <= 0) return;
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = math.min(size.width, size.height) / 2;
+    final inner = radius * 0.58;
+
+    var start = -math.pi / 2;
+    for (final s in slices) {
+      final sweep = 2 * math.pi * s.value / total;
+      canvas.drawArc(
+        Rect.fromCircle(center: center, radius: radius),
+        start,
+        sweep,
+        true,
+        Paint()..color = s.color,
+      );
+      start += sweep;
+    }
+    // Punch the hole.
+    canvas.drawCircle(center, inner, Paint()..color = centerColor);
+
+    final tp = TextPainter(
+      text: TextSpan(
+        text: totalLabel,
+        style: TextStyle(
+          color: labelColor,
+          fontSize: 16,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      textAlign: TextAlign.center,
+      textDirection: TextDirection.ltr,
+    )..layout();
+    tp.paint(canvas, center - Offset(tp.width / 2, tp.height / 2));
+  }
+
+  @override
+  bool shouldRepaint(covariant _DonutPainter old) =>
+      old.slices != slices || old.total != total;
+}

--- a/lib/views/freshness_view.dart
+++ b/lib/views/freshness_view.dart
@@ -17,8 +17,9 @@ class FreshnessView extends StatelessWidget {
         final da = daysSince(a.lastActivity, now: now);
         final db = daysSince(b.lastActivity, now: now);
         // Nulls (never any activity) sort last.
-        if (da == null && db == null)
+        if (da == null && db == null) {
           return a.displayName.compareTo(b.displayName);
+        }
         if (da == null) return 1;
         if (db == null) return -1;
         return db.compareTo(da);

--- a/lib/views/freshness_view.dart
+++ b/lib/views/freshness_view.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+import 'views_common.dart';
+
+/// "What went quiet" — repos ordered by how long since their last activity,
+/// with a freshness heat bar. Stale-but-previously-active repos rise to the top.
+class FreshnessView extends StatelessWidget {
+  const FreshnessView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final repos = [...data.healthy]
+      ..sort((a, b) {
+        final da = daysSince(a.lastActivity, now: now);
+        final db = daysSince(b.lastActivity, now: now);
+        // Nulls (never any activity) sort last.
+        if (da == null && db == null)
+          return a.displayName.compareTo(b.displayName);
+        if (da == null) return 1;
+        if (db == null) return -1;
+        return db.compareTo(da);
+      });
+
+    final maxDays = repos.fold<int>(1, (m, a) {
+      final d = daysSince(a.lastActivity, now: now) ?? 0;
+      return d > m ? d : m;
+    });
+
+    return ViewScaffold(
+      title: 'Freshness',
+      loadedAt: data.loadedAt,
+      child: repos.isEmpty
+          ? const ViewEmpty(message: 'No repositories to rank by freshness.')
+          : ListView.separated(
+              padding: const EdgeInsets.all(12),
+              itemCount: repos.length,
+              separatorBuilder: (_, _) => const SizedBox(height: 8),
+              itemBuilder: (context, i) {
+                final a = repos[i];
+                final days = daysSince(a.lastActivity, now: now);
+                final color = freshnessColor(a.lastActivity, now: now);
+                final fraction = days == null
+                    ? 1.0
+                    : (days / maxDays).clamp(0.02, 1.0);
+                return InkWell(
+                  borderRadius: BorderRadius.circular(12),
+                  onTap: () => openUrl(a.url),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: Theme.of(context).colorScheme.outlineVariant,
+                      ),
+                    ),
+                    padding: const EdgeInsets.all(12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(Icons.circle, size: 10, color: color),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                a.displayName,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context).textTheme.bodyLarge,
+                              ),
+                            ),
+                            Text(
+                              days == null ? 'no activity' : '${days}d ago',
+                              style: Theme.of(
+                                context,
+                              ).textTheme.labelMedium?.copyWith(color: color),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(4),
+                          child: LinearProgressIndicator(
+                            value: fraction,
+                            minHeight: 6,
+                            backgroundColor: Theme.of(
+                              context,
+                            ).colorScheme.surfaceContainerHighest,
+                            color: color,
+                          ),
+                        ),
+                        if (a.openPrCount > 0) ...[
+                          const SizedBox(height: 6),
+                          Text(
+                            '${a.openPrCount} open · ${a.needsReviewCount} need review',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/views/health_gauge_view.dart
+++ b/lib/views/health_gauge_view.dart
@@ -17,9 +17,11 @@ class HealthGaugeView extends StatelessWidget {
     final now = DateTime.now();
 
     // Each factor is a 0..1 score (1 = healthy).
-    final ci = repos.isEmpty
-        ? 1.0
-        : repos.where((a) => a.ciStatus != 'failure').length / repos.length;
+    // CI factor: pass rate among repos with a definitive result (success vs
+    // failure); unknown/running are excluded so all-unknown doesn't read as 100%.
+    final success = repos.where((a) => a.ciStatus == 'success').length;
+    final failure = repos.where((a) => a.ciStatus == 'failure').length;
+    final ci = (success + failure) == 0 ? 1.0 : success / (success + failure);
     final fresh = repos.isEmpty
         ? 1.0
         : repos.where((a) {

--- a/lib/views/health_gauge_view.dart
+++ b/lib/views/health_gauge_view.dart
@@ -1,0 +1,174 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import 'views_common.dart';
+
+/// A single composite "fleet health" score (0–100) on a gauge, with the
+/// contributing factors broken out so the number is explainable.
+class HealthGaugeView extends StatelessWidget {
+  const HealthGaugeView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final repos = data.healthy;
+    final now = DateTime.now();
+
+    // Each factor is a 0..1 score (1 = healthy).
+    final ci = repos.isEmpty
+        ? 1.0
+        : repos.where((a) => a.ciStatus != 'failure').length / repos.length;
+    final fresh = repos.isEmpty
+        ? 1.0
+        : repos.where((a) {
+                final d = daysSince(a.lastActivity, now: now);
+                return d != null && d <= 7;
+              }).length /
+              repos.length;
+    final aging = repos.isEmpty
+        ? 1.0
+        : repos.where((a) => (a.oldestOpenPrAgeDays ?? 0) <= 14).length /
+              repos.length;
+    final totalOpen = repos.fold<int>(0, (s, a) => s + a.openPrCount);
+    final totalReview = repos.fold<int>(0, (s, a) => s + a.needsReviewCount);
+    final review = totalOpen == 0
+        ? 1.0
+        : (1 - (totalReview / totalOpen)).clamp(0.0, 1.0);
+
+    final factors = <({String label, double value})>[
+      (label: 'CI passing', value: ci),
+      (label: 'Recently active', value: fresh),
+      (label: 'PRs not aging', value: aging),
+      (label: 'Review kept up', value: review),
+    ];
+    final score = repos.isEmpty
+        ? 0
+        : (factors.fold<double>(0, (s, f) => s + f.value) /
+                  factors.length *
+                  100)
+              .round();
+
+    return ViewScaffold(
+      title: 'Fleet health',
+      loadedAt: data.loadedAt,
+      child: repos.isEmpty
+          ? const ViewEmpty(message: 'No repositories to score.')
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                SizedBox(
+                  height: 200,
+                  child: CustomPaint(
+                    size: Size.infinite,
+                    painter: _GaugePainter(
+                      score: score / 100,
+                      color: heatColor(1 - score / 100),
+                      trackColor: Theme.of(
+                        context,
+                      ).colorScheme.surfaceContainerHighest,
+                      labelColor: Theme.of(context).colorScheme.onSurface,
+                      scoreText: '$score',
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                for (final f in factors) ...[
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          f.label,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                      Text('${(f.value * 100).round()}%'),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: LinearProgressIndicator(
+                      value: f.value,
+                      minHeight: 8,
+                      backgroundColor: Theme.of(
+                        context,
+                      ).colorScheme.surfaceContainerHighest,
+                      color: heatColor(1 - f.value),
+                    ),
+                  ),
+                  const SizedBox(height: 14),
+                ],
+              ],
+            ),
+    );
+  }
+}
+
+class _GaugePainter extends CustomPainter {
+  _GaugePainter({
+    required this.score,
+    required this.color,
+    required this.trackColor,
+    required this.labelColor,
+    required this.scoreText,
+  });
+
+  final double score; // 0..1
+  final Color color;
+  final Color trackColor;
+  final Color labelColor;
+  final String scoreText;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height * 0.9);
+    final radius = math.min(size.width / 2, size.height * 0.9) - 12;
+    if (radius <= 0) return;
+    const startAngle = math.pi; // 180°, left
+    const sweepFull = math.pi; // half circle
+
+    final track = Paint()
+      ..color = trackColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 18
+      ..strokeCap = StrokeCap.round;
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      startAngle,
+      sweepFull,
+      false,
+      track,
+    );
+
+    final value = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 18
+      ..strokeCap = StrokeCap.round;
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      startAngle,
+      sweepFull * score.clamp(0.0, 1.0),
+      false,
+      value,
+    );
+
+    final tp = TextPainter(
+      text: TextSpan(
+        text: scoreText,
+        style: TextStyle(
+          color: labelColor,
+          fontSize: 44,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    tp.paint(canvas, center - Offset(tp.width / 2, tp.height + 4));
+  }
+
+  @override
+  bool shouldRepaint(covariant _GaugePainter old) => old.score != score;
+}

--- a/lib/views/health_gauge_view.dart
+++ b/lib/views/health_gauge_view.dart
@@ -18,10 +18,14 @@ class HealthGaugeView extends StatelessWidget {
 
     // Each factor is a 0..1 score (1 = healthy).
     // CI factor: pass rate among repos with a definitive result (success vs
-    // failure); unknown/running are excluded so all-unknown doesn't read as 100%.
+    // failure). When NO repo has a definitive result it's omitted entirely (not
+    // defaulted to 1.0), so the score never reads as "100% CI passing" with no
+    // CI data.
     final success = repos.where((a) => a.ciStatus == 'success').length;
     final failure = repos.where((a) => a.ciStatus == 'failure').length;
-    final ci = (success + failure) == 0 ? 1.0 : success / (success + failure);
+    final double? ci = (success + failure) == 0
+        ? null
+        : success / (success + failure);
     final fresh = repos.isEmpty
         ? 1.0
         : repos.where((a) {
@@ -40,12 +44,12 @@ class HealthGaugeView extends StatelessWidget {
         : (1 - (totalReview / totalOpen)).clamp(0.0, 1.0);
 
     final factors = <({String label, double value})>[
-      (label: 'CI passing', value: ci),
+      if (ci != null) (label: 'CI passing', value: ci),
       (label: 'Recently active', value: fresh),
       (label: 'PRs not aging', value: aging),
       (label: 'Review kept up', value: review),
     ];
-    final score = repos.isEmpty
+    final score = (repos.isEmpty || factors.isEmpty)
         ? 0
         : (factors.fold<double>(0, (s, f) => s + f.value) /
                   factors.length *

--- a/lib/views/heatmap_view.dart
+++ b/lib/views/heatmap_view.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+
+import 'views_common.dart';
+
+/// A contribution-graph-style grid: repos as rows, recent snapshot days as
+/// columns, each cell shaded by that day's activity score.
+class HeatmapView extends StatelessWidget {
+  const HeatmapView({super.key, required this.data});
+
+  final InsightsData data;
+
+  static const int _maxDays = 30;
+
+  @override
+  Widget build(BuildContext context) {
+    // Distinct snapshot days across all repos (UTC), most recent last.
+    final daySet = <DateTime>{};
+    for (final snaps in data.history.values) {
+      for (final s in snaps) {
+        daySet.add(DateTime.utc(s.at.year, s.at.month, s.at.day));
+      }
+    }
+    final days = daySet.toList()..sort();
+    final shownDays = days.length > _maxDays
+        ? days.sublist(days.length - _maxDays)
+        : days;
+
+    // Rows: repos that have any snapshot, labeled and score-mapped per day.
+    final rows = <_Row>[];
+    var maxScore = 1.0;
+    data.history.forEach((key, snaps) {
+      if (snaps.isEmpty) return;
+      final name =
+          data.activities
+              .where((a) => a.repoKey == key)
+              .map((a) => a.displayName)
+              .fold<String?>(null, (p, e) => p ?? e) ??
+          key;
+      final byDay = <DateTime, double>{};
+      for (final s in snaps) {
+        final d = DateTime.utc(s.at.year, s.at.month, s.at.day);
+        final v = s.activityScore.toDouble();
+        byDay[d] = (byDay[d] ?? 0) + v;
+        if (byDay[d]! > maxScore) maxScore = byDay[d]!;
+      }
+      rows.add(_Row(name.split('/').last, byDay));
+    });
+    rows.sort((a, b) => a.name.compareTo(b.name));
+
+    return ViewScaffold(
+      title: 'Heatmap',
+      loadedAt: data.loadedAt,
+      child: (rows.isEmpty || shownDays.isEmpty)
+          ? const ViewEmpty(
+              message:
+                  'The heatmap fills in as daily snapshots accumulate.\nCheck back after using the app across a few days.',
+            )
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+                  child: Text(
+                    'Activity score per day (${shownDays.length} days)',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(12),
+                    child: LayoutBuilder(
+                      builder: (context, c) {
+                        const labelW = 96.0;
+                        final cell = ((c.maxWidth - labelW) / shownDays.length)
+                            .clamp(4.0, 22.0);
+                        return Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            for (final row in rows)
+                              _rowWidget(
+                                context,
+                                row,
+                                shownDays,
+                                labelW,
+                                cell,
+                                maxScore,
+                              ),
+                          ],
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+
+  Widget _rowWidget(
+    BuildContext context,
+    _Row row,
+    List<DateTime> days,
+    double labelW,
+    double cell,
+    double maxScore,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 3),
+      child: Row(
+        children: [
+          SizedBox(
+            width: labelW,
+            child: Text(
+              row.name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+          ),
+          for (final d in days)
+            Container(
+              width: cell,
+              height: cell,
+              margin: const EdgeInsets.all(1),
+              decoration: BoxDecoration(
+                color: row.byDay.containsKey(d)
+                    ? heatColor((row.byDay[d]! / maxScore).clamp(0.05, 1.0))
+                    : Theme.of(context).colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Row {
+  _Row(this.name, this.byDay);
+  final String name;
+  final Map<DateTime, double> byDay;
+}

--- a/lib/views/heatmap_view.dart
+++ b/lib/views/heatmap_view.dart
@@ -120,16 +120,25 @@ class HeatmapView extends StatelessWidget {
             ),
           ),
           for (final d in days)
-            Container(
-              width: cell,
-              height: cell,
-              margin: const EdgeInsets.all(1),
-              decoration: BoxDecoration(
-                color: row.byDay.containsKey(d)
-                    ? heatColor((row.byDay[d]! / maxScore).clamp(0.05, 1.0))
-                    : Theme.of(context).colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(2),
-              ),
+            Builder(
+              builder: (context) {
+                final v = row.byDay[d];
+                // A day with a snapshot but zero activity reads as background
+                // (empty), not a faint colored cell — 0 activity != some
+                // activity. Only strictly-positive scores get a heat color.
+                final color = (v != null && v > 0)
+                    ? heatColor((v / maxScore).clamp(0.05, 1.0))
+                    : Theme.of(context).colorScheme.surfaceContainerHighest;
+                return Container(
+                  width: cell,
+                  height: cell,
+                  margin: const EdgeInsets.all(1),
+                  decoration: BoxDecoration(
+                    color: color,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                );
+              },
             ),
         ],
       ),

--- a/lib/views/heatmap_view.dart
+++ b/lib/views/heatmap_view.dart
@@ -61,7 +61,7 @@ class HeatmapView extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
                   child: Text(
-                    'Activity score per day (${shownDays.length} days)',
+                    'Activity score per day (${shownDays.length} days). $scoreNote',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -159,13 +159,18 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       _error = null;
     });
     try {
-      final activities = await ActivityService.computeAll(
-        client: AppHttp.client,
-      );
+      // Run the two network passes concurrently so loading People doesn't
+      // serialize behind the repo activity fetch.
+      final (activities, people) = await (
+        ActivityService.computeAll(client: AppHttp.client),
+        PeopleService.computeAll(client: AppHttp.client),
+      ).wait;
+      // Record a trend snapshot from this load too (deduped ~1/day), matching
+      // Radar/Teams/Digest, so opening Insights also advances trend history.
+      await MetricStore.capture(activities, restrictToMonitored: true);
       final history = await MetricStore.all();
       final teams = await TeamStore.list();
       final rollups = TeamService.rollupAll(teams, activities);
-      final people = await PeopleService.computeAll(client: AppHttp.client);
       if (!mounted || seq != _loadSeq) return;
       setState(() {
         _data = InsightsData(

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../activity_service.dart';
 import '../app_http.dart';
 import '../metric_store.dart';
+import '../people_service.dart';
 import '../team_service.dart';
 import '../team_store.dart';
 import 'age_histogram_view.dart';
@@ -17,6 +18,7 @@ import 'provider_split_view.dart';
 import 'pulse_view.dart';
 import 'quadrant_view.dart';
 import 'repo_table_view.dart';
+import 'review_load_view.dart';
 import 'stacked_area_view.dart';
 import 'team_radar_view.dart';
 import 'treemap_view.dart';
@@ -125,6 +127,12 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       builder: (d) => ContributorCloudView(data: d),
     ),
     ViewInfo(
+      title: 'Review load',
+      blurb: 'Who can unblock whom',
+      icon: Icons.rate_review,
+      builder: (d) => ReviewLoadView(data: d),
+    ),
+    ViewInfo(
       title: 'Provider split',
       blurb: 'GitHub vs Azure DevOps',
       icon: Icons.compare_arrows,
@@ -157,6 +165,7 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       final history = await MetricStore.all();
       final teams = await TeamStore.list();
       final rollups = TeamService.rollupAll(teams, activities);
+      final people = await PeopleService.computeAll(client: AppHttp.client);
       if (!mounted || seq != _loadSeq) return;
       setState(() {
         _data = InsightsData(
@@ -164,6 +173,7 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
           history: history,
           teams: teams,
           rollups: rollups,
+          people: people,
           loadedAt: DateTime.now(),
         );
         _loading = false;

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -227,6 +227,7 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
     return RefreshIndicator(
       onRefresh: _load,
       child: GridView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(12),
         gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: 220,

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -8,9 +8,13 @@ import '../team_store.dart';
 import 'age_histogram_view.dart';
 import 'bubble_view.dart';
 import 'ci_grid_view.dart';
+import 'contributor_cloud_view.dart';
+import 'donut_view.dart';
 import 'freshness_view.dart';
 import 'heatmap_view.dart';
+import 'provider_split_view.dart';
 import 'pulse_view.dart';
+import 'quadrant_view.dart';
 import 'repo_table_view.dart';
 import 'team_radar_view.dart';
 import 'treemap_view.dart';
@@ -45,6 +49,18 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       blurb: 'PR age × count, sized by activity',
       icon: Icons.bubble_chart,
       builder: (d) => BubbleView(data: d),
+    ),
+    ViewInfo(
+      title: 'Triage quadrant',
+      blurb: 'Staleness × load, 2×2 triage',
+      icon: Icons.grid_goldenratio,
+      builder: (d) => QuadrantView(data: d),
+    ),
+    ViewInfo(
+      title: 'Open PR split',
+      blurb: 'Donut of PRs by repo',
+      icon: Icons.donut_large,
+      builder: (d) => DonutView(data: d),
     ),
     ViewInfo(
       title: 'CI health',
@@ -87,6 +103,18 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       blurb: 'What went quiet, ranked',
       icon: Icons.local_fire_department,
       builder: (d) => FreshnessView(data: d),
+    ),
+    ViewInfo(
+      title: 'Contributors',
+      blurb: 'Who is active across repos',
+      icon: Icons.groups_2,
+      builder: (d) => ContributorCloudView(data: d),
+    ),
+    ViewInfo(
+      title: 'Provider split',
+      blurb: 'GitHub vs Azure DevOps',
+      icon: Icons.compare_arrows,
+      builder: (d) => ProviderSplitView(data: d),
     ),
     ViewInfo(
       title: 'Repo table',

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -11,11 +11,13 @@ import 'ci_grid_view.dart';
 import 'contributor_cloud_view.dart';
 import 'donut_view.dart';
 import 'freshness_view.dart';
+import 'health_gauge_view.dart';
 import 'heatmap_view.dart';
 import 'provider_split_view.dart';
 import 'pulse_view.dart';
 import 'quadrant_view.dart';
 import 'repo_table_view.dart';
+import 'stacked_area_view.dart';
 import 'team_radar_view.dart';
 import 'treemap_view.dart';
 import 'trend_lines_view.dart';
@@ -43,6 +45,12 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       blurb: 'Headline counters + aggregate trend',
       icon: Icons.speed,
       builder: (d) => PulseView(data: d),
+    ),
+    ViewInfo(
+      title: 'Fleet health',
+      blurb: 'Composite health score gauge',
+      icon: Icons.health_and_safety,
+      builder: (d) => HealthGaugeView(data: d),
     ),
     ViewInfo(
       title: 'Bubble chart',
@@ -91,6 +99,12 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       blurb: 'Overlaid activity trend lines',
       icon: Icons.show_chart,
       builder: (d) => TrendLinesView(data: d),
+    ),
+    ViewInfo(
+      title: 'Stacked activity',
+      blurb: 'Who drives momentum over time',
+      icon: Icons.area_chart,
+      builder: (d) => StackedAreaView(data: d),
     ),
     ViewInfo(
       title: 'Team radar',

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+
+import '../activity_service.dart';
+import '../app_http.dart';
+import '../metric_store.dart';
+import '../team_service.dart';
+import '../team_store.dart';
+import 'age_histogram_view.dart';
+import 'bubble_view.dart';
+import 'ci_grid_view.dart';
+import 'freshness_view.dart';
+import 'heatmap_view.dart';
+import 'pulse_view.dart';
+import 'repo_table_view.dart';
+import 'team_radar_view.dart';
+import 'treemap_view.dart';
+import 'trend_lines_view.dart';
+import 'views_common.dart';
+
+/// Experimental gallery of alternative visualizations of the monitored data.
+/// Loads the data once and hands an [InsightsData] to each view, so switching
+/// between views is instant and consistent.
+class InsightsHubPage extends StatefulWidget {
+  const InsightsHubPage({super.key});
+
+  @override
+  State<InsightsHubPage> createState() => _InsightsHubPageState();
+}
+
+class _InsightsHubPageState extends State<InsightsHubPage> {
+  InsightsData? _data;
+  bool _loading = true;
+  String? _error;
+  int _loadSeq = 0;
+
+  static final List<ViewInfo> _views = [
+    ViewInfo(
+      title: 'Pulse',
+      blurb: 'Headline counters + aggregate trend',
+      icon: Icons.speed,
+      builder: (d) => PulseView(data: d),
+    ),
+    ViewInfo(
+      title: 'Bubble chart',
+      blurb: 'PR age × count, sized by activity',
+      icon: Icons.bubble_chart,
+      builder: (d) => BubbleView(data: d),
+    ),
+    ViewInfo(
+      title: 'CI health',
+      blurb: 'Status board, failures first',
+      icon: Icons.grid_view,
+      builder: (d) => CiGridView(data: d),
+    ),
+    ViewInfo(
+      title: 'Treemap',
+      blurb: 'Repos sized by activity',
+      icon: Icons.dashboard,
+      builder: (d) => TreemapView(data: d),
+    ),
+    ViewInfo(
+      title: 'PR age',
+      blurb: 'Backlog bucketed by staleness',
+      icon: Icons.bar_chart,
+      builder: (d) => AgeHistogramView(data: d),
+    ),
+    ViewInfo(
+      title: 'Heatmap',
+      blurb: 'Repo × day activity grid',
+      icon: Icons.calendar_view_month,
+      builder: (d) => HeatmapView(data: d),
+    ),
+    ViewInfo(
+      title: 'Trends',
+      blurb: 'Overlaid activity trend lines',
+      icon: Icons.show_chart,
+      builder: (d) => TrendLinesView(data: d),
+    ),
+    ViewInfo(
+      title: 'Team radar',
+      blurb: 'Compare team shapes',
+      icon: Icons.radar,
+      builder: (d) => TeamRadarView(data: d),
+    ),
+    ViewInfo(
+      title: 'Freshness',
+      blurb: 'What went quiet, ranked',
+      icon: Icons.local_fire_department,
+      builder: (d) => FreshnessView(data: d),
+    ),
+    ViewInfo(
+      title: 'Repo table',
+      blurb: 'Dense sortable metrics table',
+      icon: Icons.table_rows,
+      builder: (d) => RepoTableView(data: d),
+    ),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final seq = ++_loadSeq;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final activities = await ActivityService.computeAll(
+        client: AppHttp.client,
+      );
+      final history = await MetricStore.all();
+      final teams = await TeamStore.list();
+      final rollups = TeamService.rollupAll(teams, activities);
+      if (!mounted || seq != _loadSeq) return;
+      setState(() {
+        _data = InsightsData(
+          activities: activities,
+          history: history,
+          teams: teams,
+          rollups: rollups,
+          loadedAt: DateTime.now(),
+        );
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted || seq != _loadSeq) return;
+      setState(() {
+        _error = 'Failed to load data: $e';
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Insights'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: _loading ? null : _load,
+          ),
+        ],
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            _error!,
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ),
+      );
+    }
+    final data = _data!;
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: GridView.builder(
+        padding: const EdgeInsets.all(12),
+        gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+          maxCrossAxisExtent: 220,
+          mainAxisSpacing: 12,
+          crossAxisSpacing: 12,
+          childAspectRatio: 1.25,
+        ),
+        itemCount: _views.length,
+        itemBuilder: (context, i) {
+          final view = _views[i];
+          return Card(
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => view.builder(data)),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      view.icon,
+                      size: 30,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                    const Spacer(),
+                    Text(
+                      view.title,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      view.blurb,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/views/provider_split_view.dart
+++ b/lib/views/provider_split_view.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+
+import '../activity_service.dart';
+import 'views_common.dart';
+
+/// Side-by-side comparison of the two providers (GitHub vs Azure DevOps) across
+/// the headline metrics — useful when monitoring a mixed fleet.
+class ProviderSplitView extends StatelessWidget {
+  const ProviderSplitView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final gh = _tally(data.healthy.where((a) => a.provider == 'github'));
+    final ado = _tally(data.healthy.where((a) => a.provider != 'github'));
+
+    final metrics = <({String label, int gh, int ado})>[
+      (label: 'Repos', gh: gh.repos, ado: ado.repos),
+      (label: 'Open PRs', gh: gh.openPrs, ado: ado.openPrs),
+      (label: 'Need review', gh: gh.needsReview, ado: ado.needsReview),
+      (label: 'CI failing', gh: gh.failing, ado: ado.failing),
+      (label: 'Contributors', gh: gh.contributors, ado: ado.contributors),
+    ];
+
+    final hasBoth = gh.repos > 0 && ado.repos > 0;
+
+    return ViewScaffold(
+      title: 'Provider split',
+      loadedAt: data.loadedAt,
+      child: (gh.repos == 0 && ado.repos == 0)
+          ? const ViewEmpty(message: 'No repositories to compare.')
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                Row(
+                  children: [
+                    _header(context, 'GitHub', const Color(0xFF24292F)),
+                    const SizedBox(width: 8),
+                    _header(context, 'Azure DevOps', const Color(0xFF0078D4)),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                for (final m in metrics) ...[
+                  Text(m.label, style: Theme.of(context).textTheme.labelLarge),
+                  const SizedBox(height: 6),
+                  _dualBar(context, m.gh, m.ado),
+                  const SizedBox(height: 16),
+                ],
+                if (!hasBoth)
+                  Text(
+                    'Only one provider is in use; add repos from the other to '
+                    'see a real comparison.',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+    );
+  }
+
+  Widget _header(BuildContext context, String label, Color color) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Center(
+          child: Text(
+            label,
+            style: Theme.of(
+              context,
+            ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _dualBar(BuildContext context, int gh, int ado) {
+    final total = (gh + ado).clamp(1, 1 << 30);
+    return Row(
+      children: [
+        Expanded(
+          flex: gh == 0 ? 1 : gh,
+          child: _barSegment(context, gh, const Color(0xFF24292F), left: true),
+        ),
+        const SizedBox(width: 2),
+        Expanded(
+          flex: ado == 0 ? 1 : ado,
+          child: _barSegment(
+            context,
+            ado,
+            const Color(0xFF0078D4),
+            left: false,
+          ),
+        ),
+        // Keep zero-segments from collapsing entirely on both sides.
+        if (total == 0) const SizedBox.shrink(),
+      ],
+    );
+  }
+
+  Widget _barSegment(
+    BuildContext context,
+    int value,
+    Color color, {
+    required bool left,
+  }) {
+    final radius = left
+        ? const BorderRadius.horizontal(left: Radius.circular(6))
+        : const BorderRadius.horizontal(right: Radius.circular(6));
+    return Container(
+      height: 30,
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.8),
+        borderRadius: radius,
+      ),
+      alignment: left ? Alignment.centerLeft : Alignment.centerRight,
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Text(
+        '$value',
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+
+  static _Tally _tally(Iterable<RepoActivity> repos) {
+    final contributors = <String>{};
+    var openPrs = 0, needsReview = 0, failing = 0, count = 0;
+    for (final a in repos) {
+      count++;
+      openPrs += a.openPrCount;
+      needsReview += a.needsReviewCount;
+      if (a.ciStatus == 'failure') failing++;
+      contributors.addAll(a.contributors);
+    }
+    return _Tally(count, openPrs, needsReview, failing, contributors.length);
+  }
+}
+
+class _Tally {
+  const _Tally(
+    this.repos,
+    this.openPrs,
+    this.needsReview,
+    this.failing,
+    this.contributors,
+  );
+  final int repos;
+  final int openPrs;
+  final int needsReview;
+  final int failing;
+  final int contributors;
+}

--- a/lib/views/provider_split_view.dart
+++ b/lib/views/provider_split_view.dart
@@ -108,19 +108,22 @@ class ProviderSplitView extends StatelessWidget {
                     )
                   : Row(
                       children: [
-                        // flex 0 collapses a zero side, so proportions are true.
-                        Expanded(
-                          flex: gh,
-                          child: Container(
-                            color: ghColor.withValues(alpha: 0.85),
+                        // Only emit non-zero segments — Expanded requires
+                        // flex > 0 — so a single-provider fleet shows 100:0.
+                        if (gh > 0)
+                          Expanded(
+                            flex: gh,
+                            child: Container(
+                              color: ghColor.withValues(alpha: 0.85),
+                            ),
                           ),
-                        ),
-                        Expanded(
-                          flex: ado,
-                          child: Container(
-                            color: adoColor.withValues(alpha: 0.85),
+                        if (ado > 0)
+                          Expanded(
+                            flex: ado,
+                            child: Container(
+                              color: adoColor.withValues(alpha: 0.85),
+                            ),
                           ),
-                        ),
                       ],
                     ),
             ),

--- a/lib/views/provider_split_view.dart
+++ b/lib/views/provider_split_view.dart
@@ -81,53 +81,63 @@ class ProviderSplitView extends StatelessWidget {
   }
 
   Widget _dualBar(BuildContext context, int gh, int ado) {
-    final total = (gh + ado).clamp(1, 1 << 30);
+    final total = gh + ado;
+    const ghColor = Color(0xFF24292F);
+    const adoColor = Color(0xFF0078D4);
     return Row(
       children: [
-        Expanded(
-          flex: gh == 0 ? 1 : gh,
-          child: _barSegment(context, gh, const Color(0xFF24292F), left: true),
-        ),
-        const SizedBox(width: 2),
-        Expanded(
-          flex: ado == 0 ? 1 : ado,
-          child: _barSegment(
-            context,
-            ado,
-            const Color(0xFF0078D4),
-            left: false,
+        SizedBox(
+          width: 30,
+          child: Text(
+            '$gh',
+            textAlign: TextAlign.right,
+            style: const TextStyle(color: ghColor, fontWeight: FontWeight.bold),
           ),
         ),
-        // Keep zero-segments from collapsing entirely on both sides.
-        if (total == 0) const SizedBox.shrink(),
-      ],
-    );
-  }
-
-  Widget _barSegment(
-    BuildContext context,
-    int value,
-    Color color, {
-    required bool left,
-  }) {
-    final radius = left
-        ? const BorderRadius.horizontal(left: Radius.circular(6))
-        : const BorderRadius.horizontal(right: Radius.circular(6));
-    return Container(
-      height: 30,
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.8),
-        borderRadius: radius,
-      ),
-      alignment: left ? Alignment.centerLeft : Alignment.centerRight,
-      padding: const EdgeInsets.symmetric(horizontal: 8),
-      child: Text(
-        '$value',
-        style: const TextStyle(
-          color: Colors.white,
-          fontWeight: FontWeight.bold,
+        const SizedBox(width: 8),
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(6),
+            child: SizedBox(
+              height: 22,
+              child: total == 0
+                  ? Container(
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.surfaceContainerHighest,
+                    )
+                  : Row(
+                      children: [
+                        // flex 0 collapses a zero side, so proportions are true.
+                        Expanded(
+                          flex: gh,
+                          child: Container(
+                            color: ghColor.withValues(alpha: 0.85),
+                          ),
+                        ),
+                        Expanded(
+                          flex: ado,
+                          child: Container(
+                            color: adoColor.withValues(alpha: 0.85),
+                          ),
+                        ),
+                      ],
+                    ),
+            ),
+          ),
         ),
-      ),
+        const SizedBox(width: 8),
+        SizedBox(
+          width: 30,
+          child: Text(
+            '$ado',
+            style: const TextStyle(
+              color: adoColor,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/views/pulse_view.dart
+++ b/lib/views/pulse_view.dart
@@ -118,7 +118,7 @@ class PulseView extends StatelessWidget {
                         Text(
                           trend.length < 2
                               ? 'Trend builds up as snapshots accumulate over days.'
-                              : 'Total activity score across all repos per snapshot.',
+                              : 'Total activity score across all repos per snapshot. $scoreNote',
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(
                                 color: Theme.of(

--- a/lib/views/pulse_view.dart
+++ b/lib/views/pulse_view.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+
+import '../metric_snapshot.dart';
+import '../sparkline.dart';
+import 'views_common.dart';
+
+/// A "what's the state of the world" dashboard: headline counters plus an
+/// aggregate activity trend.
+class PulseView extends StatelessWidget {
+  const PulseView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final repos = data.healthy;
+    final now = DateTime.now();
+
+    final openPrs = repos.fold<int>(0, (s, a) => s + a.openPrCount);
+    final needsReview = repos.fold<int>(0, (s, a) => s + a.needsReviewCount);
+    final failing = repos.where((a) => a.ciStatus == 'failure').length;
+    final running = repos.where((a) => a.ciStatus == 'running').length;
+    final stale = repos.where((a) {
+      final d = daysSince(a.lastActivity, now: now);
+      return d == null || d > 14;
+    }).length;
+    final errored = data.activities.where((a) => a.error != null).length;
+    final oldest = repos
+        .map((a) => a.oldestOpenPrAgeDays ?? 0)
+        .fold<int>(0, (a, b) => a > b ? a : b);
+    final contributors = <String>{
+      for (final a in repos) ...a.contributors,
+    }.length;
+
+    final trend = _aggregateActivity(data.history);
+
+    return ViewScaffold(
+      title: 'Pulse',
+      loadedAt: data.loadedAt,
+      child: data.isEmpty
+          ? const ViewEmpty(message: 'No repositories to summarize yet.')
+          : ListView(
+              padding: const EdgeInsets.all(12),
+              children: [
+                GridView.count(
+                  crossAxisCount: MediaQuery.of(context).size.width > 520
+                      ? 4
+                      : 2,
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  childAspectRatio: 1.35,
+                  mainAxisSpacing: 8,
+                  crossAxisSpacing: 8,
+                  children: [
+                    StatTile(
+                      label: 'Open PRs',
+                      value: '$openPrs',
+                      icon: Icons.merge_type,
+                    ),
+                    StatTile(
+                      label: 'Need review',
+                      value: '$needsReview',
+                      icon: Icons.rate_review,
+                      color: const Color(0xFF6A1B9A),
+                    ),
+                    StatTile(
+                      label: 'CI failing',
+                      value: '$failing',
+                      icon: Icons.cancel,
+                      color: const Color(0xFFC62828),
+                      sub: running > 0 ? '$running running' : null,
+                    ),
+                    StatTile(
+                      label: 'Stale repos',
+                      value: '$stale',
+                      icon: Icons.bedtime,
+                      color: const Color(0xFF8D6E63),
+                      sub: 'quiet >14d',
+                    ),
+                    StatTile(
+                      label: 'Oldest PR',
+                      value: oldest > 0 ? '${oldest}d' : '—',
+                      icon: Icons.hourglass_bottom,
+                      color: const Color(0xFFEF6C00),
+                    ),
+                    StatTile(
+                      label: 'Repos',
+                      value: '${data.activities.length}',
+                      icon: Icons.folder_open,
+                      sub: errored > 0 ? '$errored errored' : null,
+                    ),
+                    StatTile(
+                      label: 'Contributors',
+                      value: '$contributors',
+                      icon: Icons.people,
+                      color: const Color(0xFF00897B),
+                    ),
+                    StatTile(
+                      label: 'Teams',
+                      value: '${data.teams.length}',
+                      icon: Icons.groups,
+                      color: const Color(0xFF1565C0),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Aggregate activity trend',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          trend.length < 2
+                              ? 'Trend builds up as snapshots accumulate over days.'
+                              : 'Total activity score across all repos per snapshot.',
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              ),
+                        ),
+                        const SizedBox(height: 12),
+                        if (trend.length >= 2)
+                          Center(
+                            child: Sparkline(
+                              values: trend,
+                              width: MediaQuery.of(context).size.width - 88,
+                              height: 72,
+                            ),
+                          )
+                        else
+                          const SizedBox(height: 24),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+
+  /// Sums each snapshot day's total activityScore across all repos into a time
+  /// series (oldest→newest).
+  static List<num> _aggregateActivity(
+    Map<String, List<MetricSnapshot>> history,
+  ) {
+    final byDay = <DateTime, num>{};
+    for (final snapshots in history.values) {
+      for (final s in snapshots) {
+        final at = s.at;
+        final day = DateTime.utc(at.year, at.month, at.day);
+        byDay[day] = (byDay[day] ?? 0) + s.activityScore;
+      }
+    }
+    final days = byDay.keys.toList()..sort();
+    return [for (final d in days) byDay[d]!];
+  }
+}

--- a/lib/views/quadrant_view.dart
+++ b/lib/views/quadrant_view.dart
@@ -1,0 +1,201 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../activity_service.dart';
+import 'views_common.dart';
+
+/// A 2×2 triage quadrant: repos plotted by staleness (x) and open-PR load (y).
+/// The top-right "act now" corner holds stale repos still carrying work.
+class QuadrantView extends StatelessWidget {
+  const QuadrantView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final repos = data.healthy
+        .where((a) => a.openPrCount > 0 || a.lastActivity != null)
+        .toList();
+
+    return ViewScaffold(
+      title: 'Triage quadrant',
+      loadedAt: data.loadedAt,
+      child: repos.isEmpty
+          ? const ViewEmpty(message: 'Nothing to triage yet.')
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: LayoutBuilder(
+                builder: (context, c) => CustomPaint(
+                  size: Size(c.maxWidth, c.maxHeight),
+                  painter: _QuadrantPainter(
+                    repos: repos,
+                    now: now,
+                    labelColor: Theme.of(context).colorScheme.onSurface,
+                    mutedColor: Theme.of(context).colorScheme.onSurfaceVariant,
+                    axisColor: Theme.of(context).colorScheme.outline,
+                    dividerColor: Theme.of(context).colorScheme.outlineVariant,
+                  ),
+                ),
+              ),
+            ),
+    );
+  }
+}
+
+class _QuadrantPainter extends CustomPainter {
+  _QuadrantPainter({
+    required this.repos,
+    required this.now,
+    required this.labelColor,
+    required this.mutedColor,
+    required this.axisColor,
+    required this.dividerColor,
+  });
+
+  final List<RepoActivity> repos;
+  final DateTime now;
+  final Color labelColor;
+  final Color mutedColor;
+  final Color axisColor;
+  final Color dividerColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const padL = 30.0, padB = 22.0, padT = 8.0, padR = 8.0;
+    final plot = Rect.fromLTRB(
+      padL,
+      padT,
+      size.width - padR,
+      size.height - padB,
+    );
+    if (plot.width <= 0 || plot.height <= 0) return;
+
+    final maxStale = math.max(
+      1,
+      repos
+          .map((r) => daysSince(r.lastActivity, now: now) ?? 0)
+          .fold<int>(1, math.max),
+    );
+    final maxLoad = math.max(
+      1,
+      repos.map((r) => r.openPrCount).fold<int>(1, math.max),
+    );
+
+    // Quadrant divider thresholds (mid).
+    final midX = plot.left + plot.width / 2;
+    final midY = plot.top + plot.height / 2;
+
+    // Quadrant tints (top-right = act now = red).
+    final tints = [
+      (
+        Rect.fromLTRB(midX, plot.top, plot.right, midY),
+        const Color(0x22C62828),
+      ),
+      (Rect.fromLTRB(plot.left, plot.top, midX, midY), const Color(0x221565C0)),
+      (
+        Rect.fromLTRB(plot.left, midY, midX, plot.bottom),
+        const Color(0x222E7D32),
+      ),
+      (
+        Rect.fromLTRB(midX, midY, plot.right, plot.bottom),
+        const Color(0x22EF6C00),
+      ),
+    ];
+    for (final (rect, color) in tints) {
+      canvas.drawRect(rect, Paint()..color = color);
+    }
+
+    final divider = Paint()
+      ..color = dividerColor
+      ..strokeWidth = 1;
+    canvas.drawLine(Offset(midX, plot.top), Offset(midX, plot.bottom), divider);
+    canvas.drawLine(Offset(plot.left, midY), Offset(plot.right, midY), divider);
+
+    // Corner labels.
+    _text(
+      canvas,
+      'act now',
+      Offset(plot.right - 6, plot.top + 4),
+      mutedColor,
+      TextAlign.right,
+    );
+    _text(
+      canvas,
+      'busy',
+      Offset(plot.left + 6, plot.top + 4),
+      mutedColor,
+      TextAlign.left,
+    );
+    _text(
+      canvas,
+      'healthy',
+      Offset(plot.left + 6, plot.bottom - 16),
+      mutedColor,
+      TextAlign.left,
+    );
+    _text(
+      canvas,
+      'dormant',
+      Offset(plot.right - 6, plot.bottom - 16),
+      mutedColor,
+      TextAlign.right,
+    );
+
+    final axisPaint = Paint()
+      ..color = axisColor
+      ..strokeWidth = 1;
+    canvas.drawLine(plot.bottomLeft, plot.bottomRight, axisPaint);
+    canvas.drawLine(plot.topLeft, plot.bottomLeft, axisPaint);
+    _text(
+      canvas,
+      'stale →',
+      Offset(plot.right, plot.bottom + 4),
+      mutedColor,
+      TextAlign.right,
+    );
+
+    for (final r in repos) {
+      final stale = daysSince(r.lastActivity, now: now) ?? maxStale;
+      final x = plot.left + plot.width * (stale / maxStale);
+      final y = plot.bottom - plot.height * (r.openPrCount / maxLoad);
+      final color = ciColor(r.ciStatus);
+      canvas.drawCircle(
+        Offset(x, y),
+        5,
+        Paint()..color = color.withValues(alpha: 0.7),
+      );
+      _text(
+        canvas,
+        r.displayName.split('/').last,
+        Offset(x + 7, y - 6),
+        labelColor,
+        TextAlign.left,
+        9,
+      );
+    }
+  }
+
+  void _text(
+    Canvas canvas,
+    String text,
+    Offset at,
+    Color color,
+    TextAlign align, [
+    double size = 10,
+  ]) {
+    final tp = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(color: color, fontSize: size),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout(maxWidth: 110);
+    final dx = align == TextAlign.right ? at.dx - tp.width : at.dx;
+    tp.paint(canvas, Offset(dx, at.dy));
+  }
+
+  @override
+  bool shouldRepaint(covariant _QuadrantPainter old) => old.repos != repos;
+}

--- a/lib/views/quadrant_view.dart
+++ b/lib/views/quadrant_view.dart
@@ -72,34 +72,39 @@ class _QuadrantPainter extends CustomPainter {
     );
     if (plot.width <= 0 || plot.height <= 0) return;
 
+    // Axis maxima leave room for the fixed thresholds to sit inside the plot
+    // even for small datasets, so a single low-activity repo doesn't get pushed
+    // into "act now".
+    const staleThreshold = 7; // days quiet
+    const loadThreshold = 3; // open PRs
     final maxStale = math.max(
-      1,
+      staleThreshold * 2,
       repos
           .map((r) => daysSince(r.lastActivity, now: now) ?? 0)
           .fold<int>(1, math.max),
     );
     final maxLoad = math.max(
-      1,
+      loadThreshold * 2,
       repos.map((r) => r.openPrCount).fold<int>(1, math.max),
     );
 
-    // Quadrant divider thresholds (mid).
-    final midX = plot.left + plot.width / 2;
-    final midY = plot.top + plot.height / 2;
+    // Dividers at meaningful FIXED thresholds (not the visual midpoint).
+    final divX = plot.left + plot.width * (staleThreshold / maxStale);
+    final divY = plot.bottom - plot.height * (loadThreshold / maxLoad);
 
-    // Quadrant tints (top-right = act now = red).
+    // Quadrant tints (top-right = stale & loaded = act now = red).
     final tints = [
       (
-        Rect.fromLTRB(midX, plot.top, plot.right, midY),
+        Rect.fromLTRB(divX, plot.top, plot.right, divY),
         const Color(0x22C62828),
       ),
-      (Rect.fromLTRB(plot.left, plot.top, midX, midY), const Color(0x221565C0)),
+      (Rect.fromLTRB(plot.left, plot.top, divX, divY), const Color(0x221565C0)),
       (
-        Rect.fromLTRB(plot.left, midY, midX, plot.bottom),
+        Rect.fromLTRB(plot.left, divY, divX, plot.bottom),
         const Color(0x222E7D32),
       ),
       (
-        Rect.fromLTRB(midX, midY, plot.right, plot.bottom),
+        Rect.fromLTRB(divX, divY, plot.right, plot.bottom),
         const Color(0x22EF6C00),
       ),
     ];
@@ -110,8 +115,8 @@ class _QuadrantPainter extends CustomPainter {
     final divider = Paint()
       ..color = dividerColor
       ..strokeWidth = 1;
-    canvas.drawLine(Offset(midX, plot.top), Offset(midX, plot.bottom), divider);
-    canvas.drawLine(Offset(plot.left, midY), Offset(plot.right, midY), divider);
+    canvas.drawLine(Offset(divX, plot.top), Offset(divX, plot.bottom), divider);
+    canvas.drawLine(Offset(plot.left, divY), Offset(plot.right, divY), divider);
 
     // Corner labels.
     _text(
@@ -156,6 +161,7 @@ class _QuadrantPainter extends CustomPainter {
       TextAlign.right,
     );
 
+    var labelled = 0;
     for (final r in repos) {
       final stale = daysSince(r.lastActivity, now: now) ?? maxStale;
       final x = plot.left + plot.width * (stale / maxStale);
@@ -166,14 +172,21 @@ class _QuadrantPainter extends CustomPainter {
         5,
         Paint()..color = color.withValues(alpha: 0.7),
       );
-      _text(
-        canvas,
-        r.displayName.split('/').last,
-        Offset(x + 7, y - 6),
-        labelColor,
-        TextAlign.left,
-        9,
-      );
+      // Only label the actionable "act now" repos (stale AND loaded), capped,
+      // so a large fleet doesn't turn into an unreadable wall of text.
+      if (stale >= staleThreshold &&
+          r.openPrCount >= loadThreshold &&
+          labelled < 8) {
+        labelled++;
+        _text(
+          canvas,
+          r.displayName.split('/').last,
+          Offset(x + 7, y - 6),
+          labelColor,
+          TextAlign.left,
+          9,
+        );
+      }
     }
   }
 

--- a/lib/views/repo_table_view.dart
+++ b/lib/views/repo_table_view.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+import '../activity_service.dart';
+import 'views_common.dart';
+
+/// A dense, sortable table of every repo and its metrics. Tap a column header
+/// to sort; tap a row to open the repo.
+class RepoTableView extends StatefulWidget {
+  const RepoTableView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  State<RepoTableView> createState() => _RepoTableViewState();
+}
+
+class _RepoTableViewState extends State<RepoTableView> {
+  int _sortColumn = 6; // activity score
+  bool _ascending = false;
+
+  int _cmp<T extends Comparable<Object?>>(T a, T b) => a.compareTo(b);
+
+  @override
+  Widget build(BuildContext context) {
+    final repos = [...widget.data.healthy];
+    final now = DateTime.now();
+
+    int compare(RepoActivity a, RepoActivity b) {
+      final r = switch (_sortColumn) {
+        0 => a.displayName.toLowerCase().compareTo(b.displayName.toLowerCase()),
+        1 => _cmp(a.openPrCount, b.openPrCount),
+        2 => _cmp(a.needsReviewCount, b.needsReviewCount),
+        3 => _cmp(a.oldestOpenPrAgeDays ?? -1, b.oldestOpenPrAgeDays ?? -1),
+        4 => a.ciStatus.compareTo(b.ciStatus),
+        5 => _cmp(
+          daysSince(a.lastActivity, now: now) ?? 1 << 30,
+          daysSince(b.lastActivity, now: now) ?? 1 << 30,
+        ),
+        _ => _cmp(a.activityScore, b.activityScore),
+      };
+      return _ascending ? r : -r;
+    }
+
+    repos.sort(compare);
+
+    return ViewScaffold(
+      title: 'Repo table',
+      loadedAt: widget.data.loadedAt,
+      child: repos.isEmpty
+          ? const ViewEmpty(message: 'No repositories to tabulate.')
+          : SingleChildScrollView(
+              scrollDirection: Axis.vertical,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: DataTable(
+                  sortColumnIndex: _sortColumn,
+                  sortAscending: _ascending,
+                  columnSpacing: 20,
+                  columns: [
+                    _col('Repo'),
+                    _col('Open', numeric: true),
+                    _col('Review', numeric: true),
+                    _col('Oldest', numeric: true),
+                    _col('CI'),
+                    _col('Last', numeric: true),
+                    _col('Score', numeric: true),
+                  ],
+                  rows: [
+                    for (final a in repos)
+                      DataRow(
+                        onSelectChanged: (_) => openUrl(a.url),
+                        cells: [
+                          DataCell(
+                            ConstrainedBox(
+                              constraints: const BoxConstraints(maxWidth: 200),
+                              child: Text(
+                                a.displayName,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ),
+                          DataCell(Text('${a.openPrCount}')),
+                          DataCell(Text('${a.needsReviewCount}')),
+                          DataCell(
+                            Text(
+                              a.oldestOpenPrAgeDays == null
+                                  ? '—'
+                                  : '${a.oldestOpenPrAgeDays}d',
+                            ),
+                          ),
+                          DataCell(
+                            Icon(
+                              ciIcon(a.ciStatus),
+                              size: 16,
+                              color: ciColor(a.ciStatus),
+                            ),
+                          ),
+                          DataCell(
+                            Text(
+                              daysSince(a.lastActivity, now: now) == null
+                                  ? '—'
+                                  : '${daysSince(a.lastActivity, now: now)}d',
+                            ),
+                          ),
+                          DataCell(Text(a.activityScore.toStringAsFixed(1))),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+            ),
+    );
+  }
+
+  DataColumn _col(String label, {bool numeric = false}) {
+    return DataColumn(
+      label: Text(label),
+      numeric: numeric,
+      onSort: (index, ascending) => setState(() {
+        _sortColumn = index;
+        _ascending = ascending;
+      }),
+    );
+  }
+}

--- a/lib/views/review_load_view.dart
+++ b/lib/views/review_load_view.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+
+import '../person.dart';
+import 'views_common.dart';
+
+/// A people-centric "who can unblock whom" view: everyone with review requests
+/// or authored open PRs, ranked by review load. Framed as collaboration and
+/// unblocking — not individual performance ranking.
+class ReviewLoadView extends StatelessWidget {
+  const ReviewLoadView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final people = [...data.people]
+      ..sort((a, b) {
+        final byReview = b.reviewRequests.compareTo(a.reviewRequests);
+        if (byReview != 0) return byReview;
+        final byWip = b.authoredOpenPrs.compareTo(a.authoredOpenPrs);
+        if (byWip != 0) return byWip;
+        return a.displayName.toLowerCase().compareTo(
+          b.displayName.toLowerCase(),
+        );
+      });
+
+    final maxLoad = people.fold<int>(
+      1,
+      (m, p) => [
+        m,
+        p.reviewRequests,
+        p.authoredOpenPrs,
+      ].reduce((a, b) => a > b ? a : b),
+    );
+
+    return ViewScaffold(
+      title: 'Review load',
+      loadedAt: data.loadedAt,
+      child: people.isEmpty
+          ? const ViewEmpty(
+              message:
+                  'No open review requests or authored PRs to show.\nThis is about unblocking, not ranking.',
+            )
+          : ListView.separated(
+              padding: const EdgeInsets.all(12),
+              itemCount: people.length,
+              separatorBuilder: (_, _) => const SizedBox(height: 6),
+              itemBuilder: (context, i) => _row(context, people[i], maxLoad),
+            ),
+    );
+  }
+
+  Widget _row(BuildContext context, Person p, int maxLoad) {
+    final scheme = Theme.of(context).colorScheme;
+    return Card(
+      elevation: 0,
+      color: p.isSelf ? scheme.primaryContainer.withValues(alpha: 0.4) : null,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                CircleAvatar(
+                  radius: 14,
+                  child: Text(
+                    _initials(p.displayName),
+                    style: const TextStyle(fontSize: 11),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    p.displayName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                ),
+                if (p.isSelf)
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 2,
+                    ),
+                    decoration: BoxDecoration(
+                      color: scheme.primary,
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Text(
+                      'You',
+                      style: TextStyle(color: scheme.onPrimary, fontSize: 11),
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            _bar(
+              context,
+              'Review requests',
+              p.reviewRequests,
+              maxLoad,
+              const Color(0xFF6A1B9A),
+            ),
+            const SizedBox(height: 6),
+            _bar(
+              context,
+              'Authored open PRs',
+              p.authoredOpenPrs,
+              maxLoad,
+              const Color(0xFF1565C0),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _bar(
+    BuildContext context,
+    String label,
+    int value,
+    int max,
+    Color color,
+  ) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 132,
+          child: Text(label, style: Theme.of(context).textTheme.bodySmall),
+        ),
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: max == 0 ? 0 : (value / max).clamp(0.0, 1.0),
+              minHeight: 10,
+              backgroundColor: Theme.of(
+                context,
+              ).colorScheme.surfaceContainerHighest,
+              color: color,
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        SizedBox(width: 22, child: Text('$value', textAlign: TextAlign.right)),
+      ],
+    );
+  }
+
+  String _initials(String name) {
+    final parts = name.trim().split(RegExp(r'[\s/_-]+'));
+    if (parts.isEmpty || parts.first.isEmpty) return '?';
+    if (parts.length == 1) {
+      return parts.first.substring(0, 1).toUpperCase();
+    }
+    return (parts[0].substring(0, 1) + parts[1].substring(0, 1)).toUpperCase();
+  }
+}

--- a/lib/views/review_load_view.dart
+++ b/lib/views/review_load_view.dart
@@ -150,11 +150,16 @@ class ReviewLoadView extends StatelessWidget {
   }
 
   String _initials(String name) {
-    final parts = name.trim().split(RegExp(r'[\s/_-]+'));
-    if (parts.isEmpty || parts.first.isEmpty) return '?';
+    final parts = name
+        .trim()
+        .split(RegExp(r'[\s/_-]+'))
+        .where((p) => p.isNotEmpty)
+        .toList();
+    if (parts.isEmpty) return '?';
     if (parts.length == 1) {
-      return parts.first.substring(0, 1).toUpperCase();
+      return parts.first.characters.first.toUpperCase();
     }
-    return (parts[0].substring(0, 1) + parts[1].substring(0, 1)).toUpperCase();
+    return (parts[0].characters.first + parts[1].characters.first)
+        .toUpperCase();
   }
 }

--- a/lib/views/stacked_area_view.dart
+++ b/lib/views/stacked_area_view.dart
@@ -1,0 +1,208 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import 'views_common.dart';
+
+/// A stacked-area chart of activity score over time, composed of the busiest
+/// repos — shows how much each repo contributes to overall momentum day to day.
+class StackedAreaView extends StatelessWidget {
+  const StackedAreaView({super.key, required this.data});
+
+  final InsightsData data;
+
+  static const _palette = <Color>[
+    Color(0xFF1565C0),
+    Color(0xFF00897B),
+    Color(0xFF7CB342),
+    Color(0xFFF9A825),
+    Color(0xFFEF6C00),
+    Color(0xFFC62828),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    // Union of all snapshot days.
+    final daySet = <DateTime>{};
+    for (final snaps in data.history.values) {
+      for (final s in snaps) {
+        daySet.add(DateTime.utc(s.at.year, s.at.month, s.at.day));
+      }
+    }
+    final days = daySet.toList()..sort();
+
+    // Per-repo activity-by-day, ranked by total contribution; keep top 5 + rest.
+    final byRepo = <String, Map<DateTime, double>>{};
+    final totals = <String, double>{};
+    data.history.forEach((key, snaps) {
+      final name =
+          data.activities
+              .where((a) => a.repoKey == key)
+              .map((a) => a.displayName)
+              .fold<String?>(null, (p, e) => p ?? e) ??
+          key;
+      final map = <DateTime, double>{};
+      var total = 0.0;
+      for (final s in snaps) {
+        final d = DateTime.utc(s.at.year, s.at.month, s.at.day);
+        map[d] = (map[d] ?? 0) + s.activityScore.toDouble();
+        total += s.activityScore.toDouble();
+      }
+      byRepo[name.split('/').last] = map;
+      totals[name.split('/').last] = total;
+    });
+    final ranked = totals.keys.toList()
+      ..sort((a, b) => totals[b]!.compareTo(totals[a]!));
+    final top = ranked.take(_palette.length - 1).toList();
+
+    // Build stacked layers (top repos, then "other").
+    final layers = <_Layer>[];
+    for (var i = 0; i < top.length; i++) {
+      layers.add(_Layer(top[i], byRepo[top[i]]!, _palette[i]));
+    }
+    if (ranked.length > top.length) {
+      final other = <DateTime, double>{};
+      for (final name in ranked.skip(top.length)) {
+        byRepo[name]!.forEach((d, v) => other[d] = (other[d] ?? 0) + v);
+      }
+      layers.add(_Layer('other', other, _palette.last));
+    }
+
+    final enough = days.length >= 2 && layers.isNotEmpty;
+
+    return ViewScaffold(
+      title: 'Stacked activity',
+      loadedAt: data.loadedAt,
+      child: !enough
+          ? const ViewEmpty(
+              message:
+                  'Stacked trends need at least two days of snapshots.\nThey fill in as the app is used over time.',
+            )
+          : Column(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 16, 16, 8),
+                    child: LayoutBuilder(
+                      builder: (context, c) => CustomPaint(
+                        size: Size(c.maxWidth, c.maxHeight),
+                        painter: _StackPainter(
+                          days: days,
+                          layers: layers,
+                          axisColor: Theme.of(context).colorScheme.outline,
+                          labelColor: Theme.of(context).colorScheme.onSurface,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                  child: Wrap(
+                    spacing: 12,
+                    runSpacing: 6,
+                    children: [
+                      for (final l in layers)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Container(width: 12, height: 12, color: l.color),
+                            const SizedBox(width: 5),
+                            Text(
+                              l.name,
+                              style: Theme.of(context).textTheme.labelSmall,
+                            ),
+                          ],
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}
+
+class _Layer {
+  const _Layer(this.name, this.byDay, this.color);
+  final String name;
+  final Map<DateTime, double> byDay;
+  final Color color;
+}
+
+class _StackPainter extends CustomPainter {
+  _StackPainter({
+    required this.days,
+    required this.layers,
+    required this.axisColor,
+    required this.labelColor,
+  });
+
+  final List<DateTime> days;
+  final List<_Layer> layers;
+  final Color axisColor;
+  final Color labelColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const padL = 30.0, padB = 16.0, padT = 6.0, padR = 6.0;
+    final plot = Rect.fromLTRB(
+      padL,
+      padT,
+      size.width - padR,
+      size.height - padB,
+    );
+    if (plot.width <= 0 || plot.height <= 0 || days.length < 2) return;
+
+    // Column totals to find the max stacked height.
+    var maxTotal = 1.0;
+    for (final d in days) {
+      var t = 0.0;
+      for (final l in layers) {
+        t += l.byDay[d] ?? 0;
+      }
+      maxTotal = math.max(maxTotal, t);
+    }
+
+    double xFor(int i) => plot.left + plot.width * i / (days.length - 1);
+    double yFor(double v) => plot.bottom - plot.height * (v / maxTotal);
+
+    // Draw from top of stack down so earlier (bigger) layers sit at the bottom.
+    final cumulative = List<double>.filled(days.length, 0);
+    for (final layer in layers) {
+      final top = Path();
+      final bottom = <Offset>[];
+      for (var i = 0; i < days.length; i++) {
+        final base = cumulative[i];
+        final add = layer.byDay[days[i]] ?? 0;
+        final upper = base + add;
+        final p = Offset(xFor(i), yFor(upper));
+        if (i == 0) {
+          top.moveTo(p.dx, p.dy);
+        } else {
+          top.lineTo(p.dx, p.dy);
+        }
+        bottom.add(Offset(xFor(i), yFor(base)));
+        cumulative[i] = upper;
+      }
+      for (var i = bottom.length - 1; i >= 0; i--) {
+        top.lineTo(bottom[i].dx, bottom[i].dy);
+      }
+      top.close();
+      canvas.drawPath(
+        top,
+        Paint()..color = layer.color.withValues(alpha: 0.85),
+      );
+    }
+
+    final axisPaint = Paint()
+      ..color = axisColor
+      ..strokeWidth = 1;
+    canvas.drawLine(plot.bottomLeft, plot.bottomRight, axisPaint);
+    canvas.drawLine(plot.topLeft, plot.bottomLeft, axisPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _StackPainter old) =>
+      old.layers != layers || old.days != days;
+}

--- a/lib/views/stacked_area_view.dart
+++ b/lib/views/stacked_area_view.dart
@@ -31,9 +31,11 @@ class StackedAreaView extends StatelessWidget {
     }
     final days = daySet.toList()..sort();
 
-    // Per-repo activity-by-day, ranked by total contribution; keep top 5 + rest.
+    // Per-repo activity-by-day keyed by repoKey (not the leaf name, which can
+    // collide across orgs), ranked by total contribution; keep top N + rest.
     final byRepo = <String, Map<DateTime, double>>{};
     final totals = <String, double>{};
+    final labels = <String, String>{};
     data.history.forEach((key, snaps) {
       final name =
           data.activities
@@ -41,6 +43,7 @@ class StackedAreaView extends StatelessWidget {
               .map((a) => a.displayName)
               .fold<String?>(null, (p, e) => p ?? e) ??
           key;
+      labels[key] = name.split('/').last;
       final map = <DateTime, double>{};
       var total = 0.0;
       for (final s in snaps) {
@@ -48,8 +51,8 @@ class StackedAreaView extends StatelessWidget {
         map[d] = (map[d] ?? 0) + s.activityScore.toDouble();
         total += s.activityScore.toDouble();
       }
-      byRepo[name.split('/').last] = map;
-      totals[name.split('/').last] = total;
+      byRepo[key] = map;
+      totals[key] = total;
     });
     final ranked = totals.keys.toList()
       ..sort((a, b) => totals[b]!.compareTo(totals[a]!));
@@ -58,12 +61,14 @@ class StackedAreaView extends StatelessWidget {
     // Build stacked layers (top repos, then "other").
     final layers = <_Layer>[];
     for (var i = 0; i < top.length; i++) {
-      layers.add(_Layer(top[i], byRepo[top[i]]!, _palette[i]));
+      layers.add(
+        _Layer(labels[top[i]] ?? top[i], byRepo[top[i]]!, _palette[i]),
+      );
     }
     if (ranked.length > top.length) {
       final other = <DateTime, double>{};
-      for (final name in ranked.skip(top.length)) {
-        byRepo[name]!.forEach((d, v) => other[d] = (other[d] ?? 0) + v);
+      for (final key in ranked.skip(top.length)) {
+        byRepo[key]!.forEach((d, v) => other[d] = (other[d] ?? 0) + v);
       }
       layers.add(_Layer('other', other, _palette.last));
     }
@@ -80,9 +85,21 @@ class StackedAreaView extends StatelessWidget {
             )
           : Column(
               children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      scoreNote,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ),
                 Expanded(
                   child: Padding(
-                    padding: const EdgeInsets.fromLTRB(12, 16, 16, 8),
+                    padding: const EdgeInsets.fromLTRB(12, 8, 16, 8),
                     child: LayoutBuilder(
                       builder: (context, c) => CustomPaint(
                         size: Size(c.maxWidth, c.maxHeight),

--- a/lib/views/team_radar_view.dart
+++ b/lib/views/team_radar_view.dart
@@ -1,0 +1,211 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../team.dart';
+import '../team_service.dart';
+import 'views_common.dart';
+
+/// One radar/spider chart per team across five normalized dimensions, so team
+/// "shapes" can be compared at a glance.
+class TeamRadarView extends StatelessWidget {
+  const TeamRadarView({super.key, required this.data});
+
+  final InsightsData data;
+
+  static const _axes = [
+    'Open PRs',
+    'Review',
+    'Oldest PR',
+    'Activity',
+    'People',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final teams = data.teams;
+
+    // Per-axis maxima across teams for normalization.
+    double maxOpen = 1, maxReview = 1, maxAge = 1, maxAct = 1, maxPeople = 1;
+    for (final t in teams) {
+      final r = data.rollups[t.id];
+      if (r == null) continue;
+      maxOpen = math.max(maxOpen, r.openPrs.toDouble());
+      maxReview = math.max(maxReview, r.needsReview.toDouble());
+      maxAge = math.max(maxAge, (r.oldestOpenPrAgeDays ?? 0).toDouble());
+      maxAct = math.max(maxAct, r.activityScore.toDouble());
+      maxPeople = math.max(maxPeople, r.contributors.length.toDouble());
+    }
+
+    return ViewScaffold(
+      title: 'Team radar',
+      loadedAt: data.loadedAt,
+      child: teams.isEmpty
+          ? const ViewEmpty(
+              message:
+                  'No teams yet. Create teams (More → Teams) to compare their shapes here.',
+            )
+          : GridView.builder(
+              padding: const EdgeInsets.all(12),
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 260,
+                mainAxisSpacing: 12,
+                crossAxisSpacing: 12,
+                childAspectRatio: 0.82,
+              ),
+              itemCount: teams.length,
+              itemBuilder: (context, i) {
+                final team = teams[i];
+                final r = data.rollups[team.id];
+                final values = r == null
+                    ? <double>[0, 0, 0, 0, 0]
+                    : <double>[
+                        r.openPrs / maxOpen,
+                        r.needsReview / maxReview,
+                        (r.oldestOpenPrAgeDays ?? 0) / maxAge,
+                        r.activityScore / maxAct,
+                        r.contributors.length / maxPeople,
+                      ];
+                return _card(context, team, r, values);
+              },
+            ),
+    );
+  }
+
+  Widget _card(
+    BuildContext context,
+    Team team,
+    TeamRollup? rollup,
+    List<double> values,
+  ) {
+    final color = Theme.of(context).colorScheme.primary;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Column(
+          children: [
+            Text(
+              team.name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(
+                context,
+              ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            Expanded(
+              child: CustomPaint(
+                size: Size.infinite,
+                painter: _RadarPainter(
+                  values: values,
+                  axes: _axes,
+                  fill: color,
+                  gridColor: Theme.of(context).colorScheme.outlineVariant,
+                  labelColor: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            Text(
+              rollup == null
+                  ? '—'
+                  : '${rollup.repoCount} repos · ${rollup.openPrs} PRs',
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RadarPainter extends CustomPainter {
+  _RadarPainter({
+    required this.values,
+    required this.axes,
+    required this.fill,
+    required this.gridColor,
+    required this.labelColor,
+  });
+
+  final List<double> values;
+  final List<String> axes;
+  final Color fill;
+  final Color gridColor;
+  final Color labelColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = math.min(size.width, size.height) / 2 - 18;
+    if (radius <= 0) return;
+    final n = values.length;
+
+    final gridPaint = Paint()
+      ..color = gridColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.7;
+
+    // Concentric rings.
+    for (var ring = 1; ring <= 3; ring++) {
+      final path = Path();
+      for (var i = 0; i <= n; i++) {
+        final angle = -math.pi / 2 + 2 * math.pi * i / n;
+        final r = radius * ring / 3;
+        final p = center + Offset(math.cos(angle) * r, math.sin(angle) * r);
+        if (i == 0) {
+          path.moveTo(p.dx, p.dy);
+        } else {
+          path.lineTo(p.dx, p.dy);
+        }
+      }
+      canvas.drawPath(path, gridPaint);
+    }
+
+    // Spokes + axis labels.
+    for (var i = 0; i < n; i++) {
+      final angle = -math.pi / 2 + 2 * math.pi * i / n;
+      final edge =
+          center + Offset(math.cos(angle) * radius, math.sin(angle) * radius);
+      canvas.drawLine(center, edge, gridPaint);
+      final labelPos =
+          center +
+          Offset(
+            math.cos(angle) * (radius + 10),
+            math.sin(angle) * (radius + 10),
+          );
+      final tp = TextPainter(
+        text: TextSpan(
+          text: axes[i],
+          style: TextStyle(color: labelColor, fontSize: 8),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      tp.paint(canvas, labelPos - Offset(tp.width / 2, tp.height / 2));
+    }
+
+    // Value polygon.
+    final valuePath = Path();
+    for (var i = 0; i <= n; i++) {
+      final idx = i % n;
+      final angle = -math.pi / 2 + 2 * math.pi * idx / n;
+      final r = radius * values[idx].clamp(0.0, 1.0);
+      final p = center + Offset(math.cos(angle) * r, math.sin(angle) * r);
+      if (i == 0) {
+        valuePath.moveTo(p.dx, p.dy);
+      } else {
+        valuePath.lineTo(p.dx, p.dy);
+      }
+    }
+    canvas.drawPath(valuePath, Paint()..color = fill.withValues(alpha: 0.25));
+    canvas.drawPath(
+      valuePath,
+      Paint()
+        ..color = fill
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _RadarPainter old) => old.values != values;
+}

--- a/lib/views/treemap_view.dart
+++ b/lib/views/treemap_view.dart
@@ -20,19 +20,39 @@ class TreemapView extends StatelessWidget {
       loadedAt: data.loadedAt,
       child: repos.isEmpty
           ? const ViewEmpty(message: 'No activity to lay out yet.')
-          : Padding(
-              padding: const EdgeInsets.all(8),
-              child: LayoutBuilder(
-                builder: (context, c) {
-                  final cells = _squarify(
-                    repos,
-                    Rect.fromLTWH(0, 0, c.maxWidth, c.maxHeight),
-                  );
-                  return Stack(
-                    children: [for (final cell in cells) _tile(context, cell)],
-                  );
-                },
-              ),
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 10, 12, 2),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'Area = $scoreNote',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: LayoutBuilder(
+                      builder: (context, c) {
+                        final cells = _squarify(
+                          repos,
+                          Rect.fromLTWH(0, 0, c.maxWidth, c.maxHeight),
+                        );
+                        return Stack(
+                          children: [
+                            for (final cell in cells) _tile(context, cell),
+                          ],
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ],
             ),
     );
   }
@@ -109,7 +129,9 @@ class TreemapView extends StatelessWidget {
       final left = items.sublist(0, split + 1);
       final right = items.sublist(split + 1);
       final leftVal = left.fold<double>(0, (s, a) => s + a.activityScore);
-      final frac = total == 0 ? 0.5 : (leftVal / total).clamp(0.1, 0.9);
+      // True proportional split (values are all > 0 here), so extreme ratios
+      // aren't flattened toward 50/50.
+      final frac = total == 0 ? 0.5 : leftVal / total;
       if (r.width >= r.height) {
         final w = r.width * frac;
         layout(left, Rect.fromLTWH(r.left, r.top, w, r.height));

--- a/lib/views/treemap_view.dart
+++ b/lib/views/treemap_view.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+
+import '../activity_service.dart';
+import 'views_common.dart';
+
+/// A treemap where each repo's area is proportional to its activity score and
+/// its color reflects freshness — a compact "where is the energy" overview.
+class TreemapView extends StatelessWidget {
+  const TreemapView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final repos = data.healthy.where((a) => a.activityScore > 0).toList()
+      ..sort((a, b) => b.activityScore.compareTo(a.activityScore));
+
+    return ViewScaffold(
+      title: 'Treemap',
+      loadedAt: data.loadedAt,
+      child: repos.isEmpty
+          ? const ViewEmpty(message: 'No activity to lay out yet.')
+          : Padding(
+              padding: const EdgeInsets.all(8),
+              child: LayoutBuilder(
+                builder: (context, c) {
+                  final cells = _squarify(
+                    repos,
+                    Rect.fromLTWH(0, 0, c.maxWidth, c.maxHeight),
+                  );
+                  return Stack(
+                    children: [for (final cell in cells) _tile(context, cell)],
+                  );
+                },
+              ),
+            ),
+    );
+  }
+
+  Widget _tile(BuildContext context, _Cell cell) {
+    final r = cell.rect;
+    final color = freshnessColor(cell.repo.lastActivity);
+    final showLabel = r.width > 54 && r.height > 30;
+    return Positioned(
+      left: r.left,
+      top: r.top,
+      width: r.width,
+      height: r.height,
+      child: Padding(
+        padding: const EdgeInsets.all(1.5),
+        child: InkWell(
+          onTap: () => openUrl(cell.repo.url),
+          child: Container(
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.85),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            padding: const EdgeInsets.all(4),
+            child: showLabel
+                ? Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        cell.repo.displayName.split('/').last,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: onColorFor(color),
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      if (r.height > 46)
+                        Text(
+                          '${cell.repo.openPrCount} PR',
+                          style: TextStyle(
+                            color: onColorFor(color).withValues(alpha: 0.9),
+                            fontSize: 10,
+                          ),
+                        ),
+                    ],
+                  )
+                : null,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Simple longest-axis binary-split treemap: partitions items ~50/50 by value
+  /// and splits along the longer side, which keeps cells reasonably square
+  /// without a full squarified pass.
+  static List<_Cell> _squarify(List<RepoActivity> repos, Rect rect) {
+    final cells = <_Cell>[];
+    void layout(List<RepoActivity> items, Rect r) {
+      if (items.isEmpty || r.width <= 0 || r.height <= 0) return;
+      if (items.length == 1) {
+        cells.add(_Cell(items.first, r));
+        return;
+      }
+      final total = items.fold<double>(0, (s, a) => s + a.activityScore);
+      var acc = 0.0;
+      var split = 0;
+      for (; split < items.length - 1; split++) {
+        if (acc + items[split].activityScore >= total / 2) break;
+        acc += items[split].activityScore;
+      }
+      split = split.clamp(0, items.length - 2);
+      final left = items.sublist(0, split + 1);
+      final right = items.sublist(split + 1);
+      final leftVal = left.fold<double>(0, (s, a) => s + a.activityScore);
+      final frac = total == 0 ? 0.5 : (leftVal / total).clamp(0.1, 0.9);
+      if (r.width >= r.height) {
+        final w = r.width * frac;
+        layout(left, Rect.fromLTWH(r.left, r.top, w, r.height));
+        layout(right, Rect.fromLTWH(r.left + w, r.top, r.width - w, r.height));
+      } else {
+        final h = r.height * frac;
+        layout(left, Rect.fromLTWH(r.left, r.top, r.width, h));
+        layout(right, Rect.fromLTWH(r.left, r.top + h, r.width, r.height - h));
+      }
+    }
+
+    layout(repos, rect);
+    return cells;
+  }
+}
+
+class _Cell {
+  const _Cell(this.repo, this.rect);
+  final RepoActivity repo;
+  final Rect rect;
+}

--- a/lib/views/trend_lines_view.dart
+++ b/lib/views/trend_lines_view.dart
@@ -1,0 +1,211 @@
+import 'dart:math' as math;
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+
+import '../metric_snapshot.dart';
+import 'views_common.dart';
+
+/// Overlaid activity-score trend lines for the most active repos over the
+/// snapshot history — the "are we speeding up or slowing down" view.
+class TrendLinesView extends StatelessWidget {
+  const TrendLinesView({super.key, required this.data});
+
+  final InsightsData data;
+
+  static const _palette = <Color>[
+    Color(0xFF1565C0),
+    Color(0xFFC62828),
+    Color(0xFF2E7D32),
+    Color(0xFF6A1B9A),
+    Color(0xFFEF6C00),
+    Color(0xFF00838F),
+    Color(0xFFAD1457),
+    Color(0xFF558B2F),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    // Repos with at least 2 snapshots, ranked by their latest activity score.
+    final series = <_Series>[];
+    data.history.forEach((key, snaps) {
+      if (snaps.length < 2) return;
+      final name =
+          data.activities
+              .where((a) => a.repoKey == key)
+              .map((a) => a.displayName)
+              .firstOrNull ??
+          key;
+      series.add(_Series(name.split('/').last, snaps));
+    });
+    series.sort(
+      (a, b) =>
+          b.snaps.last.activityScore.compareTo(a.snaps.last.activityScore),
+    );
+    final top = series.take(_palette.length).toList();
+
+    return ViewScaffold(
+      title: 'Trends',
+      loadedAt: data.loadedAt,
+      child: top.isEmpty
+          ? const ViewEmpty(
+              message:
+                  'Trends need at least two daily snapshots per repo.\nKeep the app around and they fill in.',
+            )
+          : Column(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 16, 16, 8),
+                    child: LayoutBuilder(
+                      builder: (context, c) => CustomPaint(
+                        size: Size(c.maxWidth, c.maxHeight),
+                        painter: _TrendPainter(
+                          series: top,
+                          colors: _palette,
+                          axisColor: Theme.of(context).colorScheme.outline,
+                          gridColor: Theme.of(
+                            context,
+                          ).colorScheme.outlineVariant,
+                          labelColor: Theme.of(context).colorScheme.onSurface,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                _legend(context, top),
+              ],
+            ),
+    );
+  }
+
+  Widget _legend(BuildContext context, List<_Series> top) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 6,
+        children: [
+          for (var i = 0; i < top.length; i++)
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(width: 12, height: 3, color: _palette[i]),
+                const SizedBox(width: 5),
+                Text(
+                  top[i].name,
+                  style: Theme.of(context).textTheme.labelSmall,
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Series {
+  _Series(this.name, this.snaps);
+  final String name;
+  final List<MetricSnapshot> snaps;
+}
+
+class _TrendPainter extends CustomPainter {
+  _TrendPainter({
+    required this.series,
+    required this.colors,
+    required this.axisColor,
+    required this.gridColor,
+    required this.labelColor,
+  });
+
+  final List<_Series> series;
+  final List<Color> colors;
+  final Color axisColor;
+  final Color gridColor;
+  final Color labelColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const padL = 32.0, padB = 18.0, padT = 6.0, padR = 6.0;
+    final plot = Rect.fromLTRB(
+      padL,
+      padT,
+      size.width - padR,
+      size.height - padB,
+    );
+    if (plot.width <= 0 || plot.height <= 0) return;
+
+    var minT = double.infinity, maxT = -double.infinity, maxV = 0.0;
+    for (final s in series) {
+      for (final snap in s.snaps) {
+        final t = snap.at.millisecondsSinceEpoch.toDouble();
+        minT = math.min(minT, t);
+        maxT = math.max(maxT, t);
+        maxV = math.max(maxV, snap.activityScore.toDouble());
+      }
+    }
+    if (!minT.isFinite || maxT <= minT) return;
+    maxV = math.max(maxV, 1);
+
+    final axisPaint = Paint()
+      ..color = axisColor
+      ..strokeWidth = 1;
+    final gridPaint = Paint()
+      ..color = gridColor
+      ..strokeWidth = 0.5;
+    canvas.drawLine(plot.bottomLeft, plot.bottomRight, axisPaint);
+    canvas.drawLine(plot.topLeft, plot.bottomLeft, axisPaint);
+    for (var i = 1; i <= 4; i++) {
+      final gy = plot.bottom - plot.height * i / 4;
+      canvas.drawLine(Offset(plot.left, gy), Offset(plot.right, gy), gridPaint);
+      _text(
+        canvas,
+        (maxV * i / 4).round().toString(),
+        Offset(plot.left - 4, gy - 5),
+      );
+    }
+
+    for (var i = 0; i < series.length; i++) {
+      final paint = Paint()
+        ..color = colors[i % colors.length]
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2
+        ..strokeJoin = StrokeJoin.round;
+      final path = Path();
+      final snaps = series[i].snaps;
+      for (var j = 0; j < snaps.length; j++) {
+        final t = snaps[j].at.millisecondsSinceEpoch.toDouble();
+        final x = plot.left + plot.width * (t - minT) / (maxT - minT);
+        final y =
+            plot.bottom -
+            plot.height * (snaps[j].activityScore.toDouble() / maxV);
+        if (j == 0) {
+          path.moveTo(x, y);
+        } else {
+          path.lineTo(x, y);
+        }
+        canvas.drawCircle(
+          Offset(x, y),
+          2,
+          Paint()..color = colors[i % colors.length],
+        );
+      }
+      canvas.drawPath(path, paint);
+    }
+  }
+
+  void _text(Canvas canvas, String text, Offset at) {
+    final tp = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(color: labelColor, fontSize: 9),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    tp.paint(canvas, Offset(at.dx - tp.width, at.dy));
+  }
+
+  @override
+  bool shouldRepaint(covariant _TrendPainter old) => old.series != series;
+}

--- a/lib/views/trend_lines_view.dart
+++ b/lib/views/trend_lines_view.dart
@@ -54,9 +54,21 @@ class TrendLinesView extends StatelessWidget {
             )
           : Column(
               children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      scoreNote,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ),
                 Expanded(
                   child: Padding(
-                    padding: const EdgeInsets.fromLTRB(12, 16, 16, 8),
+                    padding: const EdgeInsets.fromLTRB(12, 8, 16, 8),
                     child: LayoutBuilder(
                       builder: (context, c) => CustomPaint(
                         size: Size(c.maxWidth, c.maxHeight),

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -8,16 +8,21 @@ import '../team.dart';
 import '../team_service.dart';
 
 /// Pre-loaded data handed to every insights view so each view is a pure widget
-/// (no fetching): the hub loads once and passes this down.
+/// (no fetching): the hub loads once and passes this down. Collections are
+/// copied into unmodifiable views so a view can't mutate the shared snapshot.
 class InsightsData {
-  const InsightsData({
-    required this.activities,
-    required this.history,
-    required this.teams,
-    required this.rollups,
-    required this.people,
+  InsightsData({
+    required List<RepoActivity> activities,
+    required Map<String, List<MetricSnapshot>> history,
+    required List<Team> teams,
+    required Map<String, TeamRollup> rollups,
+    required List<Person> people,
     required this.loadedAt,
-  });
+  }) : activities = List.unmodifiable(activities),
+       history = Map.unmodifiable(history),
+       teams = List.unmodifiable(teams),
+       rollups = Map.unmodifiable(rollups),
+       people = List.unmodifiable(people);
 
   final List<RepoActivity> activities;
   final Map<String, List<MetricSnapshot>> history;
@@ -71,12 +76,17 @@ String ciLabel(String status) => switch (status) {
   _ => 'unknown',
 };
 
-/// Opens a repo URL in the external browser; silently no-ops on failure.
+/// Opens a repo URL in the external browser; silently no-ops on any failure
+/// (bad URL, unsupported scheme, or a platform channel exception).
 Future<void> openUrl(String url) async {
   final uri = Uri.tryParse(url);
   if (uri == null) return;
-  if (await canLaunchUrl(uri)) {
-    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  try {
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  } catch (e) {
+    debugPrint('openUrl failed for $url: $e');
   }
 }
 

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -80,6 +80,12 @@ Future<void> openUrl(String url) async {
   }
 }
 
+/// Shown on views that encode `activityScore`, which is not raw activity: it
+/// also weights attention (failing CI and long-stuck PRs) so repos that need a
+/// human bubble up. Disclosed so "bigger/hotter" isn't read as pure activity.
+const String scoreNote =
+    'Score blends activity + attention (failing CI / stale PRs raise it).';
+
 // ---- Time helpers -----------------------------------------------------------
 
 int? daysSince(DateTime? value, {DateTime? now}) {

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -8,8 +8,10 @@ import '../team.dart';
 import '../team_service.dart';
 
 /// Pre-loaded data handed to every insights view so each view is a pure widget
-/// (no fetching): the hub loads once and passes this down. Collections are
-/// copied into unmodifiable views so a view can't mutate the shared snapshot.
+/// (no fetching): the hub loads once and passes this down. All collections —
+/// including the nested per-repo history lists and per-team contributor sets —
+/// are copied into unmodifiable views so a view can't mutate the shared
+/// snapshot.
 class InsightsData {
   InsightsData({
     required List<RepoActivity> activities,
@@ -19,9 +21,14 @@ class InsightsData {
     required List<Person> people,
     required this.loadedAt,
   }) : activities = List.unmodifiable(activities),
-       history = Map.unmodifiable(history),
+       history = Map.unmodifiable({
+         for (final e in history.entries)
+           e.key: List<MetricSnapshot>.unmodifiable(e.value),
+       }),
        teams = List.unmodifiable(teams),
-       rollups = Map.unmodifiable(rollups),
+       rollups = Map.unmodifiable({
+         for (final e in rollups.entries) e.key: _readonlyRollup(e.value),
+       }),
        people = List.unmodifiable(people);
 
   final List<RepoActivity> activities;
@@ -37,6 +44,18 @@ class InsightsData {
 
   bool get isEmpty => activities.isEmpty;
 }
+
+/// Rebuilds a [TeamRollup] with an unmodifiable contributor set so the shared
+/// snapshot can't be mutated through it.
+TeamRollup _readonlyRollup(TeamRollup r) => TeamRollup(
+  repoCount: r.repoCount,
+  openPrs: r.openPrs,
+  needsReview: r.needsReview,
+  oldestOpenPrAgeDays: r.oldestOpenPrAgeDays,
+  contributors: Set.unmodifiable(r.contributors),
+  activityScore: r.activityScore,
+  lastActivity: r.lastActivity,
+);
 
 /// A tappable descriptor for the gallery grid on the hub.
 class ViewInfo {
@@ -76,8 +95,9 @@ String ciLabel(String status) => switch (status) {
   _ => 'unknown',
 };
 
-/// Opens a repo URL in the external browser; silently no-ops on any failure
-/// (bad URL, unsupported scheme, or a platform channel exception).
+/// Opens a repo URL in the external browser. Logs and no-ops on any failure
+/// (bad URL, unsupported scheme, or a platform channel exception) so a tap
+/// handler can't crash.
 Future<void> openUrl(String url) async {
   final uri = Uri.tryParse(url);
   if (uri == null) return;

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../activity_service.dart';
+import '../metric_snapshot.dart';
+import '../team.dart';
+import '../team_service.dart';
+
+/// Pre-loaded data handed to every insights view so each view is a pure widget
+/// (no fetching): the hub loads once and passes this down.
+class InsightsData {
+  const InsightsData({
+    required this.activities,
+    required this.history,
+    required this.teams,
+    required this.rollups,
+    required this.loadedAt,
+  });
+
+  final List<RepoActivity> activities;
+  final Map<String, List<MetricSnapshot>> history;
+  final List<Team> teams;
+  final Map<String, TeamRollup> rollups;
+  final DateTime loadedAt;
+
+  /// Repos whose fetch succeeded (errored repos would read as healthy zeros).
+  List<RepoActivity> get healthy =>
+      activities.where((a) => a.error == null).toList();
+
+  bool get isEmpty => activities.isEmpty;
+}
+
+/// A tappable descriptor for the gallery grid on the hub.
+class ViewInfo {
+  const ViewInfo({
+    required this.title,
+    required this.blurb,
+    required this.icon,
+    required this.builder,
+  });
+
+  final String title;
+  final String blurb;
+  final IconData icon;
+  final Widget Function(InsightsData data) builder;
+}
+
+// ---- CI helpers -------------------------------------------------------------
+
+Color ciColor(String status) => switch (status) {
+  'success' => const Color(0xFF2E7D32),
+  'failure' => const Color(0xFFC62828),
+  'running' => const Color(0xFFEF6C00),
+  _ => const Color(0xFF9E9E9E),
+};
+
+IconData ciIcon(String status) => switch (status) {
+  'success' => Icons.check_circle,
+  'failure' => Icons.cancel,
+  'running' => Icons.hourglass_bottom,
+  _ => Icons.help_outline,
+};
+
+String ciLabel(String status) => switch (status) {
+  'success' => 'passing',
+  'failure' => 'failing',
+  'running' => 'running',
+  _ => 'unknown',
+};
+
+/// Opens a repo URL in the external browser; silently no-ops on failure.
+Future<void> openUrl(String url) async {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return;
+  if (await canLaunchUrl(uri)) {
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+}
+
+// ---- Time helpers -----------------------------------------------------------
+
+int? daysSince(DateTime? value, {DateTime? now}) {
+  if (value == null) return null;
+  final diff = (now ?? DateTime.now()).difference(value);
+  return diff.isNegative ? 0 : diff.inDays;
+}
+
+String relativeTime(DateTime? value, {DateTime? now}) {
+  if (value == null) return 'never';
+  final diff = (now ?? DateTime.now()).difference(value);
+  if (diff.isNegative || diff.inMinutes < 1) return 'just now';
+  if (diff.inHours < 1) return '${diff.inMinutes}m ago';
+  if (diff.inDays < 1) return '${diff.inHours}h ago';
+  if (diff.inDays < 30) return '${diff.inDays}d ago';
+  final months = diff.inDays ~/ 30;
+  if (months < 12) return '${months}mo ago';
+  return '${diff.inDays ~/ 365}y ago';
+}
+
+// ---- Freshness / heat scale -------------------------------------------------
+
+/// Maps a repo's last activity to a freshness color: green (fresh) → amber
+/// (quieting) → grey (stale/quiet).
+Color freshnessColor(DateTime? lastActivity, {DateTime? now}) {
+  final days = daysSince(lastActivity, now: now);
+  if (days == null) return const Color(0xFF9E9E9E);
+  if (days <= 1) return const Color(0xFF2E7D32);
+  if (days <= 3) return const Color(0xFF66BB6A);
+  if (days <= 7) return const Color(0xFFF9A825);
+  if (days <= 21) return const Color(0xFFEF6C00);
+  return const Color(0xFF8D6E63);
+}
+
+/// Continuous cool→warm heat color for a normalized value [t] in [0,1].
+/// 0 = calm (blue), 0.5 = active (green/amber), 1 = hot (red).
+Color heatColor(double t) {
+  final clamped = t.clamp(0.0, 1.0);
+  const stops = <Color>[
+    Color(0xFF1565C0), // blue
+    Color(0xFF00897B), // teal
+    Color(0xFF7CB342), // green
+    Color(0xFFF9A825), // amber
+    Color(0xFFC62828), // red
+  ];
+  final scaled = clamped * (stops.length - 1);
+  final i = scaled.floor().clamp(0, stops.length - 2);
+  final f = scaled - i;
+  return Color.lerp(stops[i], stops[i + 1], f)!;
+}
+
+/// A readable on-color for a filled swatch.
+Color onColorFor(Color background) =>
+    ThemeData.estimateBrightnessForColor(background) == Brightness.dark
+    ? Colors.white
+    : Colors.black87;
+
+// ---- PR age buckets ---------------------------------------------------------
+
+class AgeBucket {
+  const AgeBucket(this.label, this.minInclusive, this.maxExclusive, this.color);
+  final String label;
+  final int minInclusive;
+  final int? maxExclusive; // null = unbounded
+  final Color color;
+
+  bool contains(int days) =>
+      days >= minInclusive && (maxExclusive == null || days < maxExclusive!);
+}
+
+const List<AgeBucket> ageBuckets = [
+  AgeBucket('<1d', 0, 1, Color(0xFF2E7D32)),
+  AgeBucket('1–3d', 1, 3, Color(0xFF7CB342)),
+  AgeBucket('3–7d', 3, 7, Color(0xFFF9A825)),
+  AgeBucket('1–2w', 7, 14, Color(0xFFEF6C00)),
+  AgeBucket('>2w', 14, null, Color(0xFFC62828)),
+];
+
+// ---- Small shared widgets ---------------------------------------------------
+
+/// A compact "big number" stat tile used across dashboard-style views.
+class StatTile extends StatelessWidget {
+  const StatTile({
+    super.key,
+    required this.label,
+    required this.value,
+    this.icon,
+    this.color,
+    this.sub,
+  });
+
+  final String label;
+  final String value;
+  final IconData? icon;
+  final Color? color;
+  final String? sub;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final accent = color ?? scheme.primary;
+    return Card(
+      elevation: 0,
+      color: accent.withValues(alpha: 0.10),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Row(
+              children: [
+                if (icon != null) ...[
+                  Icon(icon, size: 18, color: accent),
+                  const SizedBox(width: 6),
+                ],
+                Expanded(
+                  child: Text(
+                    label,
+                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              value,
+              style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: accent,
+              ),
+            ),
+            if (sub != null) ...[
+              const SizedBox(height: 2),
+              Text(
+                sub!,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: scheme.onSurfaceVariant),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Wraps a view body in a standard Scaffold with a title and an optional
+/// "loaded at" caption in the app bar.
+class ViewScaffold extends StatelessWidget {
+  const ViewScaffold({
+    super.key,
+    required this.title,
+    required this.child,
+    this.loadedAt,
+  });
+
+  final String title;
+  final Widget child;
+  final DateTime? loadedAt;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+        bottom: loadedAt == null
+            ? null
+            : PreferredSize(
+                preferredSize: const Size.fromHeight(18),
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 6, left: 16),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'Snapshot ${relativeTime(loadedAt)}',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+      ),
+      body: child,
+    );
+  }
+}
+
+/// Empty-state placeholder used when a view has nothing to render.
+class ViewEmpty extends StatelessWidget {
+  const ViewEmpty({super.key, required this.message});
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.insights_outlined,
+              size: 48,
+              color: Theme.of(context).colorScheme.outline,
+            ),
+            const SizedBox(height: 12),
+            Text(message, textAlign: TextAlign.center),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -3,6 +3,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../activity_service.dart';
 import '../metric_snapshot.dart';
+import '../person.dart';
 import '../team.dart';
 import '../team_service.dart';
 
@@ -14,6 +15,7 @@ class InsightsData {
     required this.history,
     required this.teams,
     required this.rollups,
+    required this.people,
     required this.loadedAt,
   });
 
@@ -21,6 +23,7 @@ class InsightsData {
   final Map<String, List<MetricSnapshot>> history;
   final List<Team> teams;
   final Map<String, TeamRollup> rollups;
+  final List<Person> people;
   final DateTime loadedAt;
 
   /// Repos whose fetch succeeded (errored repos would read as healthy zeros).

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kode_radar/activity_service.dart';
 import 'package:kode_radar/metric_snapshot.dart';
+import 'package:kode_radar/person.dart';
 import 'package:kode_radar/team.dart';
 import 'package:kode_radar/team_service.dart';
 import 'package:kode_radar/views/age_histogram_view.dart';
@@ -16,6 +17,7 @@ import 'package:kode_radar/views/provider_split_view.dart';
 import 'package:kode_radar/views/pulse_view.dart';
 import 'package:kode_radar/views/quadrant_view.dart';
 import 'package:kode_radar/views/repo_table_view.dart';
+import 'package:kode_radar/views/review_load_view.dart';
 import 'package:kode_radar/views/stacked_area_view.dart';
 import 'package:kode_radar/views/team_radar_view.dart';
 import 'package:kode_radar/views/treemap_view.dart';
@@ -92,6 +94,23 @@ InsightsData _sampleData() {
     history: history,
     teams: teams,
     rollups: TeamService.rollupAll(teams, activities),
+    people: [
+      Person(
+        key: 'github:alice',
+        displayName: 'Alice',
+        githubLogins: const {'alice'},
+        authoredOpenPrs: 3,
+        reviewRequests: 5,
+        isSelf: true,
+      ),
+      Person(
+        key: 'github:bob',
+        displayName: 'Bob',
+        githubLogins: const {'bob'},
+        authoredOpenPrs: 1,
+        reviewRequests: 2,
+      ),
+    ],
     loadedAt: DateTime.now(),
   );
 }
@@ -103,6 +122,7 @@ void main() {
     history: const {},
     teams: const [],
     rollups: const {},
+    people: const [],
     loadedAt: DateTime.now(),
   );
 
@@ -121,6 +141,7 @@ void main() {
     'TeamRadar': (d) => TeamRadarView(data: d),
     'Freshness': (d) => FreshnessView(data: d),
     'Contributors': (d) => ContributorCloudView(data: d),
+    'ReviewLoad': (d) => ReviewLoadView(data: d),
     'ProviderSplit': (d) => ProviderSplitView(data: d),
     'RepoTable': (d) => RepoTableView(data: d),
   };

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -10,11 +10,13 @@ import 'package:kode_radar/views/ci_grid_view.dart';
 import 'package:kode_radar/views/contributor_cloud_view.dart';
 import 'package:kode_radar/views/donut_view.dart';
 import 'package:kode_radar/views/freshness_view.dart';
+import 'package:kode_radar/views/health_gauge_view.dart';
 import 'package:kode_radar/views/heatmap_view.dart';
 import 'package:kode_radar/views/provider_split_view.dart';
 import 'package:kode_radar/views/pulse_view.dart';
 import 'package:kode_radar/views/quadrant_view.dart';
 import 'package:kode_radar/views/repo_table_view.dart';
+import 'package:kode_radar/views/stacked_area_view.dart';
 import 'package:kode_radar/views/team_radar_view.dart';
 import 'package:kode_radar/views/treemap_view.dart';
 import 'package:kode_radar/views/trend_lines_view.dart';
@@ -106,6 +108,7 @@ void main() {
 
   final views = <String, Widget Function(InsightsData)>{
     'Pulse': (d) => PulseView(data: d),
+    'HealthGauge': (d) => HealthGaugeView(data: d),
     'Bubble': (d) => BubbleView(data: d),
     'Quadrant': (d) => QuadrantView(data: d),
     'Donut': (d) => DonutView(data: d),
@@ -114,6 +117,7 @@ void main() {
     'AgeHistogram': (d) => AgeHistogramView(data: d),
     'Heatmap': (d) => HeatmapView(data: d),
     'TrendLines': (d) => TrendLinesView(data: d),
+    'StackedArea': (d) => StackedAreaView(data: d),
     'TeamRadar': (d) => TeamRadarView(data: d),
     'Freshness': (d) => FreshnessView(data: d),
     'Contributors': (d) => ContributorCloudView(data: d),

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -7,9 +7,13 @@ import 'package:kode_radar/team_service.dart';
 import 'package:kode_radar/views/age_histogram_view.dart';
 import 'package:kode_radar/views/bubble_view.dart';
 import 'package:kode_radar/views/ci_grid_view.dart';
+import 'package:kode_radar/views/contributor_cloud_view.dart';
+import 'package:kode_radar/views/donut_view.dart';
 import 'package:kode_radar/views/freshness_view.dart';
 import 'package:kode_radar/views/heatmap_view.dart';
+import 'package:kode_radar/views/provider_split_view.dart';
 import 'package:kode_radar/views/pulse_view.dart';
+import 'package:kode_radar/views/quadrant_view.dart';
 import 'package:kode_radar/views/repo_table_view.dart';
 import 'package:kode_radar/views/team_radar_view.dart';
 import 'package:kode_radar/views/treemap_view.dart';
@@ -103,6 +107,8 @@ void main() {
   final views = <String, Widget Function(InsightsData)>{
     'Pulse': (d) => PulseView(data: d),
     'Bubble': (d) => BubbleView(data: d),
+    'Quadrant': (d) => QuadrantView(data: d),
+    'Donut': (d) => DonutView(data: d),
     'CiGrid': (d) => CiGridView(data: d),
     'Treemap': (d) => TreemapView(data: d),
     'AgeHistogram': (d) => AgeHistogramView(data: d),
@@ -110,6 +116,8 @@ void main() {
     'TrendLines': (d) => TrendLinesView(data: d),
     'TeamRadar': (d) => TeamRadarView(data: d),
     'Freshness': (d) => FreshnessView(data: d),
+    'Contributors': (d) => ContributorCloudView(data: d),
+    'ProviderSplit': (d) => ProviderSplitView(data: d),
     'RepoTable': (d) => RepoTableView(data: d),
   };
 

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -159,4 +159,103 @@ void main() {
       expect(tester.takeException(), isNull);
     });
   });
+
+  // ---- Edge cases the reviewers called out --------------------------------
+
+  InsightsData bundle({
+    List<RepoActivity> activities = const [],
+    Map<String, List<MetricSnapshot>> history = const {},
+    List<Person> people = const [],
+  }) {
+    return InsightsData(
+      activities: activities,
+      history: history,
+      teams: const [],
+      rollups: const {},
+      people: people,
+      loadedAt: DateTime.now(),
+    );
+  }
+
+  testWidgets('AgeHistogram survives a very short surface', (tester) async {
+    tester.view.physicalSize = const Size(400, 120);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(MaterialApp(home: AgeHistogramView(data: data)));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('StackedArea keeps repos with duplicate leaf names', (
+    tester,
+  ) async {
+    final dup = bundle(
+      activities: [
+        _activity('github:orgA/app', 'orgA/app'),
+        _activity('github:orgB/app', 'orgB/app'),
+      ],
+      history: {
+        'github:orgA/app': _series(3, 5),
+        'github:orgB/app': _series(3, 9),
+      },
+    );
+    await tester.pumpWidget(MaterialApp(home: StackedAreaView(data: dup)));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('ReviewLoad handles odd display names', (tester) async {
+    final odd = bundle(
+      people: [
+        Person(key: 'a', displayName: 'bot_', reviewRequests: 1),
+        Person(key: 'b', displayName: 'team/', authoredOpenPrs: 2),
+        Person(key: 'c', displayName: 'Renée Doe', reviewRequests: 3),
+        Person(key: 'd', displayName: 'a-', reviewRequests: 1),
+        Person(key: 'e', displayName: '', reviewRequests: 1),
+      ],
+    );
+    await tester.pumpWidget(MaterialApp(home: ReviewLoadView(data: odd)));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('ProviderSplit handles a single-provider fleet', (tester) async {
+    final ghOnly = bundle(
+      activities: [
+        _activity('github:o/a', 'o/a'),
+        _activity('github:o/b', 'o/b'),
+      ],
+    );
+    await tester.pumpWidget(MaterialApp(home: ProviderSplitView(data: ghOnly)));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('single-repo score views do not crash', (tester) async {
+    final one = bundle(
+      activities: [
+        _activity(
+          'github:o/solo',
+          'o/solo',
+          open: 1,
+          oldest: 1,
+          lastDaysAgo: 1,
+        ),
+      ],
+      history: {'github:o/solo': _series(1, 3)},
+    );
+    final builds = <Widget Function(InsightsData)>[
+      (d) => QuadrantView(data: d),
+      (d) => TreemapView(data: d),
+      (d) => DonutView(data: d),
+      (d) => BubbleView(data: d),
+      (d) => HealthGaugeView(data: d),
+    ];
+    for (final b in builds) {
+      await tester.pumpWidget(MaterialApp(home: b(one)));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    }
+  });
 }

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/activity_service.dart';
+import 'package:kode_radar/metric_snapshot.dart';
+import 'package:kode_radar/team.dart';
+import 'package:kode_radar/team_service.dart';
+import 'package:kode_radar/views/age_histogram_view.dart';
+import 'package:kode_radar/views/bubble_view.dart';
+import 'package:kode_radar/views/ci_grid_view.dart';
+import 'package:kode_radar/views/freshness_view.dart';
+import 'package:kode_radar/views/heatmap_view.dart';
+import 'package:kode_radar/views/pulse_view.dart';
+import 'package:kode_radar/views/repo_table_view.dart';
+import 'package:kode_radar/views/team_radar_view.dart';
+import 'package:kode_radar/views/treemap_view.dart';
+import 'package:kode_radar/views/trend_lines_view.dart';
+import 'package:kode_radar/views/views_common.dart';
+
+RepoActivity _activity(
+  String key,
+  String name, {
+  int open = 3,
+  int review = 1,
+  int? oldest = 5,
+  int? lastDaysAgo = 2,
+  String ci = 'success',
+  num score = 4,
+  String? error,
+}) {
+  return RepoActivity(
+    repoKey: key,
+    provider: 'github',
+    displayName: name,
+    url: 'https://github.com/$name',
+    openPrCount: open,
+    needsReviewCount: review,
+    oldestOpenPrAgeDays: oldest,
+    lastActivity: lastDaysAgo == null
+        ? null
+        : DateTime.now().subtract(Duration(days: lastDaysAgo)),
+    ciStatus: ci,
+    contributors: const ['alice', 'bob'],
+    activityScore: score,
+    error: error,
+  );
+}
+
+List<MetricSnapshot> _series(int n, num base) => [
+  for (var i = 0; i < n; i++)
+    MetricSnapshot(
+      at: DateTime.utc(2026, 1, 1).add(Duration(days: i)),
+      openPrs: 2 + i,
+      needsReview: i % 2,
+      activityScore: base + i,
+    ),
+];
+
+InsightsData _sampleData() {
+  final activities = [
+    _activity('github:o/alpha', 'o/alpha', ci: 'failure', score: 9),
+    _activity('github:o/beta', 'o/beta', ci: 'running', score: 5, oldest: 20),
+    _activity(
+      'github:o/gamma',
+      'o/gamma',
+      ci: 'success',
+      score: 2,
+      lastDaysAgo: 40,
+    ),
+    _activity('github:o/delta', 'o/delta', error: 'boom', open: 0),
+  ];
+  final history = {
+    'github:o/alpha': _series(6, 3),
+    'github:o/beta': _series(4, 1),
+    'github:o/gamma': _series(1, 2),
+  };
+  final teams = [
+    const Team(id: 't1', name: 'Platform', repoKeys: {'github:o/alpha'}),
+    const Team(
+      id: 't2',
+      name: 'Infra',
+      repoKeys: {'github:o/beta', 'github:o/gamma'},
+    ),
+  ];
+  return InsightsData(
+    activities: activities,
+    history: history,
+    teams: teams,
+    rollups: TeamService.rollupAll(teams, activities),
+    loadedAt: DateTime.now(),
+  );
+}
+
+void main() {
+  final data = _sampleData();
+  final empty = InsightsData(
+    activities: const [],
+    history: const {},
+    teams: const [],
+    rollups: const {},
+    loadedAt: DateTime.now(),
+  );
+
+  final views = <String, Widget Function(InsightsData)>{
+    'Pulse': (d) => PulseView(data: d),
+    'Bubble': (d) => BubbleView(data: d),
+    'CiGrid': (d) => CiGridView(data: d),
+    'Treemap': (d) => TreemapView(data: d),
+    'AgeHistogram': (d) => AgeHistogramView(data: d),
+    'Heatmap': (d) => HeatmapView(data: d),
+    'TrendLines': (d) => TrendLinesView(data: d),
+    'TeamRadar': (d) => TeamRadarView(data: d),
+    'Freshness': (d) => FreshnessView(data: d),
+    'RepoTable': (d) => RepoTableView(data: d),
+  };
+
+  views.forEach((name, build) {
+    testWidgets('$name renders with data', (tester) async {
+      await tester.pumpWidget(MaterialApp(home: build(data)));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('$name renders when empty', (tester) async {
+      await tester.pumpWidget(MaterialApp(home: build(empty)));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds an **Insights gallery** — a new "Insights (views)" entry in the overflow menu that opens a hub of **17 alternative visualizations** of the monitored data. The hub loads the data once (repos via `ActivityService`, trend history via `MetricStore`, teams via `TeamService`, people via `PeopleService`) into an immutable `InsightsData` bundle and hands it to each view, so switching between views is instant.

This lets the user glance at the same fleet through many lenses and keep whichever they like. **Additive only** — the sole change to existing code is the menu entry in `lib/home_menu.dart`.

## The 17 views (`lib/views/`)

| Lens | Views |
|---|---|
| At-a-glance | **Pulse** (counters + aggregate trend), **Fleet health** (0–100 gauge with factor breakdown) |
| Attention / triage | **Bubble** (age×count, sized by score), **Triage quadrant** (staleness×load, fixed thresholds), **CI health** board, **Freshness** (what went quiet) |
| Composition | **Treemap** (by score), **Open-PR donut**, **PR-age histogram**, **Provider split** (GitHub vs ADO) |
| Time | **Heatmap** (repo×day), **Trend lines**, **Stacked activity** |
| People | **Review load** (who can unblock whom), **Contributor cloud** |
| Power-user | **Sortable repo table**, **Team radar** (spider) |

Shared helpers (colors, scales, buckets, `ViewScaffold`, `openUrl`) live in `lib/views/views_common.dart`.

## Notes

- Time-based views (heatmap, trends, stacked) are sparse until trend history accumulates across days; each shows a friendly "builds up over time" state. Opening Insights now also captures a snapshot, like Radar/Teams/Digest.
- `activityScore` blends activity **and attention** (failing CI / stale PRs raise it) — this is disclosed on the score-encoding views. People views are framed as collaboration/unblocking per the app's no-surveillance ethos; the contributor cloud discloses the 5-authors-per-repo cap.

## Review

Ran the review gate (code-review + rubber-duck) **before** opening and fixed everything they found — see commit `5ccda70`:
- 3 confirmed crashes (age-histogram `clamp` on short surfaces, stacked-area dropping duplicate-leaf repos, review-load `_initials` RangeError)
- truthful encodings (treemap split clamp, provider zero-bars, quadrant midpoint→fixed thresholds, fleet-health CI factor = true pass rate)
- honesty disclosures + concurrent hub load.

## Tests

`flutter analyze --fatal-infos` clean · `dart format --set-exit-if-changed .` clean · **260 tests pass**. `test/views_smoke_test.dart` renders every view populated + empty, plus edge cases (short surface, duplicate leaf names, odd/unicode display names, single-provider, single repo).
