### PR TITLE
Cache the Activity Feed on the local DB for offline-first cold starts

### DIFF
--- a/lib/activity_event_store.dart
+++ b/lib/activity_event_store.dart
@@ -15,8 +15,8 @@ import 'repo_store.dart';
 ///
 /// Events are keyed by `(repoKey, eventId)`: re-fetching the same event upserts
 /// its (possibly updated) row instead of duplicating it. On [save] the cache is
-/// pruned to the lookback window and the [ActivityFeedService.maxEvents] cap so
-/// it stays bounded.
+/// pruned to the [maxRetention] horizon and the [ActivityFeedService.maxEvents]
+/// cap so it stays bounded; reads filter to the caller's display window.
 class ActivityEventStore {
   ActivityEventStore._();
 

--- a/lib/activity_event_store.dart
+++ b/lib/activity_event_store.dart
@@ -1,0 +1,226 @@
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'activity_event.dart';
+import 'activity_feed_service.dart';
+import 'database/app_database.dart';
+import 'monitored_repos.dart';
+import 'repo_store.dart';
+
+/// Caches normalized cross-repo [ActivityEvent]s on the local SQLite database
+/// (drift) so the Activity Feed can render instantly from disk on cold start
+/// and treat the network as a refresher (Phase 2 of the local-database
+/// roadmap).
+///
+/// Events are keyed by `(repoKey, eventId)`: re-fetching the same event upserts
+/// its (possibly updated) row instead of duplicating it. On [save] the cache is
+/// pruned to the lookback window and the [ActivityFeedService.maxEvents] cap so
+/// it stays bounded.
+class ActivityEventStore {
+  ActivityEventStore._();
+
+  /// How much history to retain on disk, independent of the feed's *display*
+  /// lookback. Set to the widest lookback the UI offers so shrinking then
+  /// re-widening the lookback (e.g. 60 → 7 → 60) recovers previously-cached
+  /// events instead of permanently discarding them; reads still filter to the
+  /// caller's requested window (see [cached]).
+  static const Duration maxRetention = Duration(days: 60);
+
+  static AppDatabase? _db;
+
+  // Serializes mutating operations (save / removeRepo) relative to each other.
+  // drift already serializes transactions on the single connection; this keeps
+  // a save's upsert+prune atomic with respect to a concurrent removeRepo.
+  static Future<void> _lock = SynchronousFuture<void>(null);
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  static AppDatabase get _database => _db ??= AppDatabase();
+
+  /// Test hook: back the store with an injected (e.g. in-memory) database and
+  /// reset the mutation lock so each injected database starts from a clean
+  /// serialization state.
+  @visibleForTesting
+  static void debugUseDatabase(AppDatabase db) {
+    _db = db;
+    _lock = SynchronousFuture<void>(null);
+  }
+
+  /// Returns the cached events within [lookback] of [now] (default: now),
+  /// newest first, capped at [ActivityFeedService.maxEvents] — matching the
+  /// shape the feed would fetch from the network.
+  static Future<List<ActivityEvent>> cached({
+    Duration lookback = ActivityFeedService.defaultLookback,
+    DateTime? now,
+  }) async {
+    final since = (now ?? DateTime.now()).toUtc().subtract(lookback);
+    final db = _database;
+    final rows =
+        await (db.select(db.activityEvents)
+              ..where(
+                (t) => t.occurredAt.isBiggerOrEqualValue(
+                  since.millisecondsSinceEpoch,
+                ),
+              )
+              ..orderBy([
+                (t) => OrderingTerm(
+                  expression: t.occurredAt,
+                  mode: OrderingMode.desc,
+                ),
+                (t) => OrderingTerm(expression: t.id, mode: OrderingMode.desc),
+              ])
+              ..limit(ActivityFeedService.maxEvents))
+            .get();
+    return rows.map(_toEvent).toList();
+  }
+
+  /// Upserts [events] into the cache (keyed by `(repoKey, eventId)`), prunes
+  /// anything older than [maxRetention] before [now], then trims the whole cache
+  /// to [ActivityFeedService.maxEvents] newest rows so it stays bounded.
+  ///
+  /// Upsert (rather than replace-all) means a transient per-source fetch failure
+  /// doesn't evict still-valid cached events from sources that didn't refresh.
+  ///
+  /// When [restrictToMonitored] is true the currently-persisted repo lists are
+  /// read and (a) events for repos no longer monitored are skipped and (b) any
+  /// cached rows for unmonitored repos are purged. This self-heals the cache
+  /// against a repo removed while a feed fetch was already in flight (whose
+  /// in-flight result would otherwise re-insert the just-deleted repo's events)
+  /// and against repos removed while offline.
+  static Future<void> save(
+    List<ActivityEvent> events, {
+    DateTime? now,
+    bool restrictToMonitored = false,
+  }) async {
+    final cutoff = (now ?? DateTime.now()).toUtc().subtract(maxRetention);
+    await _runLocked(() async {
+      final db = _database;
+
+      Set<String>? monitored;
+      if (restrictToMonitored) {
+        final prefs = await SharedPreferences.getInstance();
+        monitored = parseMonitoredRepos(
+          prefs.getStringList(RepoStore.githubKey) ?? const <String>[],
+          prefs.getStringList(RepoStore.adoKey) ?? const <String>[],
+        ).map((repo) => repo.repoKey).toSet();
+      }
+
+      final toSave = monitored == null
+          ? events
+          : events.where((e) => monitored!.contains(e.repoKey)).toList();
+
+      await db.transaction(() async {
+        for (final event in toSave) {
+          await db
+              .into(db.activityEvents)
+              .insert(
+                _toCompanion(event),
+                onConflict: DoUpdate(
+                  (_) => _toCompanion(event),
+                  target: [
+                    db.activityEvents.repoKey,
+                    db.activityEvents.eventId,
+                  ],
+                ),
+              );
+        }
+
+        // Drop anything that has aged out of the retention window.
+        await (db.delete(db.activityEvents)..where(
+              (t) => t.occurredAt.isSmallerThanValue(
+                cutoff.millisecondsSinceEpoch,
+              ),
+            ))
+            .go();
+
+        // Purge cached rows for repos that are no longer monitored.
+        if (monitored != null) {
+          final keep = monitored.toList();
+          await (db.delete(db.activityEvents)..where(
+                (t) => keep.isEmpty
+                    ? const Constant(true)
+                    : t.repoKey.isNotIn(keep),
+              ))
+              .go();
+        }
+
+        await _pruneToMax(db);
+      });
+    });
+  }
+
+  /// Drops all cached events for [repoKey] (e.g. after the repo is removed from
+  /// monitoring) so deleted repos don't linger as stale rows.
+  static Future<void> removeRepo(String repoKey) async {
+    final key = repoKey.trim();
+    if (key.isEmpty) return;
+    await _runLocked(() async {
+      final db = _database;
+      await (db.delete(
+        db.activityEvents,
+      )..where((t) => t.repoKey.equals(key))).go();
+    });
+  }
+
+  /// Keeps only the newest [ActivityFeedService.maxEvents] rows across the whole
+  /// cache.
+  static Future<void> _pruneToMax(AppDatabase db) async {
+    final ids =
+        await (db.selectOnly(db.activityEvents)
+              ..addColumns([db.activityEvents.id])
+              ..orderBy([
+                OrderingTerm(
+                  expression: db.activityEvents.occurredAt,
+                  mode: OrderingMode.desc,
+                ),
+                OrderingTerm(
+                  expression: db.activityEvents.id,
+                  mode: OrderingMode.desc,
+                ),
+              ]))
+            .map((row) => row.read(db.activityEvents.id)!)
+            .get();
+    if (ids.length <= ActivityFeedService.maxEvents) return;
+    final toDelete = ids.sublist(ActivityFeedService.maxEvents);
+    await (db.delete(
+      db.activityEvents,
+    )..where((t) => t.id.isIn(toDelete))).go();
+  }
+
+  static ActivityEvent _toEvent(ActivityEventRow row) => ActivityEvent(
+    id: row.eventId,
+    type: row.type,
+    provider: row.provider,
+    repoKey: row.repoKey,
+    repoDisplay: row.repoDisplay,
+    actor: row.actor,
+    title: row.title,
+    subtitle: row.subtitle,
+    occurredAt: DateTime.fromMillisecondsSinceEpoch(
+      row.occurredAt,
+      isUtc: true,
+    ),
+    url: row.url,
+    isMine: row.isMine,
+  );
+
+  static ActivityEventsCompanion _toCompanion(ActivityEvent event) =>
+      ActivityEventsCompanion.insert(
+        eventId: event.id,
+        type: event.type,
+        provider: event.provider,
+        repoKey: event.repoKey,
+        repoDisplay: event.repoDisplay,
+        actor: event.actor,
+        title: event.title,
+        subtitle: event.subtitle,
+        occurredAt: event.occurredAt.toUtc().millisecondsSinceEpoch,
+        url: Value(event.url),
+        isMine: event.isMine,
+      );
+}

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'activity_event.dart';
 import 'activity_event_list.dart';
+import 'activity_event_store.dart';
 import 'activity_feed_service.dart';
 import 'app_http.dart';
 import 'config_revision.dart';
@@ -84,17 +85,48 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
       final selfGithub = await IdentityStore.selfGithubLogins();
       final selfAdo = await IdentityStore.selfAdoNames();
       final appPrefs = await PreferencesStore.load();
+      final lookback = Duration(days: appPrefs.feedLookbackDays);
+
+      // Phase A: render the cached feed immediately so a cold start isn't a
+      // blank spinner while the network fetch runs (or if it's offline). Only
+      // meaningful when we don't already have events on screen.
+      if (_events.isEmpty) {
+        final cached = await ActivityEventStore.cached(lookback: lookback);
+        if (!mounted || seq != _loadSeq) return;
+        if (cached.isNotEmpty) {
+          setState(() {
+            _events = cached;
+            _teams = teams;
+            _lookbackDays = appPrefs.feedLookbackDays;
+            if (_teamId != null && !teams.any((t) => t.id == _teamId)) {
+              _teamId = null;
+            }
+            _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
+            _loading = false;
+          });
+        }
+      }
+
+      // Phase B: refresh from the network and persist the result to the cache.
       final result = await ActivityFeedService.computeAll(
         client: AppHttp.client,
         selfGithubLogins: selfGithub,
         selfAdoNames: selfAdo,
-        lookback: Duration(days: appPrefs.feedLookbackDays),
+        lookback: lookback,
       );
       if (!mounted || seq != _loadSeq) return;
-      // Advance the watermark to the newest event we actually loaded — a
-      // provider timestamp, so device-clock skew can't poison it, and only on
-      // a successful load so a failure/quick pop never consumes unseen items.
-      // markSeen never moves the marker backwards.
+      await ActivityEventStore.save(result.events, restrictToMonitored: true);
+      if (!mounted || seq != _loadSeq) return;
+      // Render the persisted cache (not `result.events` directly) so a fully
+      // offline load — where per-source failures yield an empty result rather
+      // than an exception — keeps showing cached events instead of blanking,
+      // and a partial failure shows the union of fresh + still-cached events.
+      final merged = await ActivityEventStore.cached(lookback: lookback);
+      if (!mounted || seq != _loadSeq) return;
+      // Advance the watermark to the newest event this network refresh
+      // returned — a provider timestamp, so device-clock skew can't poison it,
+      // and only on a successful load so a failure/quick pop never consumes
+      // unseen items. markSeen never moves the marker backwards.
       if (result.events.isNotEmpty) {
         await SeenStore.markSeen(
           SeenStore.feedKey,
@@ -103,7 +135,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
         if (!mounted || seq != _loadSeq) return;
       }
       setState(() {
-        _events = result.events;
+        _events = merged;
         _failedSources = result.failedSources;
         _truncated = result.truncated;
         _lookbackDays = appPrefs.feedLookbackDays;
@@ -120,8 +152,13 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
       debugPrint('ActivityFeed failed to load: $e');
       if (!mounted || seq != _loadSeq) return;
       setState(() {
-        _error =
-            'Something went wrong while loading the feed. Pull down to try again.';
+        // If we already rendered cached events (Phase A), keep them on screen
+        // rather than replacing them with an error state; the refresh simply
+        // didn't land this time. Only show the error when we have nothing.
+        if (_events.isEmpty) {
+          _error =
+              'Something went wrong while loading the feed. Pull down to try again.';
+        }
         _loading = false;
       });
     }

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -98,6 +98,11 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
             _events = cached;
             _teams = teams;
             _lookbackDays = appPrefs.feedLookbackDays;
+            // The cached render carries no source-health signal, so clear any
+            // stale failed/truncated notice from a previous refresh while the
+            // new network refresh is still in flight.
+            _failedSources = 0;
+            _truncated = false;
             if (_teamId != null && !teams.any((t) => t.id == _teamId)) {
               _teamId = null;
             }

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -27,7 +27,12 @@ class ActivityFeedPage extends StatefulWidget {
 class _ActivityFeedPageState extends State<ActivityFeedPage> {
   List<ActivityEvent> _events = const [];
   List<Team> _teams = const [];
-  bool _loading = true;
+
+  /// A load (cache render + network refresh) is in flight. Gates the manual
+  /// Refresh action so a user can't stack overlapping network fetches/DB writes
+  /// on top of an in-flight refresh; cache-first renders still update the UI
+  /// underneath it.
+  bool _refreshing = true;
   bool _mineOnly = false;
   bool _identitySet = false;
   int _failedSources = 0;
@@ -70,7 +75,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
   Future<void> _load() async {
     final seq = ++_loadSeq;
     setState(() {
-      _loading = true;
+      _refreshing = true;
       _error = null;
     });
     try {
@@ -107,7 +112,6 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
               _teamId = null;
             }
             _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
-            _loading = false;
           });
         }
       }
@@ -151,7 +155,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
         }
         _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
         _lastChecked = DateTime.now();
-        _loading = false;
+        _refreshing = false;
       });
     } catch (e) {
       debugPrint('ActivityFeed failed to load: $e');
@@ -164,7 +168,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
           _error =
               'Something went wrong while loading the feed. Pull down to try again.';
         }
