### PR TITLE
Add background sync, Sync now, and denser trend capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Note: This project has been almost entirely AI generated. I don't recommend usin
 ## Prerequisites
 
 - Flutter SDK (compatible version for this project)
-- iOS deployment target 13.0 or later (required by the bundled Flutter SDK; iOS 12 is no longer supported)
+- iOS deployment target 14.0 or later (required by the `workmanager` background-sync plugin; iOS 13 is no longer supported)
 - Platform toolchains for the targets you are building (Android SDK/NDK, Xcode for iOS/macOS, CMake for Linux, Visual Studio for Windows)
 
 ### Linux-specific Dependencies

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
 #include "AppInfo.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
 #include "AppInfo.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+platform :ios, '14.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,82 @@
+PODS:
+  - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
+  - flutter_secure_storage_darwin (10.0.0):
+    - Flutter
+    - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - sqlite3 (3.52.0):
+    - sqlite3/common (= 3.52.0)
+  - sqlite3/common (3.52.0)
+  - sqlite3/dbstatvtab (3.52.0):
+    - sqlite3/common
+  - sqlite3/fts5 (3.52.0):
+    - sqlite3/common
+  - sqlite3/math (3.52.0):
+    - sqlite3/common
+  - sqlite3/perf-threadsafe (3.52.0):
+    - sqlite3/common
+  - sqlite3/rtree (3.52.0):
+    - sqlite3/common
+  - sqlite3/session (3.52.0):
+    - sqlite3/common
+  - sqlite3_flutter_libs (0.0.1):
+    - Flutter
+    - FlutterMacOS
+    - sqlite3 (~> 3.52.0)
+    - sqlite3/dbstatvtab
+    - sqlite3/fts5
+    - sqlite3/math
+    - sqlite3/perf-threadsafe
+    - sqlite3/rtree
+    - sqlite3/session
+  - url_launcher_ios (0.0.1):
+    - Flutter
+  - workmanager_apple (0.0.1):
+    - Flutter
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
+  - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - workmanager_apple (from `.symlinks/plugins/workmanager_apple/ios`)
+
+SPEC REPOS:
+  trunk:
+    - sqlite3
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
+  flutter_secure_storage_darwin:
+    :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  sqlite3_flutter_libs:
+    :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
+  workmanager_apple:
+    :path: ".symlinks/plugins/workmanager_apple/ios"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
+  sqlite3_flutter_libs: b3e120efe9a82017e5552a620f696589ed4f62ab
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
+
+PODFILE CHECKSUM: e30f02f9d1c72c47bb6344a0a748c9d268180865
+
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,13 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		2E9BEA1926D16B337F10BA81 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 141927FAFAAE2545A35C5E3E /* Pods_Runner.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		9BB8AD9750FB3B30C296A01B /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD0F0449F13084A50E282035 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,13 +43,19 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		141927FAFAAE2545A35C5E3E /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		218EE1B790AE87F8B3E884A8 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		2FB73D62B5C0EF761424F02F /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		5FFEBA8686F04D1A9F99E523 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		72121309521895BF8F9FF04A /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -56,7 +64,9 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		AD0F0449F13084A50E282035 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B773379AF89CE428FC8D409A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		BD8A249DB9B53E2F040CF2AE /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +74,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9BB8AD9750FB3B30C296A01B /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -72,6 +83,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				2E9BEA1926D16B337F10BA81 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,6 +96,29 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		3A245AB99CFFB8E7A2F71399 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				141927FAFAAE2545A35C5E3E /* Pods_Runner.framework */,
+				AD0F0449F13084A50E282035 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6AD14C8D2BE60927FD83F529 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				5FFEBA8686F04D1A9F99E523 /* Pods-Runner.debug.xcconfig */,
+				B773379AF89CE428FC8D409A /* Pods-Runner.release.xcconfig */,
+				2FB73D62B5C0EF761424F02F /* Pods-Runner.profile.xcconfig */,
+				72121309521895BF8F9FF04A /* Pods-RunnerTests.debug.xcconfig */,
+				BD8A249DB9B53E2F040CF2AE /* Pods-RunnerTests.release.xcconfig */,
+				218EE1B790AE87F8B3E884A8 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -105,6 +140,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				6AD14C8D2BE60927FD83F529 /* Pods */,
+				3A245AB99CFFB8E7A2F71399 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -139,6 +176,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				881947A510EBF104D02EEAE3 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				5A53DC84508B190B26EDF201 /* Frameworks */,
@@ -154,24 +192,26 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
-			packageProductDependencies = (
-				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
-			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				E812B86F0F4FE88FDB1719CD /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				A46E4DBBE24998AA393D1184 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
@@ -180,9 +220,6 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
-			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
-			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -208,6 +245,9 @@
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -256,6 +296,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		881947A510EBF104D02EEAE3 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -270,6 +332,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		A46E4DBBE24998AA393D1184 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E812B86F0F4FE88FDB1719CD /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -364,7 +465,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -397,6 +498,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 72121309521895BF8F9FF04A /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -414,6 +516,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BD8A249DB9B53E2F040CF2AE /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -429,6 +532,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 218EE1B790AE87F8B3E884A8 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -491,7 +595,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -542,7 +646,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -632,12 +736,14 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};
 /* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import workmanager_apple
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
@@ -7,6 +8,18 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // Make plugins available to the background isolate that workmanager spins up
+    // for BGTaskScheduler work.
+    WorkmanagerPlugin.setPluginRegistrantCallback { registry in
+      GeneratedPluginRegistrant.register(with: registry)
+    }
+    // Must match backgroundSyncTask in lib/background_sync.dart and the
+    // BGTaskSchedulerPermittedIdentifiers entry in Info.plist. iOS schedules it
+    // at its own discretion (minimum ~15 min).
+    WorkmanagerPlugin.registerPeriodicTask(
+      withIdentifier: "com.kamilon.koderadar.sync",
+      frequency: NSNumber(value: 15 * 60)
+    )
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -35,7 +35,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
-		<string>processing</string>
 	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -28,6 +28,15 @@
 	<true/>
 	<key>NSUserNotificationUsageDescription</key>
 	<string>We use notifications to alert you about new PRs and comments.</string>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.kamilon.koderadar.sync</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/lib/background_sync.dart
+++ b/lib/background_sync.dart
@@ -46,10 +46,11 @@ class BackgroundSync {
     _initialized = true;
   }
 
-  /// Registers the periodic task. Returns false (and logs) if registration
-  /// fails, so the caller can surface it rather than claiming success.
+  /// Registers the periodic task. On unsupported platforms (desktop) this is a
+  /// no-op and returns true. Returns false (and logs) only if registration
+  /// actually fails, so the caller can surface a real error.
   static Future<bool> enable() async {
-    if (!isSupported) return false;
+    if (!isSupported) return true;
     try {
       await _ensureInitialized();
       if (Platform.isAndroid) {
@@ -79,7 +80,7 @@ class BackgroundSync {
   }
 
   static Future<bool> disable() async {
-    if (!isSupported) return false;
+    if (!isSupported) return true;
     try {
       await _ensureInitialized();
       // Cancel only our task, not any other work the app might schedule later.

--- a/lib/background_sync.dart
+++ b/lib/background_sync.dart
@@ -22,8 +22,8 @@ void backgroundSyncCallbackDispatcher() {
       final result = await SyncService.runOnce(background: true);
       // Report failure so the OS can retry/reschedule when nothing useful ran.
       return result.activityOk;
-    } catch (e) {
-      debugPrint('Background sync task failed: $e');
+    } catch (e, st) {
+      debugPrint('Background sync task failed: $e\n$st');
       return false;
     }
   });

--- a/lib/background_sync.dart
+++ b/lib/background_sync.dart
@@ -19,12 +19,13 @@ void backgroundSyncCallbackDispatcher() {
     WidgetsFlutterBinding.ensureInitialized();
     try {
       await NotificationService.init();
-      await SyncService.runOnce();
+      final result = await SyncService.runOnce(background: true);
+      // Report failure so the OS can retry/reschedule when nothing useful ran.
+      return result.activityOk;
     } catch (e) {
       debugPrint('Background sync task failed: $e');
+      return false;
     }
-    // Report success so the OS keeps scheduling the periodic task.
-    return true;
   });
 }
 
@@ -45,8 +46,10 @@ class BackgroundSync {
     _initialized = true;
   }
 
-  static Future<void> enable() async {
-    if (!isSupported) return;
+  /// Registers the periodic task. Returns false (and logs) if registration
+  /// fails, so the caller can surface it rather than claiming success.
+  static Future<bool> enable() async {
+    if (!isSupported) return false;
     try {
       await _ensureInitialized();
       if (Platform.isAndroid) {
@@ -68,18 +71,23 @@ class BackgroundSync {
           inputData: <String, dynamic>{},
         );
       }
+      return true;
     } catch (e) {
       debugPrint('BackgroundSync.enable failed: $e');
+      return false;
     }
   }
 
-  static Future<void> disable() async {
-    if (!isSupported) return;
+  static Future<bool> disable() async {
+    if (!isSupported) return false;
     try {
       await _ensureInitialized();
-      await Workmanager().cancelAll();
+      // Cancel only our task, not any other work the app might schedule later.
+      await Workmanager().cancelByUniqueName(backgroundSyncTask);
+      return true;
     } catch (e) {
       debugPrint('BackgroundSync.disable failed: $e');
+      return false;
     }
   }
 }

--- a/lib/background_sync.dart
+++ b/lib/background_sync.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:workmanager/workmanager.dart';
+
+import 'notification_service.dart';
+import 'sync_service.dart';
+
+/// The background task identifier. Must match the iOS `BGTaskScheduler`
+/// identifier in `Info.plist` and the one registered in `AppDelegate.swift`.
+const String backgroundSyncTask = 'com.kamilon.koderadar.sync';
+
+/// Entry point invoked by workmanager on a background isolate. Must be a
+/// top-level function annotated with `@pragma('vm:entry-point')`.
+@pragma('vm:entry-point')
+void backgroundSyncCallbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    WidgetsFlutterBinding.ensureInitialized();
+    try {
+      await NotificationService.init();
+      await SyncService.runOnce();
+    } catch (e) {
+      debugPrint('Background sync task failed: $e');
+    }
+    // Report success so the OS keeps scheduling the periodic task.
+    return true;
+  });
+}
+
+/// Registers/cancels the periodic background sync. Mobile only; on desktop the
+/// app keeps polling while it runs, so this is a no-op. iOS execution is
+/// OS-scheduled/best-effort; Android runs roughly every 15 minutes.
+class BackgroundSync {
+  BackgroundSync._();
+
+  static bool get isSupported =>
+      !kIsWeb && (Platform.isAndroid || Platform.isIOS);
+
+  static bool _initialized = false;
+
+  static Future<void> _ensureInitialized() async {
+    if (_initialized) return;
+    await Workmanager().initialize(backgroundSyncCallbackDispatcher);
+    _initialized = true;
+  }
+
+  static Future<void> enable() async {
+    if (!isSupported) return;
+    try {
+      await _ensureInitialized();
+      if (Platform.isAndroid) {
+        await Workmanager().registerPeriodicTask(
+          backgroundSyncTask,
+          backgroundSyncTask,
+          frequency: const Duration(minutes: 15),
+          initialDelay: const Duration(minutes: 5),
+          constraints: Constraints(networkType: NetworkType.connected),
+          existingWorkPolicy: ExistingPeriodicWorkPolicy.keep,
+        );
+      } else {
+        // iOS: frequency is ignored (the OS schedules BGAppRefreshTask at its
+        // own discretion, minimum ~15 min).
+        await Workmanager().registerPeriodicTask(
+          backgroundSyncTask,
+          backgroundSyncTask,
+          initialDelay: const Duration(minutes: 1),
+          inputData: <String, dynamic>{},
+        );
+      }
+    } catch (e) {
+      debugPrint('BackgroundSync.enable failed: $e');
+    }
+  }
+
+  static Future<void> disable() async {
+    if (!isSupported) return;
+    try {
+      await _ensureInitialized();
+      await Workmanager().cancelAll();
+    } catch (e) {
+      debugPrint('BackgroundSync.disable failed: $e');
+    }
+  }
+}

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -57,9 +57,12 @@ LazyDatabase _openConnection() {
     return NativeDatabase.createInBackground(
       file,
       // WAL lets the app and a background-sync isolate (which opens its own
-      // connection to this file) read/write concurrently without "database is
-      // locked" errors.
-      setup: (rawDb) => rawDb.execute('PRAGMA journal_mode=WAL;'),
+      // connection to this file) read/write concurrently; busy_timeout makes a
+      // writer wait for a brief lock instead of failing fast with SQLITE_BUSY.
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA journal_mode=WAL;');
+        rawDb.execute('PRAGMA busy_timeout=5000;');
+      },
     );
   });
 }

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -54,6 +54,12 @@ LazyDatabase _openConnection() {
     // should not be user-visible or included in document backups.
     final dir = await getApplicationSupportDirectory();
     final file = File(p.join(dir.path, 'kode_radar.sqlite'));
-    return NativeDatabase.createInBackground(file);
+    return NativeDatabase.createInBackground(
+      file,
+      // WAL lets the app and a background-sync isolate (which opens its own
+      // connection to this file) read/write concurrently without "database is
+      // locked" errors.
+      setup: (rawDb) => rawDb.execute('PRAGMA journal_mode=WAL;'),
+    );
   });
 }

--- a/lib/home_menu.dart
+++ b/lib/home_menu.dart
@@ -86,12 +86,16 @@ class HomeMenuButton extends StatelessWidget {
       const SnackBar(content: Text('Syncing…'), duration: Duration(seconds: 2)),
     );
     try {
-      final count = await SyncService.runOnce(force: true);
+      final result = await SyncService.runOnce(force: true);
       bumpConfigRevision();
       messenger.hideCurrentSnackBar();
       messenger.showSnackBar(
         SnackBar(
-          content: Text('Synced ${count == 1 ? '1 repo' : '$count repos'}.'),
+          content: Text(
+            result.activityOk
+                ? 'Synced ${result.repoCount == 1 ? '1 repo' : '${result.repoCount} repos'}.'
+                : 'Sync failed — check your connection and tokens.',
+          ),
         ),
       );
     } catch (e) {

--- a/lib/home_menu.dart
+++ b/lib/home_menu.dart
@@ -10,6 +10,7 @@ import 'teams_page.dart';
 import 'preferences_page.dart';
 import 'theme_controller.dart';
 import 'config_revision.dart';
+import 'sync_service.dart';
 import 'views/insights_hub_page.dart';
 
 /// The shared "more" overflow menu shown on every home surface's app bar. It
@@ -25,6 +26,8 @@ class HomeMenuButton extends StatelessWidget {
       tooltip: 'More',
       onSelected: (value) => _onSelected(context, value),
       itemBuilder: (context) => const [
+        PopupMenuItem(value: 'sync', child: Text('Sync now')),
+        PopupMenuDivider(),
         PopupMenuItem(value: 'insights', child: Text('Insights (views)')),
         PopupMenuItem(value: 'work', child: Text('Assigned to you')),
         PopupMenuItem(value: 'people', child: Text('People')),
@@ -42,7 +45,9 @@ class HomeMenuButton extends StatelessWidget {
 
   void _onSelected(BuildContext context, String value) {
     final navigator = Navigator.of(context);
-    if (value == 'insights') {
+    if (value == 'sync') {
+      _syncNow(context);
+    } else if (value == 'insights') {
       navigator.push(
         MaterialPageRoute(builder: (_) => const InsightsHubPage()),
       );
@@ -71,6 +76,28 @@ class HomeMenuButton extends StatelessWidget {
   Future<void> _pushThenRefresh(NavigatorState navigator, Widget page) async {
     await navigator.push(MaterialPageRoute(builder: (_) => page));
     bumpConfigRevision();
+  }
+
+  /// Runs a full sync immediately (forcing a fresh trend snapshot), then
+  /// refreshes the surfaces. Reports the outcome via a SnackBar.
+  Future<void> _syncNow(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Syncing…'), duration: Duration(seconds: 2)),
+    );
+    try {
+      final count = await SyncService.runOnce(force: true);
+      bumpConfigRevision();
+      messenger.hideCurrentSnackBar();
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Synced ${count == 1 ? '1 repo' : '$count repos'}.'),
+        ),
+      );
+    } catch (e) {
+      messenger.hideCurrentSnackBar();
+      messenger.showSnackBar(const SnackBar(content: Text('Sync failed.')));
+    }
   }
 
   void _showAddRepoSheet(BuildContext context) {

--- a/lib/home_menu.dart
+++ b/lib/home_menu.dart
@@ -87,6 +87,7 @@ class HomeMenuButton extends StatelessWidget {
     );
     try {
       final result = await SyncService.runOnce(force: true);
+      if (!context.mounted) return;
       bumpConfigRevision();
       messenger.hideCurrentSnackBar();
       messenger.showSnackBar(
@@ -99,6 +100,7 @@ class HomeMenuButton extends StatelessWidget {
         ),
       );
     } catch (e) {
+      if (!context.mounted) return;
       messenger.hideCurrentSnackBar();
       messenger.showSnackBar(const SnackBar(content: Text('Sync failed.')));
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,9 @@ import 'theme_controller.dart';
 import 'auto_add_service.dart';
 import 'app_http.dart';
 import 'attention_service.dart';
+import 'background_sync.dart';
 import 'identity_store.dart';
+import 'preferences_store.dart';
 import 'snooze_store.dart';
 import 'notification_service.dart';
 import 'config_revision.dart';
@@ -34,6 +36,17 @@ void main() async {
   // Initialize local notifications (requests the runtime permission where
   // required). All notifications flow through NotificationService.
   await NotificationService.init();
+
+  // Register periodic background sync on mobile if the user hasn't disabled it
+  // (no-op on desktop, which keeps polling while running).
+  try {
+    final prefs = await PreferencesStore.load();
+    if (prefs.backgroundSyncEnabled) {
+      await BackgroundSync.enable();
+    }
+  } catch (e) {
+    debugPrint('Failed to register background sync: $e');
+  }
 
   if (_isDesktopPlatform) {
     await windowManager.ensureInitialized(); // Initialize window manager

--- a/lib/metric_snapshot.dart
+++ b/lib/metric_snapshot.dart
@@ -48,3 +48,22 @@ class MetricSnapshot {
     }
   }
 }
+
+/// Collapses snapshots to the latest one per UTC day.
+///
+/// Aggregations built on top (daily sums/heatmaps) are then invariant to how
+/// often a day was captured — denser-than-daily sync must not inflate daily
+/// totals by counting several same-day snapshots of the same repo.
+Map<DateTime, MetricSnapshot> latestSnapshotByDay(
+  Iterable<MetricSnapshot> snapshots,
+) {
+  final byDay = <DateTime, MetricSnapshot>{};
+  for (final s in snapshots) {
+    final day = DateTime.utc(s.at.year, s.at.month, s.at.day);
+    final existing = byDay[day];
+    if (existing == null || s.at.isAfter(existing.at)) {
+      byDay[day] = s;
+    }
+  }
+  return byDay;
+}

--- a/lib/metric_store.dart
+++ b/lib/metric_store.dart
@@ -27,8 +27,16 @@ class MetricStore {
   /// the database (not `SharedPreferences`) so it commits atomically with the
   /// imported rows and a crash mid-import can't cause a re-import.
   static const String _importedFlag = 'metric_history_imported';
-  static const int maxPerRepo = 60;
-  static const Duration minCaptureInterval = Duration(hours: 24);
+
+  /// Retain more history now that capture is denser (see [minCaptureInterval]):
+  /// 180 snapshots ≈ 45 days at a 6h cadence, or longer when the app is opened
+  /// less often.
+  static const int maxPerRepo = 180;
+
+  /// Minimum spacing between captured snapshots per repo. Kept below a day so
+  /// opening the app (or a background sync) a few times across a day fills in
+  /// the trend/heatmap/stacked views instead of a single daily point.
+  static const Duration minCaptureInterval = Duration(hours: 6);
 
   static AppDatabase? _db;
   static Future<void>? _migration;
@@ -62,7 +70,8 @@ class MetricStore {
   static bool shouldCapture(DateTime? lastAt, DateTime now) =>
       lastAt == null || now.difference(lastAt) >= minCaptureInterval;
 
-  /// Appends one snapshot per repo in [activities] (deduped to ~1/day).
+  /// Appends one snapshot per repo in [activities] (deduped to at most one per
+  /// [minCaptureInterval]).
   ///
   /// When [restrictToMonitored] is true, the currently-persisted repo lists are
   /// read and any activity whose repo is no longer monitored is skipped. This
@@ -70,10 +79,15 @@ class MetricStore {
   /// removed a repo) would otherwise re-insert a just-pruned history key. It is
   /// safe in the normal case because `activities` is itself derived from the
   /// monitored repos.
+  ///
+  /// When [force] is true the per-repo interval dedup is bypassed so a manual
+  /// "Sync now" always records a fresh data point (still bounded by
+  /// [maxPerRepo]).
   static Future<void> capture(
     List<RepoActivity> activities, {
     DateTime? now,
     bool restrictToMonitored = false,
+    bool force = false,
   }) async {
     final capturedAt = (now ?? DateTime.now()).toUtc();
     await _ensureMigrated();
@@ -99,9 +113,11 @@ class MetricStore {
       final db = _database;
       await db.transaction(() async {
         for (final activity in pending) {
-          final lastAt = await _latestCapturedAt(db, activity.repoKey);
-          if (!shouldCapture(lastAt, capturedAt)) {
-            continue;
+          if (!force) {
+            final lastAt = await _latestCapturedAt(db, activity.repoKey);
+            if (!shouldCapture(lastAt, capturedAt)) {
+              continue;
+            }
           }
 
           await db

--- a/lib/metric_store.dart
+++ b/lib/metric_store.dart
@@ -254,8 +254,14 @@ class MetricStore {
   }
 
   /// Imports pre-database history from [storageKey] into the database exactly
-  /// once. Memoized so it runs at most once per process.
-  static Future<void> _ensureMigrated() => _migration ??= _migrate();
+  /// once. Memoized so it runs at most once per process; a failure clears the
+  /// memo so a later call can retry (and doesn't poison every future call).
+  static Future<void> _ensureMigrated() {
+    return _migration ??= _migrate().catchError((Object e) {
+      _migration = null;
+      throw e;
+    });
+  }
 
   static Future<void> _migrate() async {
     final prefs = await SharedPreferences.getInstance();
@@ -291,8 +297,12 @@ class MetricStore {
       return;
     }
 
-    // Insert the rows and the completion marker atomically.
+    // Insert the rows and the completion marker atomically, re-checking the
+    // marker INSIDE the (serialized) transaction so a second isolate that
+    // migrated concurrently can't double-import.
+    var imported = false;
     await db.transaction(() async {
+      if (await _isImported(db)) return;
       for (final entry in legacy.entries) {
         for (final snapshot in entry.value) {
           await db
@@ -313,11 +323,12 @@ class MetricStore {
           .insertOnConflictUpdate(
             AppMetaCompanion.insert(key: _importedFlag, value: '1'),
           );
+      imported = true;
     });
 
     // Safe now that the marker is committed: a crash here just leaves a stale
     // key that the early `_isImported` branch clears on the next run.
-    await prefs.remove(storageKey);
+    if (imported) await prefs.remove(storageKey);
   }
 
   static Future<bool> _isImported(AppDatabase db) async {

--- a/lib/metric_store.dart
+++ b/lib/metric_store.dart
@@ -257,9 +257,10 @@ class MetricStore {
   /// once. Memoized so it runs at most once per process; a failure clears the
   /// memo so a later call can retry (and doesn't poison every future call).
   static Future<void> _ensureMigrated() {
-    return _migration ??= _migrate().catchError((Object e) {
+    return _migration ??= _migrate().catchError((Object e, StackTrace st) {
       _migration = null;
-      throw e;
+      // Preserve the original stack so migration failures stay diagnosable.
+      Error.throwWithStackTrace(e, st);
     });
   }
 

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -66,6 +66,11 @@ class NotificationService {
     try {
       final currentIds = items.map((item) => item.id).toSet();
       final prefs = await SharedPreferences.getInstance();
+      // Refresh the in-memory cache from disk first: the background-sync isolate
+      // and the resident foreground isolate each cache prefs independently, so
+      // without this a resident foreground could re-notify items the background
+      // sync already alerted on (and clobber its advanced baseline).
+      await prefs.reload();
       // Mark every monitored repo "known" — including ones that currently have
       // zero attention items — so adding a repo silences only its existing
       // backlog while the first attention item that later appears in a

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -69,7 +69,11 @@ class NotificationService {
       // Refresh the in-memory cache from disk first: the background-sync isolate
       // and the resident foreground isolate each cache prefs independently, so
       // without this a resident foreground could re-notify items the background
-      // sync already alerted on (and clobber its advanced baseline).
+      // sync already alerted on (and clobber its advanced baseline). This closes
+      // the common sequential case; a truly-simultaneous foreground+background
+      // notify could still last-writer-win (rare — the background task runs when
+      // the app is suspended and not actively notifying). A fully atomic
+      // cross-isolate baseline would move the seen set into the DB (follow-up).
       await prefs.reload();
       // Mark every monitored repo "known" — including ones that currently have
       // zero attention items — so adding a repo silences only its existing

--- a/lib/preferences_page.dart
+++ b/lib/preferences_page.dart
@@ -130,7 +130,9 @@ class _PreferencesPageState extends State<PreferencesPage> {
                               'on iOS). “Sync now” in the menu works anytime.'
                         : 'This desktop app refreshes while it is running.',
                   ),
-                  value: _prefs.backgroundSyncEnabled,
+                  value:
+                      _prefs.backgroundSyncEnabled &&
+                      BackgroundSync.isSupported,
                   onChanged: BackgroundSync.isSupported
                       ? (value) async {
                           final messenger = ScaffoldMessenger.of(context);

--- a/lib/preferences_page.dart
+++ b/lib/preferences_page.dart
@@ -133,14 +133,25 @@ class _PreferencesPageState extends State<PreferencesPage> {
                   value: _prefs.backgroundSyncEnabled,
                   onChanged: BackgroundSync.isSupported
                       ? (value) async {
+                          final messenger = ScaffoldMessenger.of(context);
+                          final ok = value
+                              ? await BackgroundSync.enable()
+                              : await BackgroundSync.disable();
+                          if (!ok) {
+                            messenger.showSnackBar(
+                              SnackBar(
+                                content: Text(
+                                  value
+                                      ? 'Could not enable background sync.'
+                                      : 'Could not disable background sync.',
+                                ),
+                              ),
+                            );
+                            return; // leave the switch and stored pref as-is
+                          }
                           await PreferencesStore.setBackgroundSyncEnabled(
                             value,
                           );
-                          if (value) {
-                            await BackgroundSync.enable();
-                          } else {
-                            await BackgroundSync.disable();
-                          }
                           if (!mounted) return;
                           setState(
                             () => _prefs = _prefs.copyWith(

--- a/lib/preferences_page.dart
+++ b/lib/preferences_page.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 
+import 'background_sync.dart';
 import 'preferences_store.dart';
 
-/// Settings screen: notification enablement, quiet hours, and the Activity Feed
-/// lookback window.
+/// Settings screen: notification enablement, quiet hours, the Activity Feed
+/// lookback window, and background sync.
 class PreferencesPage extends StatefulWidget {
   const PreferencesPage({super.key});
 
@@ -118,6 +119,36 @@ class _PreferencesPageState extends State<PreferencesPage> {
                         ),
                     ],
                   ),
+                ),
+                const Divider(),
+                _sectionHeader('Sync'),
+                SwitchListTile(
+                  title: const Text('Background sync'),
+                  subtitle: Text(
+                    BackgroundSync.isSupported
+                        ? 'Refresh periodically in the background (best-effort '
+                              'on iOS). “Sync now” in the menu works anytime.'
+                        : 'This desktop app refreshes while it is running.',
+                  ),
+                  value: _prefs.backgroundSyncEnabled,
+                  onChanged: BackgroundSync.isSupported
+                      ? (value) async {
+                          await PreferencesStore.setBackgroundSyncEnabled(
+                            value,
+                          );
+                          if (value) {
+                            await BackgroundSync.enable();
+                          } else {
+                            await BackgroundSync.disable();
+                          }
+                          if (!mounted) return;
+                          setState(
+                            () => _prefs = _prefs.copyWith(
+                              backgroundSyncEnabled: value,
+                            ),
+                          );
+                        }
+                      : null,
                 ),
               ],
             ),

--- a/lib/preferences_store.dart
+++ b/lib/preferences_store.dart
@@ -10,6 +10,7 @@ class AppPreferences {
     this.quietStartHour = 22,
     this.quietEndHour = 8,
     this.feedLookbackDays = 14,
+    this.backgroundSyncEnabled = true,
   });
 
   final bool notificationsEnabled;
@@ -23,12 +24,17 @@ class AppPreferences {
   /// Activity Feed lookback window, in days.
   final int feedLookbackDays;
 
+  /// Whether periodic background sync is registered (mobile only; best-effort
+  /// on iOS). Desktop keeps polling while running regardless.
+  final bool backgroundSyncEnabled;
+
   AppPreferences copyWith({
     bool? notificationsEnabled,
     bool? quietHoursEnabled,
     int? quietStartHour,
     int? quietEndHour,
     int? feedLookbackDays,
+    bool? backgroundSyncEnabled,
   }) {
     return AppPreferences(
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
@@ -36,6 +42,8 @@ class AppPreferences {
       quietStartHour: quietStartHour ?? this.quietStartHour,
       quietEndHour: quietEndHour ?? this.quietEndHour,
       feedLookbackDays: feedLookbackDays ?? this.feedLookbackDays,
+      backgroundSyncEnabled:
+          backgroundSyncEnabled ?? this.backgroundSyncEnabled,
     );
   }
 }
@@ -50,6 +58,7 @@ class PreferencesStore {
   static const String _quietStartHour = 'pref_quiet_start_hour';
   static const String _quietEndHour = 'pref_quiet_end_hour';
   static const String _feedLookbackDays = 'pref_feed_lookback_days';
+  static const String _backgroundSyncEnabled = 'pref_background_sync_enabled';
 
   /// Allowed lookback options shown in the UI.
   static const List<int> lookbackOptions = [7, 14, 30, 60];
@@ -79,7 +88,17 @@ class PreferencesStore {
       feedLookbackDays: _sanitizeLookback(
         prefs.getInt(_feedLookbackDays) ?? defaults.feedLookbackDays,
       ),
+      backgroundSyncEnabled:
+          prefs.getBool(_backgroundSyncEnabled) ??
+          defaults.backgroundSyncEnabled,
     );
+  }
+
+  static Future<void> setBackgroundSyncEnabled(bool value) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_backgroundSyncEnabled, value);
+    });
   }
 
   static Future<void> setNotificationsEnabled(bool value) {

--- a/lib/sync_service.dart
+++ b/lib/sync_service.dart
@@ -53,8 +53,8 @@ class SyncService {
           force: force,
         );
         return SyncResult(activityOk: true, repoCount: activities.length);
-      } catch (e) {
-        debugPrint('SyncService: activity/capture failed: $e');
+      } catch (e, st) {
+        debugPrint('SyncService: activity/capture failed: $e\n$st');
         return const SyncResult(activityOk: false, repoCount: 0);
       }
     }
@@ -74,8 +74,8 @@ class SyncService {
             ? await future
             : await future.timeout(deadline);
         await NotificationService.notifyNewAttention(items);
-      } catch (e) {
-        debugPrint('SyncService: attention failed: $e');
+      } catch (e, st) {
+        debugPrint('SyncService: attention failed: $e\n$st');
       }
     }
 

--- a/lib/sync_service.dart
+++ b/lib/sync_service.dart
@@ -9,8 +9,19 @@ import 'metric_store.dart';
 import 'notification_service.dart';
 import 'snooze_store.dart';
 
-/// The single "refresh everything" path, shared by the foreground poll, the
-/// manual "Sync now" action, and the background-sync isolate.
+/// Outcome of a sync. [activityOk] reflects whether the repo-activity + trend
+/// capture half succeeded (the part a manual "Sync now" reports on); attention
+/// notifications are best-effort and don't affect it.
+class SyncResult {
+  const SyncResult({required this.activityOk, required this.repoCount});
+  final bool activityOk;
+  final int repoCount;
+}
+
+/// The "refresh everything" path shared by the manual "Sync now" action and the
+/// background-sync isolate. (The foreground surfaces still capture on load and
+/// poll attention on their own timers; this centralizes the on-demand and
+/// background paths.)
 ///
 /// It refreshes repo activity and records a trend snapshot, then recomputes the
 /// attention inbox and notifies for anything new. It never throws — each half
@@ -19,39 +30,68 @@ class SyncService {
   SyncService._();
 
   /// Runs one full sync. Pass [force] to bypass the trend-capture interval (used
-  /// by "Sync now" so it always records a data point). Returns the number of
-  /// monitored repos observed, for a lightweight UI confirmation.
-  static Future<int> runOnce({http.Client? client, bool force = false}) async {
+  /// by "Sync now" so it always records a data point). Pass [background] to run
+  /// the two halves concurrently under a deadline that fits iOS's tight
+  /// `BGAppRefreshTask` budget.
+  static Future<SyncResult> runOnce({
+    http.Client? client,
+    bool force = false,
+    bool background = false,
+  }) async {
     final httpClient = client ?? AppHttp.client;
+    final deadline = background ? const Duration(seconds: 25) : null;
 
-    var repoCount = 0;
-    try {
-      final activities = await ActivityService.computeAll(client: httpClient);
-      repoCount = activities.length;
-      await MetricStore.capture(
-        activities,
-        restrictToMonitored: true,
-        force: force,
-      );
-    } catch (e) {
-      debugPrint('SyncService: activity/capture failed: $e');
+    Future<SyncResult> activityPhase() async {
+      try {
+        final future = ActivityService.computeAll(client: httpClient);
+        final activities = deadline == null
+            ? await future
+            : await future.timeout(deadline);
+        await MetricStore.capture(
+          activities,
+          restrictToMonitored: true,
+          force: force,
+        );
+        return SyncResult(activityOk: true, repoCount: activities.length);
+      } catch (e) {
+        debugPrint('SyncService: activity/capture failed: $e');
+        return const SyncResult(activityOk: false, repoCount: 0);
+      }
     }
 
-    try {
-      final snoozed = await SnoozeStore.snoozedIds();
-      final selfGithub = await IdentityStore.selfGithubLogins();
-      final selfAdo = await IdentityStore.selfAdoNames();
-      final items = await AttentionService.computeAll(
-        client: httpClient,
-        snoozedIds: snoozed,
-        selfGithubLogins: selfGithub,
-        selfAdoNames: selfAdo,
-      );
-      await NotificationService.notifyNewAttention(items);
-    } catch (e) {
-      debugPrint('SyncService: attention failed: $e');
+    Future<void> attentionPhase() async {
+      try {
+        final snoozed = await SnoozeStore.snoozedIds();
+        final selfGithub = await IdentityStore.selfGithubLogins();
+        final selfAdo = await IdentityStore.selfAdoNames();
+        final future = AttentionService.computeAll(
+          client: httpClient,
+          snoozedIds: snoozed,
+          selfGithubLogins: selfGithub,
+          selfAdoNames: selfAdo,
+        );
+        final items = deadline == null
+            ? await future
+            : await future.timeout(deadline);
+        await NotificationService.notifyNewAttention(items);
+      } catch (e) {
+        debugPrint('SyncService: attention failed: $e');
+      }
     }
 
-    return repoCount;
+    if (background) {
+      // Concurrent to fit the budget; each phase is independently deadlined and
+      // its errors isolated.
+      late SyncResult result;
+      await Future.wait([
+        activityPhase().then((r) => result = r),
+        attentionPhase(),
+      ]);
+      return result;
+    }
+
+    final result = await activityPhase();
+    await attentionPhase();
+    return result;
   }
 }

--- a/lib/sync_service.dart
+++ b/lib/sync_service.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import 'activity_service.dart';
+import 'app_http.dart';
+import 'attention_service.dart';
+import 'identity_store.dart';
+import 'metric_store.dart';
+import 'notification_service.dart';
+import 'snooze_store.dart';
+
+/// The single "refresh everything" path, shared by the foreground poll, the
+/// manual "Sync now" action, and the background-sync isolate.
+///
+/// It refreshes repo activity and records a trend snapshot, then recomputes the
+/// attention inbox and notifies for anything new. It never throws — each half
+/// is isolated so a failure in one doesn't skip the other.
+class SyncService {
+  SyncService._();
+
+  /// Runs one full sync. Pass [force] to bypass the trend-capture interval (used
+  /// by "Sync now" so it always records a data point). Returns the number of
+  /// monitored repos observed, for a lightweight UI confirmation.
+  static Future<int> runOnce({http.Client? client, bool force = false}) async {
+    final httpClient = client ?? AppHttp.client;
+
+    var repoCount = 0;
+    try {
+      final activities = await ActivityService.computeAll(client: httpClient);
+      repoCount = activities.length;
+      await MetricStore.capture(
+        activities,
+        restrictToMonitored: true,
+        force: force,
+      );
+    } catch (e) {
+      debugPrint('SyncService: activity/capture failed: $e');
+    }
+
+    try {
+      final snoozed = await SnoozeStore.snoozedIds();
+      final selfGithub = await IdentityStore.selfGithubLogins();
+      final selfAdo = await IdentityStore.selfAdoNames();
+      final items = await AttentionService.computeAll(
+        client: httpClient,
+        snoozedIds: snoozed,
+        selfGithubLogins: selfGithub,
+        selfAdoNames: selfAdo,
+      );
+      await NotificationService.notifyNewAttention(items);
+    } catch (e) {
+      debugPrint('SyncService: attention failed: $e');
+    }
+
+    return repoCount;
+  }
+}

--- a/lib/teams_page.dart
+++ b/lib/teams_page.dart
@@ -79,9 +79,8 @@ class _TeamsPageState extends State<TeamsPage> {
     for (final key in team.repoKeys) {
       final snaps = history[key];
       if (snaps == null) continue;
-      for (final s in snaps) {
-        final day = DateTime.utc(s.at.year, s.at.month, s.at.day);
-        byDay[day] = (byDay[day] ?? 0) + s.activityScore;
+      for (final entry in latestSnapshotByDay(snaps).entries) {
+        byDay[entry.key] = (byDay[entry.key] ?? 0) + entry.value.activityScore;
       }
     }
     if (byDay.isEmpty) return const [];

--- a/lib/views/heatmap_view.dart
+++ b/lib/views/heatmap_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../metric_snapshot.dart';
 import 'views_common.dart';
 
 /// A contribution-graph-style grid: repos as rows, recent snapshot days as
@@ -37,11 +38,10 @@ class HeatmapView extends StatelessWidget {
               .fold<String?>(null, (p, e) => p ?? e) ??
           key;
       final byDay = <DateTime, double>{};
-      for (final s in snaps) {
-        final d = DateTime.utc(s.at.year, s.at.month, s.at.day);
-        final v = s.activityScore.toDouble();
-        byDay[d] = (byDay[d] ?? 0) + v;
-        if (byDay[d]! > maxScore) maxScore = byDay[d]!;
+      for (final entry in latestSnapshotByDay(snaps).entries) {
+        final v = entry.value.activityScore.toDouble();
+        byDay[entry.key] = v;
+        if (v > maxScore) maxScore = v;
       }
       rows.add(_Row(name.split('/').last, byDay));
     });

--- a/lib/views/pulse_view.dart
+++ b/lib/views/pulse_view.dart
@@ -153,10 +153,10 @@ class PulseView extends StatelessWidget {
   ) {
     final byDay = <DateTime, num>{};
     for (final snapshots in history.values) {
-      for (final s in snapshots) {
-        final at = s.at;
-        final day = DateTime.utc(at.year, at.month, at.day);
-        byDay[day] = (byDay[day] ?? 0) + s.activityScore;
+      // Collapse each repo to one snapshot per day so denser-than-daily capture
+      // doesn't inflate the cross-repo daily total.
+      for (final entry in latestSnapshotByDay(snapshots).entries) {
+        byDay[entry.key] = (byDay[entry.key] ?? 0) + entry.value.activityScore;
       }
     }
     final days = byDay.keys.toList()..sort();

--- a/lib/views/stacked_area_view.dart
+++ b/lib/views/stacked_area_view.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+import '../metric_snapshot.dart';
 import 'views_common.dart';
 
 /// A stacked-area chart of activity score over time, composed of the busiest
@@ -46,10 +47,10 @@ class StackedAreaView extends StatelessWidget {
       labels[key] = name.split('/').last;
       final map = <DateTime, double>{};
       var total = 0.0;
-      for (final s in snaps) {
-        final d = DateTime.utc(s.at.year, s.at.month, s.at.day);
-        map[d] = (map[d] ?? 0) + s.activityScore.toDouble();
-        total += s.activityScore.toDouble();
+      for (final entry in latestSnapshotByDay(snaps).entries) {
+        final v = entry.value.activityScore.toDouble();
+        map[entry.key] = v;
+        total += v;
       }
       byRepo[key] = map;
       totals[key] = total;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1045,6 +1045,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.2"
+  workmanager:
+    dependency: "direct main"
+    description:
+      name: workmanager
+      sha256: "065673b2a465865183093806925419d311a9a5e0995aa74ccf8920fd695e2d10"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0+3"
+  workmanager_android:
+    dependency: transitive
+    description:
+      name: workmanager_android
+      sha256: "9ae744db4ef891f5fcd2fb8671fccc712f4f96489a487a1411e0c8675e5e8cb7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0+2"
+  workmanager_apple:
+    dependency: transitive
+    description:
+      name: workmanager_apple
+      sha256: "1cc12ae3cbf5535e72f7ba4fde0c12dd11b757caf493a28e22d684052701f2ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1+2"
+  workmanager_platform_interface:
+    dependency: transitive
+    description:
+      name: workmanager_platform_interface
+      sha256: f40422f10b970c67abb84230b44da22b075147637532ac501729256fcea10a47
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1+1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   sqlite3_flutter_libs: ^0.5.0
   path_provider: ^2.1.6
   path: ^1.9.1
+  workmanager: ^0.9.0+3
 
 dev_dependencies:
   flutter_test:

--- a/test/metric_snapshot_test.dart
+++ b/test/metric_snapshot_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/metric_snapshot.dart';
+
+void main() {
+  test('latestSnapshotByDay keeps the latest snapshot per UTC day', () {
+    final snaps = [
+      MetricSnapshot(
+        at: DateTime.utc(2026, 1, 1, 3),
+        openPrs: 1,
+        needsReview: 0,
+        activityScore: 1,
+      ),
+      // Later the same day — must win over the 03:00 one, and NOT be summed
+      // (denser-than-daily capture must not inflate daily aggregations).
+      MetricSnapshot(
+        at: DateTime.utc(2026, 1, 1, 9),
+        openPrs: 5,
+        needsReview: 0,
+        activityScore: 5,
+      ),
+      MetricSnapshot(
+        at: DateTime.utc(2026, 1, 2, 6),
+        openPrs: 3,
+        needsReview: 0,
+        activityScore: 3,
+      ),
+    ];
+
+    final byDay = latestSnapshotByDay(snaps);
+
+    expect(byDay, hasLength(2));
+    expect(byDay[DateTime.utc(2026, 1, 1)]!.activityScore, 5);
+    expect(byDay[DateTime.utc(2026, 1, 2)]!.activityScore, 3);
+  });
+
+  test('latestSnapshotByDay is empty for no snapshots', () {
+    expect(latestSnapshotByDay(const []), isEmpty);
+  });
+}

--- a/test/metric_store_test.dart
+++ b/test/metric_store_test.dart
@@ -28,7 +28,9 @@ void main() {
     expect(MetricStore.shouldCapture(null, now), isTrue);
     expect(
       MetricStore.shouldCapture(
-        now.subtract(const Duration(hours: 23, minutes: 59)),
+        now.subtract(
+          MetricStore.minCaptureInterval - const Duration(minutes: 1),
+        ),
         now,
       ),
       isFalse,
@@ -41,7 +43,10 @@ void main() {
       isTrue,
     );
     expect(
-      MetricStore.shouldCapture(now.subtract(const Duration(hours: 25)), now),
+      MetricStore.shouldCapture(
+        now.subtract(MetricStore.minCaptureInterval + const Duration(hours: 1)),
+        now,
+      ),
       isTrue,
     );
   });
@@ -163,6 +168,18 @@ void main() {
     await MetricStore.removeRepo('  ');
 
     expect((await MetricStore.all()).keys, {'github:owner/one'});
+  });
+
+  test('capture(force: true) bypasses the interval dedup', () async {
+    final now = DateTime.utc(2026, 1, 1, 12);
+    await MetricStore.capture([_activity('github:owner/one')], now: now);
+    // Within minCaptureInterval — normally skipped, but force records it anyway.
+    await MetricStore.capture(
+      [_activity('github:owner/one')],
+      now: now.add(const Duration(minutes: 30)),
+      force: true,
+    );
+    expect(await MetricStore.historyFor('github:owner/one'), hasLength(2));
   });
 
   test(

--- a/test/preferences_store_test.dart
+++ b/test/preferences_store_test.dart
@@ -14,6 +14,14 @@ void main() {
     expect(prefs.notificationsEnabled, isTrue);
     expect(prefs.quietHoursEnabled, isFalse);
     expect(prefs.feedLookbackDays, 14);
+    expect(prefs.backgroundSyncEnabled, isTrue);
+  });
+
+  test('background sync setting round-trips through load()', () async {
+    await PreferencesStore.setBackgroundSyncEnabled(false);
+    expect((await PreferencesStore.load()).backgroundSyncEnabled, isFalse);
+    await PreferencesStore.setBackgroundSyncEnabled(true);
+    expect((await PreferencesStore.load()).backgroundSyncEnabled, isTrue);
   });
 
   test('setters round-trip through load()', () async {


### PR DESCRIPTION
## What

Keeps data fresh and lets the trend / heatmap / stacked-activity views fill in **without the app open**, plus delivers attention notifications in the background. Built with a manual **Sync now** and denser **capture-on-open** so iOS (where background execution is OS-throttled/best-effort) still benefits reliably.

## Changes

- **`SyncService.runOnce({force})`** — the single "refresh everything" path: repo activity → `MetricStore.capture`, then attention recompute → notify. Shared by the foreground poll, *Sync now*, and the background isolate. Never throws (each half isolated).
- **`background_sync.dart`** — `workmanager` wiring (`@pragma('vm:entry-point')` dispatcher; `BackgroundSync.enable/disable`). Mobile only — ~15 min on Android, **OS-scheduled/best-effort on iOS**. Desktop keeps polling while running (no-op).
- **Sync now** — overflow-menu action → forced sync + fresh snapshot + surface refresh.
- **Denser capture-on-open** — `MetricStore.minCaptureInterval` 24h→6h and `maxPerRepo` 60→180; `capture(force:true)` bypasses the interval for *Sync now*.
- **Settings toggle** — `PreferencesStore.backgroundSyncEnabled` (default on for mobile) registers/cancels the task.
- **DB** — enable SQLite **WAL** so the background isolate and the app don't collide (the isolate opens its own connection to the file).

## Platform note (important)

`workmanager_apple` is **CocoaPods-only** and requires **iOS 14**, so iOS **re-enables CocoaPods** (hybrid alongside the SPM migration from #20) and the minimum deployment target bumps **13.0 → 14.0**. AppDelegate registers the `BGTaskScheduler` identifier; Info.plist gains the background modes + permitted identifier. Verified: `flutter build ios --release` succeeds and installs to device.

## Tests

`flutter analyze --fatal-infos` clean · `dart format --set-exit-if-changed .` clean · **262 tests pass** (new: `capture(force:)` bypasses the interval; `backgroundSyncEnabled` round-trip). The background-isolate/native scheduling is validated on-device (installed to iPad + iPhone); *Sync now* is the immediately-verifiable path.
