### PR TITLE
Cache the Attention Inbox on the local DB for offline-first cold starts

### DIFF
--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -95,24 +95,35 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         }
       }
 
-      // Phase B: refresh from the network and persist the snapshot.
+      // Phase B: refresh from the network and persist the snapshot. Compute
+      // WITHOUT snooze filtering so `save` sees each repo's true success/failure
+      // (a snoozed-away item or a dismissed error marker must not make a repo
+      // look "clean" and wipe its last-known-good cache); snooze is applied only
+      // when rendering/notifying below.
       final computed = await AttentionService.computeAll(
         client: AppHttp.client,
-        snoozedIds: snoozed,
         selfGithubLogins: selfGithub,
         selfAdoNames: selfAdo,
       );
       if (!mounted || seq != _loadSeq) return;
       await AttentionStore.save(computed);
       if (!mounted || seq != _loadSeq) return;
+      // Re-read snoozes now (a dismiss may have happened during the fetch) so a
+      // just-dismissed item can't flicker back into the rendered snapshot.
+      final freshSnoozed = await SnoozeStore.snoozedIds();
+      if (!mounted || seq != _loadSeq) return;
       // Render the persisted snapshot (which keeps last-known-good items for any
       // repo that failed this round) plus this round's fresh error items, so an
       // offline/partial refresh never blanks the inbox yet still surfaces which
       // repos couldn't load.
-      final cachedReal = await AttentionStore.cached(snoozedIds: snoozed);
+      final cachedReal = await AttentionStore.cached(snoozedIds: freshSnoozed);
       if (!mounted || seq != _loadSeq) return;
       final errors = computed
-          .where((i) => i.category == AttentionStore.errorCategory)
+          .where(
+            (i) =>
+                i.category == AttentionStore.errorCategory &&
+                !freshSnoozed.contains(i.id),
+          )
           .toList();
       final merged = [...cachedReal, ...errors]
         ..sort((a, b) {
@@ -126,7 +137,13 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         _lastChecked = DateTime.now();
         _refreshing = false;
       });
-      unawaited(NotificationService.notifyNewAttention(computed));
+      // Notify on the fresh, snooze-filtered set (error items are additionally
+      // excluded inside NotificationService).
+      unawaited(
+        NotificationService.notifyNewAttention(
+          computed.where((i) => !freshSnoozed.contains(i.id)).toList(),
+        ),
+      );
     } catch (e) {
       debugPrint('AttentionInbox failed to load: $e');
       if (!mounted || seq != _loadSeq) return;
@@ -165,8 +182,16 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       ),
       body: _showSpinner
           ? const Center(child: CircularProgressIndicator())
-          : RefreshIndicator(onRefresh: _load, child: _buildContent()),
+          : RefreshIndicator(onRefresh: _refresh, child: _buildContent()),
     );
+  }
+
+  /// Pull-to-refresh handler. Coalesces with an already-running load (e.g. the
+  /// initial/config-driven load that isn't owned by this RefreshIndicator) so a
+  /// pull can't kick off a second concurrent network fetch.
+  Future<void> _refresh() async {
+    if (_refreshing) return;
+    await _load();
   }
 
   void _toggleMine() {

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -5,6 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'app_http.dart';
 import 'attention_service.dart';
+import 'attention_store.dart';
 import 'config_revision.dart';
 import 'home_menu.dart';
 import 'identity_store.dart';
@@ -23,7 +24,11 @@ class AttentionInboxPage extends StatefulWidget {
 
 class _AttentionInboxPageState extends State<AttentionInboxPage> {
   List<AttentionItem> _items = const [];
-  bool _loading = true;
+
+  /// A load (cache render + network refresh) is in flight. Gates the manual
+  /// Refresh action so overlapping network fetches/DB writes can't stack on top
+  /// of an in-flight refresh; the cache-first render still updates underneath.
+  bool _refreshing = true;
   bool _mineOnly = false;
   String? _categoryFilter;
   bool _identitySet = false;
@@ -32,6 +37,11 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
 
   // Guards against a stale in-flight load applying after a newer one.
   int _loadSeq = 0;
+
+  /// Show the full-screen spinner only when a load is in flight and there's
+  /// nothing cached to render yet; once items are on screen, content stays
+  /// visible while the network refresh continues underneath.
+  bool get _showSpinner => _refreshing && _items.isEmpty && _error == null;
 
   @override
   void initState() {
@@ -63,34 +73,71 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
   Future<void> _load() async {
     final seq = ++_loadSeq;
     setState(() {
-      _loading = true;
+      _refreshing = true;
       _error = null;
     });
     try {
       final snoozed = await SnoozeStore.snoozedIds();
       final selfGithub = await IdentityStore.selfGithubLogins();
       final selfAdo = await IdentityStore.selfAdoNames();
-      final items = await AttentionService.computeAll(
+
+      // Phase A: render the cached snapshot immediately so a cold start isn't a
+      // blank spinner while the network fetch runs (or if it's offline). Only
+      // meaningful when we don't already have items on screen.
+      if (_items.isEmpty) {
+        final cachedItems = await AttentionStore.cached(snoozedIds: snoozed);
+        if (!mounted || seq != _loadSeq) return;
+        if (cachedItems.isNotEmpty) {
+          setState(() {
+            _items = cachedItems;
+            _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
+          });
+        }
+      }
+
+      // Phase B: refresh from the network and persist the snapshot.
+      final computed = await AttentionService.computeAll(
         client: AppHttp.client,
         snoozedIds: snoozed,
         selfGithubLogins: selfGithub,
         selfAdoNames: selfAdo,
       );
       if (!mounted || seq != _loadSeq) return;
+      await AttentionStore.save(computed);
+      if (!mounted || seq != _loadSeq) return;
+      // Render the persisted snapshot (which keeps last-known-good items for any
+      // repo that failed this round) plus this round's fresh error items, so an
+      // offline/partial refresh never blanks the inbox yet still surfaces which
+      // repos couldn't load.
+      final cachedReal = await AttentionStore.cached(snoozedIds: snoozed);
+      if (!mounted || seq != _loadSeq) return;
+      final errors = computed
+          .where((i) => i.category == AttentionStore.errorCategory)
+          .toList();
+      final merged = [...cachedReal, ...errors]
+        ..sort((a, b) {
+          final bySeverity = b.severity.compareTo(a.severity);
+          if (bySeverity != 0) return bySeverity;
+          return a.repoDisplay.compareTo(b.repoDisplay);
+        });
       setState(() {
-        _items = items;
+        _items = merged;
         _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
         _lastChecked = DateTime.now();
-        _loading = false;
+        _refreshing = false;
       });
-      unawaited(NotificationService.notifyNewAttention(items));
+      unawaited(NotificationService.notifyNewAttention(computed));
     } catch (e) {
       debugPrint('AttentionInbox failed to load: $e');
       if (!mounted || seq != _loadSeq) return;
       setState(() {
-        _error =
-            'Something went wrong while loading your inbox. Pull down to try again.';
-        _loading = false;
+        // Keep any cached items rendered in Phase A rather than replacing them
+        // with an error state; only show the error when we have nothing.
+        if (_items.isEmpty) {
+          _error =
+              'Something went wrong while loading your inbox. Pull down to try again.';
+        }
+        _refreshing = false;
       });
     }
   }
@@ -106,17 +153,17 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
             tooltip: _mineOnly
                 ? 'Showing yours — tap for all'
                 : 'Show only mine',
-            onPressed: _loading ? null : _toggleMine,
+            onPressed: _showSpinner ? null : _toggleMine,
           ),
           IconButton(
             icon: const Icon(Icons.refresh),
             tooltip: 'Refresh',
-            onPressed: _loading ? null : _load,
+            onPressed: _refreshing ? null : _load,
           ),
           const HomeMenuButton(),
         ],
       ),
-      body: _loading
+      body: _showSpinner
           ? const Center(child: CircularProgressIndicator())
           : RefreshIndicator(onRefresh: _load, child: _buildContent()),
     );

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -189,9 +189,10 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
     );
   }
 