-        _loading = false;
+        _refreshing = false;
       });
     }
   }
@@ -194,6 +198,11 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
     if (since == null) return 0;
     return _visibleEvents.where((e) => e.occurredAt.isAfter(since)).length;
   }
+
+  /// Show the full-screen spinner only when a load is in flight and there's
+  /// nothing cached to render yet; once cache (or fresh) events are on screen,
+  /// content stays visible while the network refresh continues underneath.
+  bool get _showSpinner => _refreshing && _events.isEmpty && _error == null;
 
   void _applyView(SavedView view) {
     setState(() {
@@ -330,19 +339,19 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
             tooltip: _mineOnly
                 ? 'Showing yours — tap for all'
                 : 'Show only mine',
-            onPressed: _loading
+            onPressed: _showSpinner
                 ? null
                 : () => setState(() => _mineOnly = !_mineOnly),
           ),
           IconButton(
             icon: const Icon(Icons.bookmarks_outlined),
             tooltip: 'Saved views',
-            onPressed: _loading ? null : _openSavedViews,
+            onPressed: _showSpinner ? null : _openSavedViews,
           ),
           IconButton(
             icon: const Icon(Icons.refresh),
             tooltip: 'Refresh',
-            onPressed: _loading ? null : _load,
+            onPressed: _refreshing ? null : _load,
           ),
           const HomeMenuButton(),
         ],
@@ -351,14 +360,14 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
         children: [
           _buildFilterBar(),
           const Divider(height: 1),
-          if (!_loading && _error == null) sinceLastLookedBanner(_newCount),
-          if (!_loading && _error == null)
+          if (!_showSpinner && _error == null) sinceLastLookedBanner(_newCount),
+          if (!_showSpinner && _error == null)
             activitySourceNotice(
               failedSources: _failedSources,
               truncated: _truncated,
             ),
           Expanded(
-            child: _loading
+            child: _showSpinner
                 ? const Center(child: CircularProgressIndicator())
                 : RefreshIndicator(onRefresh: _load, child: _buildContent()),
           ),
@@ -372,7 +381,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
       FilterChip(
         label: const Text('All'),
         selected: _groups.isEmpty,
-        onSelected: _loading ? null : (_) => setState(_groups.clear),
+        onSelected: _showSpinner ? null : (_) => setState(_groups.clear),
       ),
       for (final group in ActivityType.groups)
         Padding(
@@ -380,7 +389,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
           child: FilterChip(
             label: Text(ActivityType.groupLabel(group)),
             selected: _groups.contains(group),
-            onSelected: _loading
+            onSelected: _showSpinner
                 ? null
                 : (selected) => setState(() {
                     if (selected) {
@@ -413,7 +422,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
                     value: _teamId,
                     isDense: true,
                     hint: const Text('All teams'),
-                    onChanged: _loading
+                    onChanged: _showSpinner
                         ? null
                         : (value) => setState(() => _teamId = value),
                     items: [

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -86,24 +86,27 @@ class AppDatabase extends _$AppDatabase {
       // (repo_key, event_id) UNIQUE index the upsert relies on must be created
       // separately or existing (v1) installs would get duplicate rows.
       //
-      // Guard on the table's existence so a concurrent open from a second
-      // connection (e.g. the background-sync isolate) that also observed v1
-      // can't fail with "table already exists": SQLite serializes writers, so
-      // by the time the second migration's transaction runs, it sees the table
-      // the first one committed and skips the (non-idempotent) DDL.
+      // All statements are unconditionally idempotent (`IF NOT EXISTS`) so a
+      // concurrent open from a second connection (e.g. the background-sync
+      // isolate) that also observed v1 can't crash on "table/index already
+      // exists": drift runs `onUpgrade` in autocommit (no wrapping migration
+      // transaction), so the check-then-create couldn't otherwise be made race
+      // free. `createTable` already emits `CREATE TABLE IF NOT EXISTS`; the
+      // index DDL drift generates does not, so issue it directly.
       if (from < 2) {
-        final existing = await m.database
-            .customSelect(
-              "SELECT 1 FROM sqlite_master "
-              "WHERE type = 'table' AND name = 'activity_events'",
-            )
-            .get();
-        if (existing.isEmpty) {
-          await m.createTable(activityEvents);
-          await m.create(idxActivityEventsRepoKey);
-          await m.create(idxActivityEventsOccurredAt);
-          await m.create(idxActivityEventsRepoEvent);
-        }
+        await m.createTable(activityEvents);
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_activity_events_repo_key '
+          'ON activity_events (repo_key)',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_activity_events_occurred_at '
+          'ON activity_events (occurred_at)',
+        );
+        await customStatement(
+          'CREATE UNIQUE INDEX IF NOT EXISTS idx_activity_events_repo_event '
+          'ON activity_events (repo_key, event_id)',
+        );
       }
     },
   );

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -22,6 +22,36 @@ class MetricSnapshots extends Table {
   RealColumn get activityScore => real()();
 }
 
+/// Cached, normalized cross-repo activity feed events (Phase 2 domain cache).
+/// Rows mirror the `ActivityEvent` DTO so the feed can render instantly from
+/// this table on cold start and treat the network as a refresher. `occurredAt`
+/// is milliseconds since epoch in UTC. `(repoKey, eventId)` is unique so a
+/// re-fetch upserts the same event instead of duplicating it. The generated row
+/// class is named `ActivityEventRow` to avoid colliding with the `ActivityEvent`
+/// DTO.
+@DataClassName('ActivityEventRow')
+@TableIndex(name: 'idx_activity_events_repo_key', columns: {#repoKey})
+@TableIndex(name: 'idx_activity_events_occurred_at', columns: {#occurredAt})
+@TableIndex(
+  name: 'idx_activity_events_repo_event',
+  columns: {#repoKey, #eventId},
+  unique: true,
+)
+class ActivityEvents extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get eventId => text()();
+  TextColumn get type => text()();
+  TextColumn get provider => text()();
+  TextColumn get repoKey => text()();
+  TextColumn get repoDisplay => text()();
+  TextColumn get actor => text()();
+  TextColumn get title => text()();
+  TextColumn get subtitle => text()();
+  IntColumn get occurredAt => integer()();
+  TextColumn get url => text().nullable()();
+  BoolColumn get isMine => boolean()();
+}
+
 /// Small key/value table for database-local bookkeeping (e.g. one-time
 /// migration markers that must commit atomically with the data they guard).
 @DataClassName('AppMetaRow')
@@ -36,7 +66,7 @@ class AppMeta extends Table {
 /// The application's local SQLite database. Holds cached, aggregated monitoring
 /// data that would not fit in `SharedPreferences` at scale. Configuration
 /// (tokens, repo lists, preferences) continues to live in `SharedPreferences`.
-@DriftDatabase(tables: [MetricSnapshots, AppMeta])
+@DriftDatabase(tables: [MetricSnapshots, AppMeta, ActivityEvents])
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(_openConnection());
 
@@ -45,7 +75,38 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (m) => m.createAll(),
+    onUpgrade: (m, from, to) async {
+      // v2 adds the activity-feed cache (Phase 2). Create the table and its
+      // indexes explicitly — `createTable` only issues `CREATE TABLE`, so the
+      // (repo_key, event_id) UNIQUE index the upsert relies on must be created
+      // separately or existing (v1) installs would get duplicate rows.
+      //
+      // Guard on the table's existence so a concurrent open from a second
+      // connection (e.g. the background-sync isolate) that also observed v1
+      // can't fail with "table already exists": SQLite serializes writers, so
+      // by the time the second migration's transaction runs, it sees the table
+      // the first one committed and skips the (non-idempotent) DDL.
+      if (from < 2) {
+        final existing = await m.database
+            .customSelect(
+              "SELECT 1 FROM sqlite_master "
+              "WHERE type = 'table' AND name = 'activity_events'",
+            )
+            .get();
+        if (existing.isEmpty) {
+          await m.createTable(activityEvents);
+          await m.create(idxActivityEventsRepoKey);
+          await m.create(idxActivityEventsOccurredAt);
+          await m.create(idxActivityEventsRepoEvent);
+        }
+      }
+    },
+  );
 }
 
 LazyDatabase _openConnection() {

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -623,6 +623,700 @@ class AppMetaCompanion extends UpdateCompanion<AppMetaRow> {
   }
 }
 
+class $ActivityEventsTable extends ActivityEvents
+    with TableInfo<$ActivityEventsTable, ActivityEventRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ActivityEventsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _eventIdMeta = const VerificationMeta(
+    'eventId',
+  );
+  @override
+  late final GeneratedColumn<String> eventId = GeneratedColumn<String>(
+    'event_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _typeMeta = const VerificationMeta('type');
+  @override
+  late final GeneratedColumn<String> type = GeneratedColumn<String>(
+    'type',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _providerMeta = const VerificationMeta(
+    'provider',
+  );
+  @override
+  late final GeneratedColumn<String> provider = GeneratedColumn<String>(
+    'provider',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _repoKeyMeta = const VerificationMeta(
+    'repoKey',
+  );
+  @override
+  late final GeneratedColumn<String> repoKey = GeneratedColumn<String>(
+    'repo_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _repoDisplayMeta = const VerificationMeta(
+    'repoDisplay',
+  );
+  @override
+  late final GeneratedColumn<String> repoDisplay = GeneratedColumn<String>(
+    'repo_display',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _actorMeta = const VerificationMeta('actor');
+  @override
+  late final GeneratedColumn<String> actor = GeneratedColumn<String>(
+    'actor',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _subtitleMeta = const VerificationMeta(
+    'subtitle',
+  );
+  @override
+  late final GeneratedColumn<String> subtitle = GeneratedColumn<String>(
+    'subtitle',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _occurredAtMeta = const VerificationMeta(
+    'occurredAt',
+  );
+  @override
+  late final GeneratedColumn<int> occurredAt = GeneratedColumn<int>(
+    'occurred_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _urlMeta = const VerificationMeta('url');
+  @override
+  late final GeneratedColumn<String> url = GeneratedColumn<String>(
+    'url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _isMineMeta = const VerificationMeta('isMine');
+  @override
+  late final GeneratedColumn<bool> isMine = GeneratedColumn<bool>(
+    'is_mine',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_mine" IN (0, 1))',
+    ),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    eventId,
+    type,
+    provider,
+    repoKey,
+    repoDisplay,
+    actor,
+    title,
+    subtitle,
+    occurredAt,
+    url,
+    isMine,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'activity_events';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<ActivityEventRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('event_id')) {
+      context.handle(
+        _eventIdMeta,
+        eventId.isAcceptableOrUnknown(data['event_id']!, _eventIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_eventIdMeta);
+    }
+    if (data.containsKey('type')) {
+      context.handle(
+        _typeMeta,
+        type.isAcceptableOrUnknown(data['type']!, _typeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_typeMeta);
+    }
+    if (data.containsKey('provider')) {
+      context.handle(
+        _providerMeta,
+        provider.isAcceptableOrUnknown(data['provider']!, _providerMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_providerMeta);
+    }
+    if (data.containsKey('repo_key')) {
+      context.handle(
+        _repoKeyMeta,
+        repoKey.isAcceptableOrUnknown(data['repo_key']!, _repoKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_repoKeyMeta);
+    }
+    if (data.containsKey('repo_display')) {
+      context.handle(
+        _repoDisplayMeta,
+        repoDisplay.isAcceptableOrUnknown(
+          data['repo_display']!,
+          _repoDisplayMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_repoDisplayMeta);
+    }
+    if (data.containsKey('actor')) {
+      context.handle(
+        _actorMeta,
+        actor.isAcceptableOrUnknown(data['actor']!, _actorMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_actorMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('subtitle')) {
+      context.handle(
+        _subtitleMeta,
+        subtitle.isAcceptableOrUnknown(data['subtitle']!, _subtitleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_subtitleMeta);
+    }
+    if (data.containsKey('occurred_at')) {
+      context.handle(
+        _occurredAtMeta,
+        occurredAt.isAcceptableOrUnknown(data['occurred_at']!, _occurredAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_occurredAtMeta);
+    }
+    if (data.containsKey('url')) {
+      context.handle(
+        _urlMeta,
+        url.isAcceptableOrUnknown(data['url']!, _urlMeta),
+      );
+    }
+    if (data.containsKey('is_mine')) {
+      context.handle(
+        _isMineMeta,
+        isMine.isAcceptableOrUnknown(data['is_mine']!, _isMineMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_isMineMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  ActivityEventRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ActivityEventRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      eventId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}event_id'],
+      )!,
+      type: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}type'],
+      )!,
+      provider: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}provider'],
+      )!,
+      repoKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_key'],
+      )!,
+      repoDisplay: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_display'],
+      )!,
+      actor: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}actor'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
+      subtitle: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}subtitle'],
+      )!,
+      occurredAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}occurred_at'],
+      )!,
+      url: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}url'],
+      ),
+      isMine: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_mine'],
+      )!,
+    );
+  }
+
+  @override
+  $ActivityEventsTable createAlias(String alias) {
+    return $ActivityEventsTable(attachedDatabase, alias);
+  }
+}
+
+class ActivityEventRow extends DataClass
+    implements Insertable<ActivityEventRow> {
+  final int id;
+  final String eventId;
+  final String type;
+  final String provider;
+  final String repoKey;
+  final String repoDisplay;
+  final String actor;
+  final String title;
+  final String subtitle;
+  final int occurredAt;
+  final String? url;
+  final bool isMine;
+  const ActivityEventRow({
+    required this.id,
+    required this.eventId,
+    required this.type,
+    required this.provider,
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.actor,
+    required this.title,
+    required this.subtitle,
+    required this.occurredAt,
+    this.url,
+    required this.isMine,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['event_id'] = Variable<String>(eventId);
+    map['type'] = Variable<String>(type);
+    map['provider'] = Variable<String>(provider);
+    map['repo_key'] = Variable<String>(repoKey);
+    map['repo_display'] = Variable<String>(repoDisplay);
+    map['actor'] = Variable<String>(actor);
+    map['title'] = Variable<String>(title);
+    map['subtitle'] = Variable<String>(subtitle);
+    map['occurred_at'] = Variable<int>(occurredAt);
+    if (!nullToAbsent || url != null) {
+      map['url'] = Variable<String>(url);
+    }
+    map['is_mine'] = Variable<bool>(isMine);
+    return map;
+  }
+
+  ActivityEventsCompanion toCompanion(bool nullToAbsent) {
+    return ActivityEventsCompanion(
+      id: Value(id),
+      eventId: Value(eventId),
+      type: Value(type),
+      provider: Value(provider),
+      repoKey: Value(repoKey),
+      repoDisplay: Value(repoDisplay),
+      actor: Value(actor),
+      title: Value(title),
+      subtitle: Value(subtitle),
+      occurredAt: Value(occurredAt),
+      url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+      isMine: Value(isMine),
+    );
+  }
+
+  factory ActivityEventRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ActivityEventRow(
+      id: serializer.fromJson<int>(json['id']),
+      eventId: serializer.fromJson<String>(json['eventId']),
+      type: serializer.fromJson<String>(json['type']),
+      provider: serializer.fromJson<String>(json['provider']),
+      repoKey: serializer.fromJson<String>(json['repoKey']),
+      repoDisplay: serializer.fromJson<String>(json['repoDisplay']),
+      actor: serializer.fromJson<String>(json['actor']),
+      title: serializer.fromJson<String>(json['title']),
+      subtitle: serializer.fromJson<String>(json['subtitle']),
+      occurredAt: serializer.fromJson<int>(json['occurredAt']),
+      url: serializer.fromJson<String?>(json['url']),
+      isMine: serializer.fromJson<bool>(json['isMine']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'eventId': serializer.toJson<String>(eventId),
+      'type': serializer.toJson<String>(type),
+      'provider': serializer.toJson<String>(provider),
+      'repoKey': serializer.toJson<String>(repoKey),
+      'repoDisplay': serializer.toJson<String>(repoDisplay),
+      'actor': serializer.toJson<String>(actor),
+      'title': serializer.toJson<String>(title),
+      'subtitle': serializer.toJson<String>(subtitle),
+      'occurredAt': serializer.toJson<int>(occurredAt),
+      'url': serializer.toJson<String?>(url),
+      'isMine': serializer.toJson<bool>(isMine),
+    };
+  }
+
+  ActivityEventRow copyWith({
+    int? id,
+    String? eventId,
+    String? type,
+    String? provider,
+    String? repoKey,
+    String? repoDisplay,
+    String? actor,
+    String? title,
+    String? subtitle,
+    int? occurredAt,
+    Value<String?> url = const Value.absent(),
+    bool? isMine,
+  }) => ActivityEventRow(
+    id: id ?? this.id,
+    eventId: eventId ?? this.eventId,
+    type: type ?? this.type,
+    provider: provider ?? this.provider,
+    repoKey: repoKey ?? this.repoKey,
+    repoDisplay: repoDisplay ?? this.repoDisplay,
+    actor: actor ?? this.actor,
+    title: title ?? this.title,
+    subtitle: subtitle ?? this.subtitle,
+    occurredAt: occurredAt ?? this.occurredAt,
+    url: url.present ? url.value : this.url,
+    isMine: isMine ?? this.isMine,
+  );
+  ActivityEventRow copyWithCompanion(ActivityEventsCompanion data) {
+    return ActivityEventRow(
+      id: data.id.present ? data.id.value : this.id,
+      eventId: data.eventId.present ? data.eventId.value : this.eventId,
+      type: data.type.present ? data.type.value : this.type,
+      provider: data.provider.present ? data.provider.value : this.provider,
+      repoKey: data.repoKey.present ? data.repoKey.value : this.repoKey,
+      repoDisplay: data.repoDisplay.present
+          ? data.repoDisplay.value
+          : this.repoDisplay,
+      actor: data.actor.present ? data.actor.value : this.actor,
+      title: data.title.present ? data.title.value : this.title,
+      subtitle: data.subtitle.present ? data.subtitle.value : this.subtitle,
+      occurredAt: data.occurredAt.present
+          ? data.occurredAt.value
+          : this.occurredAt,
+      url: data.url.present ? data.url.value : this.url,
+      isMine: data.isMine.present ? data.isMine.value : this.isMine,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ActivityEventRow(')
+          ..write('id: $id, ')
+          ..write('eventId: $eventId, ')
+          ..write('type: $type, ')
+          ..write('provider: $provider, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('repoDisplay: $repoDisplay, ')
+          ..write('actor: $actor, ')
+          ..write('title: $title, ')
+          ..write('subtitle: $subtitle, ')
+          ..write('occurredAt: $occurredAt, ')
+          ..write('url: $url, ')
+          ..write('isMine: $isMine')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    eventId,
+    type,
+    provider,
+    repoKey,
+    repoDisplay,
+    actor,
+    title,
+    subtitle,
+    occurredAt,
+    url,
+    isMine,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ActivityEventRow &&
+          other.id == this.id &&
+          other.eventId == this.eventId &&
+          other.type == this.type &&
+          other.provider == this.provider &&
+          other.repoKey == this.repoKey &&
+          other.repoDisplay == this.repoDisplay &&
+          other.actor == this.actor &&
+          other.title == this.title &&
+          other.subtitle == this.subtitle &&
+          other.occurredAt == this.occurredAt &&
+          other.url == this.url &&
+          other.isMine == this.isMine);
+}
+
+class ActivityEventsCompanion extends UpdateCompanion<ActivityEventRow> {
+  final Value<int> id;
+  final Value<String> eventId;
+  final Value<String> type;
+  final Value<String> provider;
+  final Value<String> repoKey;
+  final Value<String> repoDisplay;
+  final Value<String> actor;
+  final Value<String> title;
+  final Value<String> subtitle;
+  final Value<int> occurredAt;
+  final Value<String?> url;
+  final Value<bool> isMine;
+  const ActivityEventsCompanion({
+    this.id = const Value.absent(),
+    this.eventId = const Value.absent(),
+    this.type = const Value.absent(),
+    this.provider = const Value.absent(),
+    this.repoKey = const Value.absent(),
+    this.repoDisplay = const Value.absent(),
+    this.actor = const Value.absent(),
+    this.title = const Value.absent(),
+    this.subtitle = const Value.absent(),
+    this.occurredAt = const Value.absent(),
+    this.url = const Value.absent(),
+    this.isMine = const Value.absent(),
+  });
+  ActivityEventsCompanion.insert({
+    this.id = const Value.absent(),
+    required String eventId,
+    required String type,
+    required String provider,
+    required String repoKey,
+    required String repoDisplay,
+    required String actor,
+    required String title,
+    required String subtitle,
+    required int occurredAt,
+    this.url = const Value.absent(),
+    required bool isMine,
+  }) : eventId = Value(eventId),
+       type = Value(type),
+       provider = Value(provider),
+       repoKey = Value(repoKey),
+       repoDisplay = Value(repoDisplay),
+       actor = Value(actor),
+       title = Value(title),
+       subtitle = Value(subtitle),
+       occurredAt = Value(occurredAt),
+       isMine = Value(isMine);
+  static Insertable<ActivityEventRow> custom({
+    Expression<int>? id,
+    Expression<String>? eventId,
+    Expression<String>? type,
+    Expression<String>? provider,
+    Expression<String>? repoKey,
+    Expression<String>? repoDisplay,
+    Expression<String>? actor,
+    Expression<String>? title,
+    Expression<String>? subtitle,
+    Expression<int>? occurredAt,
+    Expression<String>? url,
+    Expression<bool>? isMine,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (eventId != null) 'event_id': eventId,
+      if (type != null) 'type': type,
+      if (provider != null) 'provider': provider,
+      if (repoKey != null) 'repo_key': repoKey,
+      if (repoDisplay != null) 'repo_display': repoDisplay,
+      if (actor != null) 'actor': actor,
+      if (title != null) 'title': title,
+      if (subtitle != null) 'subtitle': subtitle,
+      if (occurredAt != null) 'occurred_at': occurredAt,
+      if (url != null) 'url': url,
+      if (isMine != null) 'is_mine': isMine,
+    });
+  }
+
+  ActivityEventsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? eventId,
+    Value<String>? type,
+    Value<String>? provider,
+    Value<String>? repoKey,
+    Value<String>? repoDisplay,
+    Value<String>? actor,
+    Value<String>? title,
+    Value<String>? subtitle,
+    Value<int>? occurredAt,
+    Value<String?>? url,
+    Value<bool>? isMine,
+  }) {
+    return ActivityEventsCompanion(
+      id: id ?? this.id,
+      eventId: eventId ?? this.eventId,
+      type: type ?? this.type,
+      provider: provider ?? this.provider,
+      repoKey: repoKey ?? this.repoKey,
+      repoDisplay: repoDisplay ?? this.repoDisplay,
+      actor: actor ?? this.actor,
+      title: title ?? this.title,
+      subtitle: subtitle ?? this.subtitle,
+      occurredAt: occurredAt ?? this.occurredAt,
+      url: url ?? this.url,
+      isMine: isMine ?? this.isMine,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (eventId.present) {
+      map['event_id'] = Variable<String>(eventId.value);
+    }
+    if (type.present) {
+      map['type'] = Variable<String>(type.value);
+    }
+    if (provider.present) {
+      map['provider'] = Variable<String>(provider.value);
+    }
+    if (repoKey.present) {
+      map['repo_key'] = Variable<String>(repoKey.value);
+    }
+    if (repoDisplay.present) {
+      map['repo_display'] = Variable<String>(repoDisplay.value);
+    }
+    if (actor.present) {
+      map['actor'] = Variable<String>(actor.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (subtitle.present) {
+      map['subtitle'] = Variable<String>(subtitle.value);
+    }
+    if (occurredAt.present) {
+      map['occurred_at'] = Variable<int>(occurredAt.value);
+    }
+    if (url.present) {
+      map['url'] = Variable<String>(url.value);
+    }
+    if (isMine.present) {
+      map['is_mine'] = Variable<bool>(isMine.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ActivityEventsCompanion(')
+          ..write('id: $id, ')
+          ..write('eventId: $eventId, ')
+          ..write('type: $type, ')
+          ..write('provider: $provider, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('repoDisplay: $repoDisplay, ')
+          ..write('actor: $actor, ')
+          ..write('title: $title, ')
+          ..write('subtitle: $subtitle, ')
+          ..write('occurredAt: $occurredAt, ')
+          ..write('url: $url, ')
+          ..write('isMine: $isMine')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -630,9 +1324,22 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     this,
   );
   late final $AppMetaTable appMeta = $AppMetaTable(this);
+  late final $ActivityEventsTable activityEvents = $ActivityEventsTable(this);
   late final Index idxMetricSnapshotsRepoKey = Index(
     'idx_metric_snapshots_repo_key',
     'CREATE INDEX idx_metric_snapshots_repo_key ON metric_snapshots (repo_key)',
+  );
+  late final Index idxActivityEventsRepoKey = Index(
+    'idx_activity_events_repo_key',
+    'CREATE INDEX idx_activity_events_repo_key ON activity_events (repo_key)',
+  );
+  late final Index idxActivityEventsOccurredAt = Index(
+    'idx_activity_events_occurred_at',
+    'CREATE INDEX idx_activity_events_occurred_at ON activity_events (occurred_at)',
+  );
+  late final Index idxActivityEventsRepoEvent = Index(
+    'idx_activity_events_repo_event',
+    'CREATE UNIQUE INDEX idx_activity_events_repo_event ON activity_events (repo_key, event_id)',
   );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
@@ -641,7 +1348,11 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [
     metricSnapshots,
     appMeta,
+    activityEvents,
     idxMetricSnapshotsRepoKey,
+    idxActivityEventsRepoKey,
+    idxActivityEventsOccurredAt,
+    idxActivityEventsRepoEvent,
   ];
 }
 
@@ -1003,6 +1714,343 @@ typedef $$AppMetaTableProcessedTableManager =
       AppMetaRow,
       PrefetchHooks Function()
     >;
+typedef $$ActivityEventsTableCreateCompanionBuilder =
+    ActivityEventsCompanion Function({
+      Value<int> id,
+      required String eventId,
+      required String type,
+      required String provider,
+      required String repoKey,
+      required String repoDisplay,
+      required String actor,
+      required String title,
+      required String subtitle,
+      required int occurredAt,
+      Value<String?> url,
+      required bool isMine,
+    });
+typedef $$ActivityEventsTableUpdateCompanionBuilder =
+    ActivityEventsCompanion Function({
+      Value<int> id,
+      Value<String> eventId,
+      Value<String> type,
+      Value<String> provider,
+      Value<String> repoKey,
+      Value<String> repoDisplay,
+      Value<String> actor,
+      Value<String> title,
+      Value<String> subtitle,
+      Value<int> occurredAt,
+      Value<String?> url,
+      Value<bool> isMine,
+    });
+
+class $$ActivityEventsTableFilterComposer
+    extends Composer<_$AppDatabase, $ActivityEventsTable> {
+  $$ActivityEventsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get eventId => $composableBuilder(
+    column: $table.eventId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get provider => $composableBuilder(
+    column: $table.provider,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get actor => $composableBuilder(
+    column: $table.actor,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get subtitle => $composableBuilder(
+    column: $table.subtitle,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get occurredAt => $composableBuilder(
+    column: $table.occurredAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isMine => $composableBuilder(
+    column: $table.isMine,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$ActivityEventsTableOrderingComposer
+    extends Composer<_$AppDatabase, $ActivityEventsTable> {
+  $$ActivityEventsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get eventId => $composableBuilder(
+    column: $table.eventId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get provider => $composableBuilder(
+    column: $table.provider,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get actor => $composableBuilder(
+    column: $table.actor,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get subtitle => $composableBuilder(
+    column: $table.subtitle,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get occurredAt => $composableBuilder(
+    column: $table.occurredAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isMine => $composableBuilder(
+    column: $table.isMine,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$ActivityEventsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $ActivityEventsTable> {
+  $$ActivityEventsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get eventId =>
+      $composableBuilder(column: $table.eventId, builder: (column) => column);
+
+  GeneratedColumn<String> get type =>
+      $composableBuilder(column: $table.type, builder: (column) => column);
+
+  GeneratedColumn<String> get provider =>
+      $composableBuilder(column: $table.provider, builder: (column) => column);
+
+  GeneratedColumn<String> get repoKey =>
+      $composableBuilder(column: $table.repoKey, builder: (column) => column);
+
+  GeneratedColumn<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get actor =>
+      $composableBuilder(column: $table.actor, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get subtitle =>
+      $composableBuilder(column: $table.subtitle, builder: (column) => column);
+
+  GeneratedColumn<int> get occurredAt => $composableBuilder(
+    column: $table.occurredAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get url =>
+      $composableBuilder(column: $table.url, builder: (column) => column);
+
+  GeneratedColumn<bool> get isMine =>
+      $composableBuilder(column: $table.isMine, builder: (column) => column);
+}
+
+class $$ActivityEventsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $ActivityEventsTable,
+          ActivityEventRow,
+          $$ActivityEventsTableFilterComposer,
+          $$ActivityEventsTableOrderingComposer,
+          $$ActivityEventsTableAnnotationComposer,
+          $$ActivityEventsTableCreateCompanionBuilder,
+          $$ActivityEventsTableUpdateCompanionBuilder,
+          (
+            ActivityEventRow,
+            BaseReferences<
+              _$AppDatabase,
+              $ActivityEventsTable,
+              ActivityEventRow
+            >,
+          ),
+          ActivityEventRow,
+          PrefetchHooks Function()
+        > {
+  $$ActivityEventsTableTableManager(
+    _$AppDatabase db,
+    $ActivityEventsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ActivityEventsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ActivityEventsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ActivityEventsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> eventId = const Value.absent(),
+                Value<String> type = const Value.absent(),
+                Value<String> provider = const Value.absent(),
+                Value<String> repoKey = const Value.absent(),
+                Value<String> repoDisplay = const Value.absent(),
+                Value<String> actor = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<String> subtitle = const Value.absent(),
+                Value<int> occurredAt = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+                Value<bool> isMine = const Value.absent(),
+              }) => ActivityEventsCompanion(
+                id: id,
+                eventId: eventId,
+                type: type,
+                provider: provider,
+                repoKey: repoKey,
+                repoDisplay: repoDisplay,
+                actor: actor,
+                title: title,
+                subtitle: subtitle,
+                occurredAt: occurredAt,
+                url: url,
+                isMine: isMine,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String eventId,
+                required String type,
+                required String provider,
+                required String repoKey,
+                required String repoDisplay,
+                required String actor,
+                required String title,
+                required String subtitle,
+                required int occurredAt,
+                Value<String?> url = const Value.absent(),
+                required bool isMine,
+              }) => ActivityEventsCompanion.insert(
+                id: id,
+                eventId: eventId,
+                type: type,
+                provider: provider,
+                repoKey: repoKey,
+                repoDisplay: repoDisplay,
+                actor: actor,
+                title: title,
+                subtitle: subtitle,
+                occurredAt: occurredAt,
+                url: url,
+                isMine: isMine,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$ActivityEventsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $ActivityEventsTable,
+      ActivityEventRow,
+      $$ActivityEventsTableFilterComposer,
+      $$ActivityEventsTableOrderingComposer,
+      $$ActivityEventsTableAnnotationComposer,
+      $$ActivityEventsTableCreateCompanionBuilder,
+      $$ActivityEventsTableUpdateCompanionBuilder,
+      (
+        ActivityEventRow,
+        BaseReferences<_$AppDatabase, $ActivityEventsTable, ActivityEventRow>,
+      ),
+      ActivityEventRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -1011,4 +2059,6 @@ class $AppDatabaseManager {
       $$MetricSnapshotsTableTableManager(_db, _db.metricSnapshots);
   $$AppMetaTableTableManager get appMeta =>
       $$AppMetaTableTableManager(_db, _db.appMeta);
+  $$ActivityEventsTableTableManager get activityEvents =>
+      $$ActivityEventsTableTableManager(_db, _db.activityEvents);
 }

--- a/lib/manage_repos_page.dart
+++ b/lib/manage_repos_page.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'register_github_repo.dart';
 import 'register_ado_repo.dart';
+import 'activity_event_store.dart';
 import 'ignore_store.dart';
 import 'manage_ignored_page.dart';
 import 'metric_store.dart';
@@ -199,6 +200,7 @@ class _ManageReposPageState extends State<ManageReposPage> {
       );
       if (!stillMonitored) {
         await MetricStore.removeRepo(repoKey);
+        await ActivityEventStore.removeRepo(repoKey);
         await TeamStore.removeRepoFromAll(repoKey);
       }
     }

--- a/test/activity_event_store_test.dart
+++ b/test/activity_event_store_test.dart
@@ -221,6 +221,26 @@ void main() {
     },
   );
 
+  test(
+    'restrictToMonitored purges all rows when nothing is monitored',
+    () async {
+      await ActivityEventStore.save([
+        _event(id: 'a', repoKey: 'github:owner/one', occurredAt: now),
+        _event(id: 'b', repoKey: 'github:owner/two', occurredAt: now),
+      ], now: now);
+
+      // No monitored repos in prefs -> the cache should be fully purged.
+      SharedPreferences.setMockInitialValues({});
+      await ActivityEventStore.save(
+        const [],
+        now: now,
+        restrictToMonitored: true,
+      );
+
+      expect(await ActivityEventStore.cached(now: now), isEmpty);
+    },
+  );
+
   test('save trims the cache to maxEvents newest rows', () async {
     final many = [
       for (var i = 0; i < ActivityFeedService.maxEvents + 25; i++)

--- a/test/activity_event_store_test.dart
+++ b/test/activity_event_store_test.dart
@@ -1,0 +1,291 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/activity_event.dart';
+import 'package:kode_radar/activity_event_store.dart';
+import 'package:kode_radar/activity_feed_service.dart';
+import 'package:kode_radar/database/app_database.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+ActivityEvent _event({
+  required String id,
+  required String repoKey,
+  required DateTime occurredAt,
+  String type = ActivityType.prOpened,
+  String provider = 'github',
+  String repoDisplay = 'owner/name',
+  String actor = 'octocat',
+  String title = 'PR title',
+  String subtitle = 'subtitle',
+  String? url = 'https://example.com/1',
+  bool isMine = false,
+}) => ActivityEvent(
+  id: id,
+  type: type,
+  provider: provider,
+  repoKey: repoKey,
+  repoDisplay: repoDisplay,
+  actor: actor,
+  title: title,
+  subtitle: subtitle,
+  occurredAt: occurredAt,
+  url: url,
+  isMine: isMine,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  final now = DateTime.utc(2026, 1, 15, 12);
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.forExecutor(NativeDatabase.memory());
+    ActivityEventStore.debugUseDatabase(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('save then cached round-trips events newest-first', () async {
+    await ActivityEventStore.save([
+      _event(
+        id: 'a',
+        repoKey: 'github:owner/name',
+        occurredAt: now.subtract(const Duration(hours: 2)),
+      ),
+      _event(
+        id: 'b',
+        repoKey: 'github:owner/name',
+        occurredAt: now.subtract(const Duration(hours: 1)),
+        isMine: true,
+        url: null,
+      ),
+    ], now: now);
+
+    final cached = await ActivityEventStore.cached(now: now);
+    expect(cached.map((e) => e.id).toList(), ['b', 'a']);
+    // Fields survive the round-trip.
+    expect(cached.first.isMine, isTrue);
+    expect(cached.first.url, isNull);
+    expect(cached.last.repoDisplay, 'owner/name');
+    expect(cached.first.occurredAt.isUtc, isTrue);
+  });
+
+  test(
+    're-saving the same (repoKey, eventId) upserts instead of duplicating',
+    () async {
+      await ActivityEventStore.save([
+        _event(
+          id: 'a',
+          repoKey: 'github:owner/name',
+          occurredAt: now.subtract(const Duration(hours: 3)),
+          title: 'old title',
+        ),
+      ], now: now);
+      await ActivityEventStore.save([
+        _event(
+          id: 'a',
+          repoKey: 'github:owner/name',
+          occurredAt: now.subtract(const Duration(hours: 3)),
+          title: 'new title',
+        ),
+      ], now: now);
+
+      final cached = await ActivityEventStore.cached(now: now);
+      expect(cached, hasLength(1));
+      expect(cached.single.title, 'new title');
+    },
+  );
+
+  test('same eventId in different repos are kept separately', () async {
+    await ActivityEventStore.save([
+      _event(id: '1', repoKey: 'github:a/a', occurredAt: now),
+      _event(id: '1', repoKey: 'github:b/b', occurredAt: now),
+    ], now: now);
+
+    final cached = await ActivityEventStore.cached(now: now);
+    expect(cached, hasLength(2));
+    expect(cached.map((e) => e.repoKey).toSet(), {'github:a/a', 'github:b/b'});
+  });
+
+  test('save prunes events older than the retention horizon', () async {
+    await ActivityEventStore.save([
+      _event(
+        id: 'fresh',
+        repoKey: 'github:owner/name',
+        occurredAt: now.subtract(const Duration(days: 2)),
+      ),
+      _event(
+        id: 'stale',
+        repoKey: 'github:owner/name',
+        // Older than ActivityEventStore.maxRetention (60 days).
+        occurredAt: now.subtract(const Duration(days: 70)),
+      ),
+    ], now: now);
+
+    // Read with a wide window so only the retention prune (not the read filter)
+    // can drop the stale event.
+    final cached = await ActivityEventStore.cached(
+      lookback: const Duration(days: 365),
+      now: now,
+    );
+    expect(cached.map((e) => e.id).toList(), ['fresh']);
+  });
+
+  test('retention keeps events beyond the display lookback', () async {
+    await ActivityEventStore.save([
+      _event(
+        id: 'recent',
+        repoKey: 'github:owner/name',
+        occurredAt: now.subtract(const Duration(days: 3)),
+      ),
+      _event(
+        id: 'old',
+        repoKey: 'github:owner/name',
+        occurredAt: now.subtract(const Duration(days: 40)),
+      ),
+    ], now: now);
+
+    // A narrow display window hides the 40-day event...
+    expect(
+      (await ActivityEventStore.cached(
+        lookback: const Duration(days: 7),
+        now: now,
+      )).map((e) => e.id).toList(),
+      ['recent'],
+    );
+    // ...but it is still retained on disk, so a wider window recovers it (the
+    // write-side prune uses maxRetention, not the display lookback).
+    expect(
+      (await ActivityEventStore.cached(
+        lookback: const Duration(days: 60),
+        now: now,
+      )).map((e) => e.id).toList(),
+      ['recent', 'old'],
+    );
+  });
+
+  test('cached honors the lookback window on read', () async {
+    await ActivityEventStore.save([
+      _event(
+        id: 'recent',
+        repoKey: 'github:owner/name',
+        occurredAt: now.subtract(const Duration(days: 3)),
+      ),
+      _event(
+        id: 'older',
+        repoKey: 'github:owner/name',
+        occurredAt: now.subtract(const Duration(days: 10)),
+      ),
+    ], now: now);
+
+    final cached = await ActivityEventStore.cached(
+      lookback: const Duration(days: 7),
+      now: now,
+    );
+    expect(cached.map((e) => e.id).toList(), ['recent']);
+  });
+
+  test(
+    'save with restrictToMonitored skips and purges unmonitored repos',
+    () async {
+      // A previously-cached event for a repo that is about to be unmonitored.
+      await ActivityEventStore.save([
+        _event(id: 'gone', repoKey: 'github:owner/gone', occurredAt: now),
+      ], now: now);
+
+      SharedPreferences.setMockInitialValues({
+        'github_repos': [
+          jsonEncode({'owner': 'owner', 'repoName': 'kept'}),
+        ],
+      });
+
+      // Simulates an in-flight fetch (computed before 'gone' was removed) trying
+      // to re-insert its events alongside the still-monitored repo's.
+      await ActivityEventStore.save(
+        [
+          _event(id: 'kept', repoKey: 'github:owner/kept', occurredAt: now),
+          _event(id: 'gone2', repoKey: 'github:owner/gone', occurredAt: now),
+        ],
+        now: now,
+        restrictToMonitored: true,
+      );
+
+      final cached = await ActivityEventStore.cached(now: now);
+      expect(cached.map((e) => e.repoKey).toSet(), {'github:owner/kept'});
+    },
+  );
+
+  test('save trims the cache to maxEvents newest rows', () async {
+    final many = [
+      for (var i = 0; i < ActivityFeedService.maxEvents + 25; i++)
+        _event(
+          id: 'e$i',
+          repoKey: 'github:owner/name',
+          occurredAt: now.subtract(Duration(minutes: i)),
+        ),
+    ];
+    await ActivityEventStore.save(many, now: now);
+
+    final cached = await ActivityEventStore.cached(now: now);
+    expect(cached, hasLength(ActivityFeedService.maxEvents));
+    // Newest kept, oldest evicted.
+    expect(cached.first.id, 'e0');
+    expect(
+      cached.any((e) => e.id == 'e${ActivityFeedService.maxEvents + 24}'),
+      isFalse,
+    );
+  });
+
+  test('removeRepo drops only the given repo', () async {
+    await ActivityEventStore.save([
+      _event(id: '1', repoKey: 'github:a/a', occurredAt: now),
+      _event(id: '2', repoKey: 'github:b/b', occurredAt: now),
+    ], now: now);
+
+    await ActivityEventStore.removeRepo('github:a/a');
+
+    final cached = await ActivityEventStore.cached(now: now);
+    expect(cached.map((e) => e.repoKey).toList(), ['github:b/b']);
+  });
+
+  test(
+    'v1 -> v2 upgrade creates activity_events with a working unique index',
+    () async {
+      // Build a database that looks like the Phase-1 (v1) schema: no
+      // activity_events table and user_version = 1, so opening AppDatabase over
+      // it runs onUpgrade(1 -> 2) rather than onCreate.
+      final native = sqlite3.openInMemory();
+      native.execute('PRAGMA user_version = 1;');
+      final upgraded = AppDatabase.forExecutor(
+        NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+      );
+      ActivityEventStore.debugUseDatabase(upgraded);
+
+      // Same (repoKey, eventId) twice: only works without duplicating if the
+      // UNIQUE (repo_key, event_id) index was created by the migration (the
+      // upsert's conflict target requires it).
+      await ActivityEventStore.save([
+        _event(id: 'x', repoKey: 'github:owner/name', occurredAt: now),
+      ], now: now);
+      await ActivityEventStore.save([
+        _event(
+          id: 'x',
+          repoKey: 'github:owner/name',
+          occurredAt: now,
+          title: 'updated',
+        ),
+      ], now: now);
+
+      final cached = await ActivityEventStore.cached(now: now);
+      expect(cached, hasLength(1));
+      expect(cached.single.title, 'updated');
+      await upgraded.close();
+    },
+  );
+}

--- a/test/manage_repos_test.dart
+++ b/test/manage_repos_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:kode_radar/database/app_database.dart';
+import 'package:kode_radar/activity_event_store.dart';
 import 'package:kode_radar/manage_repos_page.dart';
 import 'package:kode_radar/metric_store.dart';
 import 'package:kode_radar/team_store.dart';
@@ -17,6 +18,7 @@ void main() {
     FlutterSecureStorage.setMockInitialValues({});
     db = AppDatabase.forExecutor(NativeDatabase.memory());
     MetricStore.debugUseDatabase(db);
+    ActivityEventStore.debugUseDatabase(db);
   });
 
   tearDown(() async {


### PR DESCRIPTION
## What

Local-database **Phase 2a** — persist normalized cross-repo activity events on the local SQLite/drift database so the **Activity Feed renders instantly from disk on cold start** (and offline), with the network as a refresher. Natural follow-on to #23 (drift pilot) and #25 (background sync).

## Changes

- **Schema** (`lib/database/app_database.dart`): new `activity_events` table mirroring the `ActivityEvent` DTO, with a UNIQUE index on `(repoKey, eventId)` plus indexes on `repoKey` and `occurredAt`. `schemaVersion` 1→2 with an `onUpgrade` migration that creates the table **and its indexes** (drift's `createTable` only issues `CREATE TABLE`), guarded on table existence so a concurrent background-isolate open can't fail with "table already exists".
- **`ActivityEventStore`** (new): mirrors the existing `MetricStore` drift patterns (static singleton, `debugUseDatabase`, `_lock` serialization). `cached({lookback})` reads newest-first within the window; `save(events, {restrictToMonitored})` upserts by `(repoKey, eventId)`, prunes to a **60-day retention** horizon (decoupled from the display lookback so shrinking then re-widening the lookback recovers history), self-heals by purging rows for unmonitored repos, and trims to `maxEvents`; `removeRepo`.
- **Cache-first `ActivityFeedPage._load()`**: renders the cache immediately, then refreshes from the network and **renders the persisted merged set** — so a fully-offline load (per-source failures return an empty result, not an exception) keeps showing cached events, and a partial failure shows the union of fresh + still-cached events instead of shrinking.
- **Repo delete** prunes the cache alongside `MetricStore`/`TeamStore`.

## Testing

- `test/activity_event_store_test.dart`: round-trip, upsert dedup, per-repo separation, retention vs display-lookback, read-lookback filter, `maxEvents` trim, `restrictToMonitored` skip+purge, `removeRepo`, and a **v1→v2 upgrade** test proving the unique index is created (the upsert throws without it).
- `flutter test` (274), `flutter analyze --fatal-infos`, `dart format` all clean.

## Notes / follow-ups

- Cached `isMine` is stored as computed at fetch time; a successful online refresh re-fetches the same window and upserts fresh values, so staleness is negligible in practice. Deriving it at read time is a possible follow-up (Phase 2b).
- Phase 2b: attention/PR cache so the Attention Inbox and repo-detail read cache-first.