-  /// Pull-to-refresh handler. Coalesces with an already-running load (e.g. the
-  /// initial/config-driven load that isn't owned by this RefreshIndicator) so a
-  /// pull can't kick off a second concurrent network fetch.
+  /// Pull-to-refresh handler. If a load is already in flight (e.g. the
+  /// initial/config-driven load that this RefreshIndicator doesn't own), ignore
+  /// the pull instead of starting a second concurrent network fetch; the
+  /// in-flight load updates the list when it completes.
   Future<void> _refresh() async {
     if (_refreshing) return;
     await _load();

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -129,7 +129,10 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         ..sort((a, b) {
           final bySeverity = b.severity.compareTo(a.severity);
           if (bySeverity != 0) return bySeverity;
-          return a.repoDisplay.compareTo(b.repoDisplay);
+          final byRepo = a.repoDisplay.compareTo(b.repoDisplay);
+          if (byRepo != 0) return byRepo;
+          // Stable final tie-breaker so ties don't reorder between renders.
+          return a.id.compareTo(b.id);
         });
       setState(() {
         _items = merged;

--- a/lib/attention_service.dart
+++ b/lib/attention_service.dart
@@ -49,6 +49,11 @@ class AttentionItem {
 class AttentionService {
   AttentionService._();
 
+  /// Category marking a per-repo fetch failure surfaced in the inbox. These are
+  /// not real attention items — they are never persisted to the cache and never
+  /// trigger notifications.
+  static const String errorCategory = 'error';
+
   /// A PR open longer than this many days (with no pending review/changes) is
   /// surfaced as an "old open PR".
   static const int oldOpenPrDays = 7;

--- a/lib/attention_service.dart
+++ b/lib/attention_service.dart
@@ -44,8 +44,10 @@ class AttentionItem {
 /// all monitored repos: waiting on review, changes requested, or open a long
 /// time. Items are optionally tagged as the current user's
 /// (`AttentionItem.isMine`) when GitHub logins / ADO names are supplied, and
-/// snoozed items are filtered out. CI-failing repos are surfaced on the Radar,
-/// not here.
+/// snoozed items are filtered out **only when a non-empty `snoozedIds` is
+/// passed to [computeAll]** — callers that cache the full snapshot (e.g. the
+/// inbox) omit it and apply snooze at read time instead. CI-failing repos are
+/// surfaced on the Radar, not here.
 class AttentionService {
   AttentionService._();
 

--- a/lib/attention_store.dart
+++ b/lib/attention_store.dart
@@ -54,14 +54,24 @@ class AttentionStore {
               (t) =>
                   OrderingTerm(expression: t.severity, mode: OrderingMode.desc),
               (t) => OrderingTerm(expression: t.repoDisplay),
+              // Final tie-breaker so same-severity items in the same repo have a
+              // stable order (SQLite is otherwise free to reorder them, causing
+              // list jitter between cache and network renders).
+              (t) => OrderingTerm(expression: t.id),
             ]))
             .get();
     return rows.where((r) => !snoozedIds.contains(r.id)).map(_toItem).toList();
   }
 
   /// Replaces the cached snapshot from a freshly-[computed] list (as returned by
-  /// [AttentionService.computeAll], which already excludes snoozed items and
-  /// emits one `error` item per repo that failed to load).
+  /// [AttentionService.computeAll], which emits one `error` item per repo that
+  /// failed to load).
+  ///
+  /// Callers should pass the FULL snapshot (do not pre-filter snoozed items):
+  /// the cache is the source of truth for what each repo currently has, and
+  /// snooze is a display concern applied at read time by [cached]. Pre-filtering
+  /// would make a snoozed-away or dismissed item look like the repo went clean
+  /// and wrongly evict its cached data.
   ///
   /// Repos that returned an `error` this round keep their previously-cached
   /// items (so a transient/offline failure doesn't drop their data); every other

--- a/lib/attention_store.dart
+++ b/lib/attention_store.dart
@@ -1,0 +1,126 @@
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+
+import 'attention_service.dart';
+import 'database/app_database.dart';
+
+/// Caches the attention-inbox snapshot on the local SQLite database (drift) so
+/// the inbox renders instantly from disk on cold start / offline, with the
+/// network as a refresher (Phase 2b of the local-database roadmap).
+///
+/// Attention items are a *computed ranking*, not an append-only log, so the
+/// cache is a replaceable snapshot keyed by each item's deterministic
+/// [AttentionItem.id]. [save] merges intelligently: items for repos that
+/// returned an `error` this round (a transient/offline failure) are retained
+/// from the prior snapshot, while repos that were fetched successfully have
+/// their items replaced. Transient `error` items are never persisted; snoozed
+/// items are filtered on read.
+class AttentionStore {
+  AttentionStore._();
+
+  /// Category marking a per-repo fetch failure (not a real attention item).
+  static const String errorCategory = 'error';
+
+  static AppDatabase? _db;
+
+  // Serializes mutating operations (save) relative to each other.
+  static Future<void> _lock = SynchronousFuture<void>(null);
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  static AppDatabase get _database => _db ??= AppDatabase();
+
+  /// Test hook: back the store with an injected (e.g. in-memory) database and
+  /// reset the mutation lock.
+  @visibleForTesting
+  static void debugUseDatabase(AppDatabase db) {
+    _db = db;
+    _lock = SynchronousFuture<void>(null);
+  }
+
+  /// Returns the cached snapshot ranked most-urgent first (severity desc, then
+  /// repo), excluding any ids in [snoozedIds] so a just-made dismiss/snooze is
+  /// honored even before the next network refresh rewrites the cache.
+  static Future<List<AttentionItem>> cached({
+    Set<String> snoozedIds = const {},
+  }) async {
+    final db = _database;
+    final rows =
+        await (db.select(db.attentionItems)..orderBy([
+              (t) =>
+                  OrderingTerm(expression: t.severity, mode: OrderingMode.desc),
+              (t) => OrderingTerm(expression: t.repoDisplay),
+            ]))
+            .get();
+    return rows.where((r) => !snoozedIds.contains(r.id)).map(_toItem).toList();
+  }
+
+  /// Replaces the cached snapshot from a freshly-[computed] list (as returned by
+  /// [AttentionService.computeAll], which already excludes snoozed items and
+  /// emits one `error` item per repo that failed to load).
+  ///
+  /// Repos that returned an `error` this round keep their previously-cached
+  /// items (so a transient/offline failure doesn't drop their data); every other
+  /// repo's cached items are replaced by the fresh set (and repos no longer
+  /// present — clean, or unmonitored — are dropped, self-healing the cache).
+  /// `error` items themselves are never stored.
+  static Future<void> save(List<AttentionItem> computed) async {
+    await _runLocked(() async {
+      final db = _database;
+      final failedDisplays = computed
+          .where((i) => i.category == errorCategory)
+          .map((i) => i.repoDisplay)
+          .toSet();
+      final fresh = computed.where((i) => i.category != errorCategory).toList();
+
+      await db.transaction(() async {
+        // Drop everything except the rows for repos that failed this round,
+        // which we retain as the last-known-good data for them.
+        final keep = failedDisplays.toList();
+        await (db.delete(db.attentionItems)..where(
+              (t) => keep.isEmpty
+                  ? const Constant(true)
+                  : t.repoDisplay.isNotIn(keep),
+            ))
+            .go();
+
+        // Insert the fresh (successful-repo) items; disjoint from the retained
+        // failed-repo rows by repo, but upsert defensively on the id PK.
+        for (final item in fresh) {
+          await db
+              .into(db.attentionItems)
+              .insert(_toCompanion(item), mode: InsertMode.insertOrReplace);
+        }
+      });
+    });
+  }
+
+  static AttentionItem _toItem(AttentionItemRow row) => AttentionItem(
+    id: row.id,
+    category: row.category,
+    severity: row.severity,
+    title: row.title,
+    subtitle: row.subtitle,
+    repoDisplay: row.repoDisplay,
+    url: row.url,
+    ageDays: row.ageDays,
+    isMine: row.isMine,
+  );
+
+  static AttentionItemsCompanion _toCompanion(AttentionItem item) =>
+      AttentionItemsCompanion.insert(
+        id: item.id,
+        category: item.category,
+        severity: item.severity,
+        title: item.title,
+        subtitle: item.subtitle,
+        repoDisplay: item.repoDisplay,
+        url: Value(item.url),
+        ageDays: Value(item.ageDays),
+        isMine: item.isMine,
+      );
+}

--- a/lib/attention_store.dart
+++ b/lib/attention_store.dart
@@ -19,7 +19,7 @@ class AttentionStore {
   AttentionStore._();
 
   /// Category marking a per-repo fetch failure (not a real attention item).
-  static const String errorCategory = 'error';
+  static const String errorCategory = AttentionService.errorCategory;
 
   static AppDatabase? _db;
 

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -52,6 +52,30 @@ class ActivityEvents extends Table {
   BoolColumn get isMine => boolean()();
 }
 
+/// Cached attention-inbox items (Phase 2b). A ranked snapshot of PRs needing
+/// action across all monitored repos, so the inbox renders instantly on cold
+/// start / offline. `id` is the deterministic identity the service already
+/// assigns (e.g. `reviewRequested:owner/name:PR #12`) and is used as the PK so
+/// a recompute replaces rather than duplicates. Transient `error` items are not
+/// persisted. The generated row class is named `AttentionItemRow` to avoid
+/// colliding with the `AttentionItem` DTO.
+@DataClassName('AttentionItemRow')
+@TableIndex(name: 'idx_attention_items_repo_display', columns: {#repoDisplay})
+class AttentionItems extends Table {
+  TextColumn get id => text()();
+  TextColumn get category => text()();
+  IntColumn get severity => integer()();
+  TextColumn get title => text()();
+  TextColumn get subtitle => text()();
+  TextColumn get repoDisplay => text()();
+  TextColumn get url => text().nullable()();
+  IntColumn get ageDays => integer().nullable()();
+  BoolColumn get isMine => boolean()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
 /// Small key/value table for database-local bookkeeping (e.g. one-time
 /// migration markers that must commit atomically with the data they guard).
 @DataClassName('AppMetaRow')
@@ -66,7 +90,9 @@ class AppMeta extends Table {
 /// The application's local SQLite database. Holds cached, aggregated monitoring
 /// data that would not fit in `SharedPreferences` at scale. Configuration
 /// (tokens, repo lists, preferences) continues to live in `SharedPreferences`.
-@DriftDatabase(tables: [MetricSnapshots, AppMeta, ActivityEvents])
+@DriftDatabase(
+  tables: [MetricSnapshots, AppMeta, ActivityEvents, AttentionItems],
+)
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(_openConnection());
 
@@ -75,7 +101,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -106,6 +132,16 @@ class AppDatabase extends _$AppDatabase {
         await customStatement(
           'CREATE UNIQUE INDEX IF NOT EXISTS idx_activity_events_repo_event '
           'ON activity_events (repo_key, event_id)',
+        );
+      }
+      // v3 adds the attention-inbox cache (Phase 2b). Same idempotent-DDL
+      // reasoning as above; the PK index is part of `CREATE TABLE`, so only the
+      // secondary repo_display index needs an explicit statement.
+      if (from < 3) {
+        await m.createTable(attentionItems);
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_attention_items_repo_display '
+          'ON attention_items (repo_display)',
         );
       }
     },

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -1317,6 +1317,569 @@ class ActivityEventsCompanion extends UpdateCompanion<ActivityEventRow> {
   }
 }
 
+class $AttentionItemsTable extends AttentionItems
+    with TableInfo<$AttentionItemsTable, AttentionItemRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $AttentionItemsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _categoryMeta = const VerificationMeta(
+    'category',
+  );
+  @override
+  late final GeneratedColumn<String> category = GeneratedColumn<String>(
+    'category',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _severityMeta = const VerificationMeta(
+    'severity',
+  );
+  @override
+  late final GeneratedColumn<int> severity = GeneratedColumn<int>(
+    'severity',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _subtitleMeta = const VerificationMeta(
+    'subtitle',
+  );
+  @override
+  late final GeneratedColumn<String> subtitle = GeneratedColumn<String>(
+    'subtitle',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _repoDisplayMeta = const VerificationMeta(
+    'repoDisplay',
+  );
+  @override
+  late final GeneratedColumn<String> repoDisplay = GeneratedColumn<String>(
+    'repo_display',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _urlMeta = const VerificationMeta('url');
+  @override
+  late final GeneratedColumn<String> url = GeneratedColumn<String>(
+    'url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _ageDaysMeta = const VerificationMeta(
+    'ageDays',
+  );
+  @override
+  late final GeneratedColumn<int> ageDays = GeneratedColumn<int>(
+    'age_days',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _isMineMeta = const VerificationMeta('isMine');
+  @override
+  late final GeneratedColumn<bool> isMine = GeneratedColumn<bool>(
+    'is_mine',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_mine" IN (0, 1))',
+    ),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    category,
+    severity,
+    title,
+    subtitle,
+    repoDisplay,
+    url,
+    ageDays,
+    isMine,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'attention_items';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<AttentionItemRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('category')) {
+      context.handle(
+        _categoryMeta,
+        category.isAcceptableOrUnknown(data['category']!, _categoryMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_categoryMeta);
+    }
+    if (data.containsKey('severity')) {
+      context.handle(
+        _severityMeta,
+        severity.isAcceptableOrUnknown(data['severity']!, _severityMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_severityMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('subtitle')) {
+      context.handle(
+        _subtitleMeta,
+        subtitle.isAcceptableOrUnknown(data['subtitle']!, _subtitleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_subtitleMeta);
+    }
+    if (data.containsKey('repo_display')) {
+      context.handle(
+        _repoDisplayMeta,
+        repoDisplay.isAcceptableOrUnknown(
+          data['repo_display']!,
+          _repoDisplayMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_repoDisplayMeta);
+    }
+    if (data.containsKey('url')) {
+      context.handle(
+        _urlMeta,
+        url.isAcceptableOrUnknown(data['url']!, _urlMeta),
+      );
+    }
+    if (data.containsKey('age_days')) {
+      context.handle(
+        _ageDaysMeta,
+        ageDays.isAcceptableOrUnknown(data['age_days']!, _ageDaysMeta),
+      );
+    }
+    if (data.containsKey('is_mine')) {
+      context.handle(
+        _isMineMeta,
+        isMine.isAcceptableOrUnknown(data['is_mine']!, _isMineMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_isMineMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  AttentionItemRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return AttentionItemRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      category: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}category'],
+      )!,
+      severity: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}severity'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
+      subtitle: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}subtitle'],
+      )!,
+      repoDisplay: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_display'],
+      )!,
+      url: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}url'],
+      ),
+      ageDays: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}age_days'],
+      ),
+      isMine: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_mine'],
+      )!,
+    );
+  }
+
+  @override
+  $AttentionItemsTable createAlias(String alias) {
+    return $AttentionItemsTable(attachedDatabase, alias);
+  }
+}
+
+class AttentionItemRow extends DataClass
+    implements Insertable<AttentionItemRow> {
+  final String id;
+  final String category;
+  final int severity;
+  final String title;
+  final String subtitle;
+  final String repoDisplay;
+  final String? url;
+  final int? ageDays;
+  final bool isMine;
+  const AttentionItemRow({
+    required this.id,
+    required this.category,
+    required this.severity,
+    required this.title,
+    required this.subtitle,
+    required this.repoDisplay,
+    this.url,
+    this.ageDays,
+    required this.isMine,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['category'] = Variable<String>(category);
+    map['severity'] = Variable<int>(severity);
+    map['title'] = Variable<String>(title);
+    map['subtitle'] = Variable<String>(subtitle);
+    map['repo_display'] = Variable<String>(repoDisplay);
+    if (!nullToAbsent || url != null) {
+      map['url'] = Variable<String>(url);
+    }
+    if (!nullToAbsent || ageDays != null) {
+      map['age_days'] = Variable<int>(ageDays);
+    }
+    map['is_mine'] = Variable<bool>(isMine);
+    return map;
+  }
+
+  AttentionItemsCompanion toCompanion(bool nullToAbsent) {
+    return AttentionItemsCompanion(
+      id: Value(id),
+      category: Value(category),
+      severity: Value(severity),
+      title: Value(title),
+      subtitle: Value(subtitle),
+      repoDisplay: Value(repoDisplay),
+      url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+      ageDays: ageDays == null && nullToAbsent
+          ? const Value.absent()
+          : Value(ageDays),
+      isMine: Value(isMine),
+    );
+  }
+
+  factory AttentionItemRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return AttentionItemRow(
+      id: serializer.fromJson<String>(json['id']),
+      category: serializer.fromJson<String>(json['category']),
+      severity: serializer.fromJson<int>(json['severity']),
+      title: serializer.fromJson<String>(json['title']),
+      subtitle: serializer.fromJson<String>(json['subtitle']),
+      repoDisplay: serializer.fromJson<String>(json['repoDisplay']),
+      url: serializer.fromJson<String?>(json['url']),
+      ageDays: serializer.fromJson<int?>(json['ageDays']),
+      isMine: serializer.fromJson<bool>(json['isMine']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'category': serializer.toJson<String>(category),
+      'severity': serializer.toJson<int>(severity),
+      'title': serializer.toJson<String>(title),
+      'subtitle': serializer.toJson<String>(subtitle),
+      'repoDisplay': serializer.toJson<String>(repoDisplay),
+      'url': serializer.toJson<String?>(url),
+      'ageDays': serializer.toJson<int?>(ageDays),
+      'isMine': serializer.toJson<bool>(isMine),
+    };
+  }
+
+  AttentionItemRow copyWith({
+    String? id,
+    String? category,
+    int? severity,
+    String? title,
+    String? subtitle,
+    String? repoDisplay,
+    Value<String?> url = const Value.absent(),
+    Value<int?> ageDays = const Value.absent(),
+    bool? isMine,
+  }) => AttentionItemRow(
+    id: id ?? this.id,
+    category: category ?? this.category,
+    severity: severity ?? this.severity,
+    title: title ?? this.title,
+    subtitle: subtitle ?? this.subtitle,
+    repoDisplay: repoDisplay ?? this.repoDisplay,
+    url: url.present ? url.value : this.url,
+    ageDays: ageDays.present ? ageDays.value : this.ageDays,
+    isMine: isMine ?? this.isMine,
+  );
+  AttentionItemRow copyWithCompanion(AttentionItemsCompanion data) {
+    return AttentionItemRow(
+      id: data.id.present ? data.id.value : this.id,
+      category: data.category.present ? data.category.value : this.category,
+      severity: data.severity.present ? data.severity.value : this.severity,
+      title: data.title.present ? data.title.value : this.title,
+      subtitle: data.subtitle.present ? data.subtitle.value : this.subtitle,
+      repoDisplay: data.repoDisplay.present
+          ? data.repoDisplay.value
+          : this.repoDisplay,
+      url: data.url.present ? data.url.value : this.url,
+      ageDays: data.ageDays.present ? data.ageDays.value : this.ageDays,
+      isMine: data.isMine.present ? data.isMine.value : this.isMine,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('AttentionItemRow(')
+          ..write('id: $id, ')
+          ..write('category: $category, ')
+          ..write('severity: $severity, ')
+          ..write('title: $title, ')
+          ..write('subtitle: $subtitle, ')
+          ..write('repoDisplay: $repoDisplay, ')
+          ..write('url: $url, ')
+          ..write('ageDays: $ageDays, ')
+          ..write('isMine: $isMine')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    category,
+    severity,
+    title,
+    subtitle,
+    repoDisplay,
+    url,
+    ageDays,
+    isMine,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is AttentionItemRow &&
+          other.id == this.id &&
+          other.category == this.category &&
+          other.severity == this.severity &&
+          other.title == this.title &&
+          other.subtitle == this.subtitle &&
+          other.repoDisplay == this.repoDisplay &&
+          other.url == this.url &&
+          other.ageDays == this.ageDays &&
+          other.isMine == this.isMine);
+}
+
+class AttentionItemsCompanion extends UpdateCompanion<AttentionItemRow> {
+  final Value<String> id;
+  final Value<String> category;
+  final Value<int> severity;
+  final Value<String> title;
+  final Value<String> subtitle;
+  final Value<String> repoDisplay;
+  final Value<String?> url;
+  final Value<int?> ageDays;
+  final Value<bool> isMine;
+  final Value<int> rowid;
+  const AttentionItemsCompanion({
+    this.id = const Value.absent(),
+    this.category = const Value.absent(),
+    this.severity = const Value.absent(),
+    this.title = const Value.absent(),
+    this.subtitle = const Value.absent(),
+    this.repoDisplay = const Value.absent(),
+    this.url = const Value.absent(),
+    this.ageDays = const Value.absent(),
+    this.isMine = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  AttentionItemsCompanion.insert({
+    required String id,
+    required String category,
+    required int severity,
+    required String title,
+    required String subtitle,
+    required String repoDisplay,
+    this.url = const Value.absent(),
+    this.ageDays = const Value.absent(),
+    required bool isMine,
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       category = Value(category),
+       severity = Value(severity),
+       title = Value(title),
+       subtitle = Value(subtitle),
+       repoDisplay = Value(repoDisplay),
+       isMine = Value(isMine);
+  static Insertable<AttentionItemRow> custom({
+    Expression<String>? id,
+    Expression<String>? category,
+    Expression<int>? severity,
+    Expression<String>? title,
+    Expression<String>? subtitle,
+    Expression<String>? repoDisplay,
+    Expression<String>? url,
+    Expression<int>? ageDays,
+    Expression<bool>? isMine,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (category != null) 'category': category,
+      if (severity != null) 'severity': severity,
+      if (title != null) 'title': title,
+      if (subtitle != null) 'subtitle': subtitle,
+      if (repoDisplay != null) 'repo_display': repoDisplay,
+      if (url != null) 'url': url,
+      if (ageDays != null) 'age_days': ageDays,
+      if (isMine != null) 'is_mine': isMine,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  AttentionItemsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? category,
+    Value<int>? severity,
+    Value<String>? title,
+    Value<String>? subtitle,
+    Value<String>? repoDisplay,
+    Value<String?>? url,
+    Value<int?>? ageDays,
+    Value<bool>? isMine,
+    Value<int>? rowid,
+  }) {
+    return AttentionItemsCompanion(
+      id: id ?? this.id,
+      category: category ?? this.category,
+      severity: severity ?? this.severity,
+      title: title ?? this.title,
+      subtitle: subtitle ?? this.subtitle,
+      repoDisplay: repoDisplay ?? this.repoDisplay,
+      url: url ?? this.url,
+      ageDays: ageDays ?? this.ageDays,
+      isMine: isMine ?? this.isMine,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (category.present) {
+      map['category'] = Variable<String>(category.value);
+    }
+    if (severity.present) {
+      map['severity'] = Variable<int>(severity.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (subtitle.present) {
+      map['subtitle'] = Variable<String>(subtitle.value);
+    }
+    if (repoDisplay.present) {
+      map['repo_display'] = Variable<String>(repoDisplay.value);
+    }
+    if (url.present) {
+      map['url'] = Variable<String>(url.value);
+    }
+    if (ageDays.present) {
+      map['age_days'] = Variable<int>(ageDays.value);
+    }
+    if (isMine.present) {
+      map['is_mine'] = Variable<bool>(isMine.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('AttentionItemsCompanion(')
+          ..write('id: $id, ')
+          ..write('category: $category, ')
+          ..write('severity: $severity, ')
+          ..write('title: $title, ')
+          ..write('subtitle: $subtitle, ')
+          ..write('repoDisplay: $repoDisplay, ')
+          ..write('url: $url, ')
+          ..write('ageDays: $ageDays, ')
+          ..write('isMine: $isMine, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -1325,6 +1888,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   );
   late final $AppMetaTable appMeta = $AppMetaTable(this);
   late final $ActivityEventsTable activityEvents = $ActivityEventsTable(this);
+  late final $AttentionItemsTable attentionItems = $AttentionItemsTable(this);
   late final Index idxMetricSnapshotsRepoKey = Index(
     'idx_metric_snapshots_repo_key',
     'CREATE INDEX idx_metric_snapshots_repo_key ON metric_snapshots (repo_key)',
@@ -1341,6 +1905,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'idx_activity_events_repo_event',
     'CREATE UNIQUE INDEX idx_activity_events_repo_event ON activity_events (repo_key, event_id)',
   );
+  late final Index idxAttentionItemsRepoDisplay = Index(
+    'idx_attention_items_repo_display',
+    'CREATE INDEX idx_attention_items_repo_display ON attention_items (repo_display)',
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -1349,10 +1917,12 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     metricSnapshots,
     appMeta,
     activityEvents,
+    attentionItems,
     idxMetricSnapshotsRepoKey,
     idxActivityEventsRepoKey,
     idxActivityEventsOccurredAt,
     idxActivityEventsRepoEvent,
+    idxAttentionItemsRepoDisplay,
   ];
 }
 
@@ -2051,6 +2621,290 @@ typedef $$ActivityEventsTableProcessedTableManager =
       ActivityEventRow,
       PrefetchHooks Function()
     >;
+typedef $$AttentionItemsTableCreateCompanionBuilder =
+    AttentionItemsCompanion Function({
+      required String id,
+      required String category,
+      required int severity,
+      required String title,
+      required String subtitle,
+      required String repoDisplay,
+      Value<String?> url,
+      Value<int?> ageDays,
+      required bool isMine,
+      Value<int> rowid,
+    });
+typedef $$AttentionItemsTableUpdateCompanionBuilder =
+    AttentionItemsCompanion Function({
+      Value<String> id,
+      Value<String> category,
+      Value<int> severity,
+      Value<String> title,
+      Value<String> subtitle,
+      Value<String> repoDisplay,
+      Value<String?> url,
+      Value<int?> ageDays,
+      Value<bool> isMine,
+      Value<int> rowid,
+    });
+
+class $$AttentionItemsTableFilterComposer
+    extends Composer<_$AppDatabase, $AttentionItemsTable> {
+  $$AttentionItemsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get severity => $composableBuilder(
+    column: $table.severity,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get subtitle => $composableBuilder(
+    column: $table.subtitle,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get ageDays => $composableBuilder(
+    column: $table.ageDays,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isMine => $composableBuilder(
+    column: $table.isMine,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$AttentionItemsTableOrderingComposer
+    extends Composer<_$AppDatabase, $AttentionItemsTable> {
+  $$AttentionItemsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get severity => $composableBuilder(
+    column: $table.severity,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get subtitle => $composableBuilder(
+    column: $table.subtitle,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get ageDays => $composableBuilder(
+    column: $table.ageDays,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isMine => $composableBuilder(
+    column: $table.isMine,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$AttentionItemsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $AttentionItemsTable> {
+  $$AttentionItemsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
+
+  GeneratedColumn<int> get severity =>
+      $composableBuilder(column: $table.severity, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get subtitle =>
+      $composableBuilder(column: $table.subtitle, builder: (column) => column);
+
+  GeneratedColumn<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get url =>
+      $composableBuilder(column: $table.url, builder: (column) => column);
+
+  GeneratedColumn<int> get ageDays =>
+      $composableBuilder(column: $table.ageDays, builder: (column) => column);
+
+  GeneratedColumn<bool> get isMine =>
+      $composableBuilder(column: $table.isMine, builder: (column) => column);
+}
+
+class $$AttentionItemsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $AttentionItemsTable,
+          AttentionItemRow,
+          $$AttentionItemsTableFilterComposer,
+          $$AttentionItemsTableOrderingComposer,
+          $$AttentionItemsTableAnnotationComposer,
+          $$AttentionItemsTableCreateCompanionBuilder,
+          $$AttentionItemsTableUpdateCompanionBuilder,
+          (
+            AttentionItemRow,
+            BaseReferences<
+              _$AppDatabase,
+              $AttentionItemsTable,
+              AttentionItemRow
+            >,
+          ),
+          AttentionItemRow,
+          PrefetchHooks Function()
+        > {
+  $$AttentionItemsTableTableManager(
+    _$AppDatabase db,
+    $AttentionItemsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$AttentionItemsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$AttentionItemsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$AttentionItemsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> category = const Value.absent(),
+                Value<int> severity = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<String> subtitle = const Value.absent(),
+                Value<String> repoDisplay = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+                Value<int?> ageDays = const Value.absent(),
+                Value<bool> isMine = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => AttentionItemsCompanion(
+                id: id,
+                category: category,
+                severity: severity,
+                title: title,
+                subtitle: subtitle,
+                repoDisplay: repoDisplay,
+                url: url,
+                ageDays: ageDays,
+                isMine: isMine,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String category,
+                required int severity,
+                required String title,
+                required String subtitle,
+                required String repoDisplay,
+                Value<String?> url = const Value.absent(),
+                Value<int?> ageDays = const Value.absent(),
+                required bool isMine,
+                Value<int> rowid = const Value.absent(),
+              }) => AttentionItemsCompanion.insert(
+                id: id,
+                category: category,
+                severity: severity,
+                title: title,
+                subtitle: subtitle,
+                repoDisplay: repoDisplay,
+                url: url,
+                ageDays: ageDays,
+                isMine: isMine,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$AttentionItemsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $AttentionItemsTable,
+      AttentionItemRow,
+      $$AttentionItemsTableFilterComposer,
+      $$AttentionItemsTableOrderingComposer,
+      $$AttentionItemsTableAnnotationComposer,
+      $$AttentionItemsTableCreateCompanionBuilder,
+      $$AttentionItemsTableUpdateCompanionBuilder,
+      (
+        AttentionItemRow,
+        BaseReferences<_$AppDatabase, $AttentionItemsTable, AttentionItemRow>,
+      ),
+      AttentionItemRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -2061,4 +2915,6 @@ class $AppDatabaseManager {
       $$AppMetaTableTableManager(_db, _db.appMeta);
   $$ActivityEventsTableTableManager get activityEvents =>
       $$ActivityEventsTableTableManager(_db, _db.activityEvents);
+  $$AttentionItemsTableTableManager get attentionItems =>
+      $$AttentionItemsTableTableManager(_db, _db.attentionItems);
 }

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -64,7 +64,14 @@ class NotificationService {
 
   static Future<void> _notifyNewAttention(List<AttentionItem> items) async {
     try {
-      final currentIds = items.map((item) => item.id).toSet();
+      // Error items are per-repo fetch failures, not attention: never notify on
+      // them and never record them in the baseline, so an offline/failed refresh
+      // can't emit a spurious "items need attention" (the ids would otherwise be
+      // "new" for an already-known repo).
+      final attention = items
+          .where((item) => item.category != AttentionService.errorCategory)
+          .toList();
+      final currentIds = attention.map((item) => item.id).toSet();
       final prefs = await SharedPreferences.getInstance();
       // Refresh the in-memory cache from disk first: the background-sync isolate
       // and the resident foreground isolate each cache prefs independently, so
@@ -92,7 +99,7 @@ class NotificationService {
       final newIds = pendingIds(
         seen: seen,
         knownRepos: knownRepos,
-        items: items,
+        items: attention,
         firstRun: firstRun,
       );
       final now = DateTime.now();
@@ -112,7 +119,7 @@ class NotificationService {
 
       if (newIds.isNotEmpty &&
           PreferencesStore.notificationsAllowed(appPrefs, now)) {
-        final newItems = items
+        final newItems = attention
             .where((item) => newIds.contains(item.id))
             .toList(growable: false);
         await _showSummaryNotification(newItems);
@@ -156,8 +163,12 @@ class NotificationService {
     required bool firstRun,
   }) {
     if (firstRun) return const <String>{};
-    final currentIds = items.map((item) => item.id).toSet();
-    final newRepoItemIds = items
+    // Never treat per-repo fetch failures as new attention.
+    final attention = items
+        .where((item) => item.category != AttentionService.errorCategory)
+        .toList();
+    final currentIds = attention.map((item) => item.id).toSet();
+    final newRepoItemIds = attention
         .where((item) => !knownRepos.contains(item.repoDisplay))
         .map((item) => item.id)
         .toSet();

--- a/test/attention_store_test.dart
+++ b/test/attention_store_test.dart
@@ -69,6 +69,17 @@ void main() {
     expect(cached.first.ageDays, 2);
   });
 
+  test('cached breaks severity+repo ties deterministically by id', () async {
+    await AttentionStore.save([
+      _item(id: 'z', repoDisplay: 'owner/one', severity: 3000),
+      _item(id: 'a', repoDisplay: 'owner/one', severity: 3000),
+      _item(id: 'm', repoDisplay: 'owner/one', severity: 3000),
+    ]);
+
+    final cached = await AttentionStore.cached();
+    expect(cached.map((e) => e.id).toList(), ['a', 'm', 'z']);
+  });
+
   test('cached filters out snoozed ids on read', () async {
     await AttentionStore.save([
       _item(id: 'a', repoDisplay: 'owner/one'),

--- a/test/attention_store_test.dart
+++ b/test/attention_store_test.dart
@@ -161,8 +161,10 @@ void main() {
   );
 
   test('v2 -> v3 upgrade creates a working attention_items table', () async {
-    // A v2-shaped database (activity_events cache exists, attention_items does
-    // not), user_version = 2, so opening AppDatabase runs onUpgrade(2 -> 3).
+    // Set user_version = 2 so opening AppDatabase runs onUpgrade(2 -> 3) rather
+    // than onCreate. We don't materialize the other v2 tables because this test
+    // only exercises the v3 step (creating attention_items), which is
+    // independent of them.
     final native = sqlite3.openInMemory();
     native.execute('PRAGMA user_version = 2;');
     final upgraded = AppDatabase.forExecutor(

--- a/test/attention_store_test.dart
+++ b/test/attention_store_test.dart
@@ -1,0 +1,168 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/attention_service.dart';
+import 'package:kode_radar/attention_store.dart';
+import 'package:kode_radar/database/app_database.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+AttentionItem _item({
+  required String id,
+  required String repoDisplay,
+  String category = 'reviewRequested',
+  int severity = 3000,
+  String title = 'PR #1',
+  String subtitle = 'subtitle',
+  String? url = 'https://example.com/1',
+  int? ageDays = 2,
+  bool isMine = false,
+}) => AttentionItem(
+  id: id,
+  category: category,
+  severity: severity,
+  title: title,
+  subtitle: subtitle,
+  repoDisplay: repoDisplay,
+  url: url,
+  ageDays: ageDays,
+  isMine: isMine,
+);
+
+AttentionItem _error(String repoDisplay) => AttentionItem(
+  id: 'error:$repoDisplay',
+  category: AttentionStore.errorCategory,
+  severity: 0,
+  title: 'Could not load',
+  subtitle: repoDisplay,
+  repoDisplay: repoDisplay,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forExecutor(NativeDatabase.memory());
+    AttentionStore.debugUseDatabase(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('save persists non-error items and never stores error items', () async {
+    await AttentionStore.save([
+      _item(id: 'a', repoDisplay: 'owner/one', severity: 3002),
+      _item(id: 'b', repoDisplay: 'owner/two', severity: 2001),
+      _error('owner/three'),
+    ]);
+
+    final cached = await AttentionStore.cached();
+    // Ranked by severity desc; error item not stored.
+    expect(cached.map((e) => e.id).toList(), ['a', 'b']);
+    expect(
+      cached.any((e) => e.category == AttentionStore.errorCategory),
+      isFalse,
+    );
+    // Fields round-trip.
+    expect(cached.first.repoDisplay, 'owner/one');
+    expect(cached.first.ageDays, 2);
+  });
+
+  test('cached filters out snoozed ids on read', () async {
+    await AttentionStore.save([
+      _item(id: 'a', repoDisplay: 'owner/one'),
+      _item(id: 'b', repoDisplay: 'owner/two'),
+    ]);
+
+    final cached = await AttentionStore.cached(snoozedIds: {'a'});
+    expect(cached.map((e) => e.id).toList(), ['b']);
+  });
+
+  test('a successful refresh replaces a repo\'s items', () async {
+    await AttentionStore.save([
+      _item(id: 'old', repoDisplay: 'owner/one', title: 'old'),
+    ]);
+    // Same repo fetched successfully again, different item.
+    await AttentionStore.save([
+      _item(id: 'new', repoDisplay: 'owner/one', title: 'new'),
+    ]);
+
+    final cached = await AttentionStore.cached();
+    expect(cached.map((e) => e.id).toList(), ['new']);
+  });
+
+  test('a repo that is now clean drops its cached items', () async {
+    await AttentionStore.save([
+      _item(id: 'a', repoDisplay: 'owner/one'),
+      _item(id: 'b', repoDisplay: 'owner/two'),
+    ]);
+    // owner/one is now clean (no items, no error) while owner/two still has one.
+    await AttentionStore.save([_item(id: 'b', repoDisplay: 'owner/two')]);
+
+    final cached = await AttentionStore.cached();
+    expect(cached.map((e) => e.id).toList(), ['b']);
+  });
+
+  test('items for a repo that errored this round are retained', () async {
+    await AttentionStore.save([
+      _item(id: 'a', repoDisplay: 'owner/one', severity: 3000),
+      _item(id: 'b', repoDisplay: 'owner/two', severity: 2000),
+    ]);
+    // owner/one errors this round; owner/two succeeds with an updated item.
+    await AttentionStore.save([
+      _error('owner/one'),
+      _item(id: 'b2', repoDisplay: 'owner/two', severity: 2500),
+    ]);
+
+    final cached = await AttentionStore.cached();
+    // owner/one's cached 'a' is kept; owner/two replaced 'b' -> 'b2'.
+    expect(cached.map((e) => e.id).toSet(), {'a', 'b2'});
+  });
+
+  test(
+    'a fully offline refresh (all errors) keeps the prior snapshot',
+    () async {
+      await AttentionStore.save([
+        _item(id: 'a', repoDisplay: 'owner/one'),
+        _item(id: 'b', repoDisplay: 'owner/two'),
+      ]);
+      await AttentionStore.save([_error('owner/one'), _error('owner/two')]);
+
+      final cached = await AttentionStore.cached();
+      expect(cached.map((e) => e.id).toSet(), {'a', 'b'});
+    },
+  );
+
+  test(
+    'a repo no longer fetched (removed) self-heals out of the cache',
+    () async {
+      await AttentionStore.save([
+        _item(id: 'a', repoDisplay: 'owner/one'),
+        _item(id: 'gone', repoDisplay: 'owner/removed'),
+      ]);
+      // Next refresh only fetches owner/one (owner/removed was unmonitored).
+      await AttentionStore.save([_item(id: 'a', repoDisplay: 'owner/one')]);
+
+      final cached = await AttentionStore.cached();
+      expect(cached.map((e) => e.repoDisplay).toSet(), {'owner/one'});
+    },
+  );
+
+  test('v2 -> v3 upgrade creates a working attention_items table', () async {
+    // A v2-shaped database (activity_events cache exists, attention_items does
+    // not), user_version = 2, so opening AppDatabase runs onUpgrade(2 -> 3).
+    final native = sqlite3.openInMemory();
+    native.execute('PRAGMA user_version = 2;');
+    final upgraded = AppDatabase.forExecutor(
+      NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+    );
+    AttentionStore.debugUseDatabase(upgraded);
+
+    await AttentionStore.save([_item(id: 'a', repoDisplay: 'owner/one')]);
+    final cached = await AttentionStore.cached();
+    expect(cached.map((e) => e.id).toList(), ['a']);
+
+    await upgraded.close();
+  });
+}

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -111,6 +111,24 @@ void main() {
       );
       expect(pending, {'b'});
     });
+
+    test('excludes per-repo error items (offline failure never notifies)', () {
+      final errorItem = AttentionItem(
+        id: 'error:r1',
+        category: AttentionService.errorCategory,
+        severity: 0,
+        title: 'Could not load',
+        subtitle: 'r1',
+        repoDisplay: 'r1',
+      );
+      final pending = NotificationService.pendingIds(
+        seen: const {'a'},
+        knownRepos: const {'r1'},
+        items: [errorItem],
+        firstRun: false,
+      );
+      expect(pending, isEmpty);
+    });
   });
 
   group('mergeSeen', () {


### PR DESCRIPTION
## What

Local-database **Phase 2b** — persist the attention-inbox snapshot on the local SQLite/drift database so the **Attention Inbox renders instantly on cold start** (and offline), with the network as a refresher. Follows #26 (activity-feed cache).

## Design

`AttentionItem` is a *computed ranking* with a deterministic `id` but no `repoKey`/timestamp, and `error` items are transient per-repo fetch failures — so the cache is a **merge-replace snapshot** rather than an append log:

- **`AttentionStore.save(computed)`** (one transaction): `error` items identify which repos failed this round; their cached rows are **retained** (last-known-good), every other repo's rows are **replaced** with the fresh set, and clean/removed repos **self-heal** out. `error` items are never stored.
- **`cached({snoozedIds})`** ranks severity-desc then repo and filters snoozed ids on read (so a just-made dismiss is honored before the next refresh).
- **`AttentionInboxPage._load()`** is cache-first: render cache immediately, then compute → save → render the persisted snapshot **plus this round's fresh error items**, so an offline/partial refresh never blanks the inbox yet still surfaces which repos couldn't load. Loading state is split into `_refreshing` (gates the Refresh action) and `_showSpinner` to prevent overlapping refreshes.
- **Schema**: new `attention_items` table (`id` PK, index on `repoDisplay`); `schemaVersion` 2→3 with an idempotent `onUpgrade`.

## Testing

- `test/attention_store_test.dart`: persist/exclude-errors, snooze read-filter, replace-on-success, clean-repo drop, errored-repo retain, fully-offline keep, removed-repo self-heal, and a **v2→v3 upgrade** test.
- `flutter test` (283), `flutter analyze --fatal-infos`, `dart format` all clean.

## Notes / follow-ups

- Relies on self-heal (next refresh drops an unmonitored repo) rather than an explicit prune on repo delete, since attention items have no `repoKey`; `configRevision` triggers that refresh on delete.
- A repo that *permanently* errors while still monitored keeps its last items indefinitely (shown alongside its error marker) until removed — acceptable, and visible to the user.
- Phase 2c: repo-detail drill-down cache-first.