### PR TITLE
Cache the repo-detail drill-down on the local DB for offline-first cold starts

### DIFF
--- a/lib/activity_event_store.dart
+++ b/lib/activity_event_store.dart
@@ -54,19 +54,26 @@ class ActivityEventStore {
   /// Returns the cached events within [lookback] of [now] (default: now),
   /// newest first, capped at [ActivityFeedService.maxEvents] — matching the
   /// shape the feed would fetch from the network.
+  ///
+  /// When [repoKey] is given, only that repo's events are returned (and the cap
+  /// applies to that repo), so a single repo's cached timeline isn't hidden
+  /// behind the global newest-[ActivityFeedService.maxEvents] window.
   static Future<List<ActivityEvent>> cached({
     Duration lookback = ActivityFeedService.defaultLookback,
     DateTime? now,
+    String? repoKey,
   }) async {
     final since = (now ?? DateTime.now()).toUtc().subtract(lookback);
     final db = _database;
+    final query = db.select(db.activityEvents)
+      ..where(
+        (t) => t.occurredAt.isBiggerOrEqualValue(since.millisecondsSinceEpoch),
+      );
+    if (repoKey != null) {
+      query.where((t) => t.repoKey.equals(repoKey));
+    }
     final rows =
-        await (db.select(db.activityEvents)
-              ..where(
-                (t) => t.occurredAt.isBiggerOrEqualValue(
-                  since.millisecondsSinceEpoch,
-                ),
-              )
+        await (query
               ..orderBy([
                 (t) => OrderingTerm(
                   expression: t.occurredAt,

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -76,6 +76,50 @@ class AttentionItems extends Table {
   Set<Column> get primaryKey => {id};
 }
 
+/// Cached per-repo detail (Phase 2c): the open pull requests, CI runs, and
+/// releases shown on the repo drill-down, so it renders instantly on cold start
+/// / offline. Each row carries its `repoKey`; the autoincrement `id` preserves
+/// the provider's list order. Generated row classes are suffixed `Row` to avoid
+/// colliding with the `RepoPr`/`RepoRun`/`RepoRelease` DTOs.
+@DataClassName('RepoPrRow')
+@TableIndex(name: 'idx_repo_pulls_repo_key', columns: {#repoKey})
+class RepoPulls extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get repoKey => text()();
+  TextColumn get label => text()();
+  TextColumn get title => text()();
+  TextColumn get author => text()();
+  TextColumn get reviewState => text()();
+  IntColumn get ageDays => integer().nullable()();
+  BoolColumn get draft => boolean()();
+  TextColumn get url => text().nullable()();
+}
+
+@DataClassName('RepoRunRow')
+@TableIndex(name: 'idx_repo_runs_repo_key', columns: {#repoKey})
+class RepoRuns extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get repoKey => text()();
+  TextColumn get name => text()();
+  TextColumn get status => text()();
+  TextColumn get conclusion => text()();
+  TextColumn get branch => text().nullable()();
+  IntColumn get finishedAt => integer().nullable()();
+  TextColumn get url => text().nullable()();
+}
+
+@DataClassName('RepoReleaseRow')
+@TableIndex(name: 'idx_repo_releases_repo_key', columns: {#repoKey})
+class RepoReleases extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get repoKey => text()();
+  TextColumn get tag => text()();
+  TextColumn get name => text().nullable()();
+  TextColumn get author => text().nullable()();
+  IntColumn get publishedAt => integer().nullable()();
+  TextColumn get url => text().nullable()();
+}
+
 /// Small key/value table for database-local bookkeeping (e.g. one-time
 /// migration markers that must commit atomically with the data they guard).
 @DataClassName('AppMetaRow')
@@ -91,7 +135,15 @@ class AppMeta extends Table {
 /// data that would not fit in `SharedPreferences` at scale. Configuration
 /// (tokens, repo lists, preferences) continues to live in `SharedPreferences`.
 @DriftDatabase(
-  tables: [MetricSnapshots, AppMeta, ActivityEvents, AttentionItems],
+  tables: [
+    MetricSnapshots,
+    AppMeta,
+    ActivityEvents,
+    AttentionItems,
+    RepoPulls,
+    RepoRuns,
+    RepoReleases,
+  ],
 )
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(_openConnection());
@@ -101,7 +153,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -142,6 +194,25 @@ class AppDatabase extends _$AppDatabase {
         await customStatement(
           'CREATE INDEX IF NOT EXISTS idx_attention_items_repo_display '
           'ON attention_items (repo_display)',
+        );
+      }
+      // v4 adds the repo-detail cache (Phase 2c): pulls, CI runs, releases.
+      // Same idempotent-DDL reasoning as above.
+      if (from < 4) {
+        await m.createTable(repoPulls);
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_repo_pulls_repo_key '
+          'ON repo_pulls (repo_key)',
+        );
+        await m.createTable(repoRuns);
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_repo_runs_repo_key '
+          'ON repo_runs (repo_key)',
+        );
+        await m.createTable(repoReleases);
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_repo_releases_repo_key '
+          'ON repo_releases (repo_key)',
         );
       }
     },

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -1880,6 +1880,1497 @@ class AttentionItemsCompanion extends UpdateCompanion<AttentionItemRow> {
   }
 }
 
+class $RepoPullsTable extends RepoPulls
+    with TableInfo<$RepoPullsTable, RepoPrRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $RepoPullsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _repoKeyMeta = const VerificationMeta(
+    'repoKey',
+  );
+  @override
+  late final GeneratedColumn<String> repoKey = GeneratedColumn<String>(
+    'repo_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _labelMeta = const VerificationMeta('label');
+  @override
+  late final GeneratedColumn<String> label = GeneratedColumn<String>(
+    'label',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _authorMeta = const VerificationMeta('author');
+  @override
+  late final GeneratedColumn<String> author = GeneratedColumn<String>(
+    'author',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _reviewStateMeta = const VerificationMeta(
+    'reviewState',
+  );
+  @override
+  late final GeneratedColumn<String> reviewState = GeneratedColumn<String>(
+    'review_state',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _ageDaysMeta = const VerificationMeta(
+    'ageDays',
+  );
+  @override
+  late final GeneratedColumn<int> ageDays = GeneratedColumn<int>(
+    'age_days',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _draftMeta = const VerificationMeta('draft');
+  @override
+  late final GeneratedColumn<bool> draft = GeneratedColumn<bool>(
+    'draft',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("draft" IN (0, 1))',
+    ),
+  );
+  static const VerificationMeta _urlMeta = const VerificationMeta('url');
+  @override
+  late final GeneratedColumn<String> url = GeneratedColumn<String>(
+    'url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    repoKey,
+    label,
+    title,
+    author,
+    reviewState,
+    ageDays,
+    draft,
+    url,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'repo_pulls';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<RepoPrRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('repo_key')) {
+      context.handle(
+        _repoKeyMeta,
+        repoKey.isAcceptableOrUnknown(data['repo_key']!, _repoKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_repoKeyMeta);
+    }
+    if (data.containsKey('label')) {
+      context.handle(
+        _labelMeta,
+        label.isAcceptableOrUnknown(data['label']!, _labelMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_labelMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('author')) {
+      context.handle(
+        _authorMeta,
+        author.isAcceptableOrUnknown(data['author']!, _authorMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_authorMeta);
+    }
+    if (data.containsKey('review_state')) {
+      context.handle(
+        _reviewStateMeta,
+        reviewState.isAcceptableOrUnknown(
+          data['review_state']!,
+          _reviewStateMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_reviewStateMeta);
+    }
+    if (data.containsKey('age_days')) {
+      context.handle(
+        _ageDaysMeta,
+        ageDays.isAcceptableOrUnknown(data['age_days']!, _ageDaysMeta),
+      );
+    }
+    if (data.containsKey('draft')) {
+      context.handle(
+        _draftMeta,
+        draft.isAcceptableOrUnknown(data['draft']!, _draftMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_draftMeta);
+    }
+    if (data.containsKey('url')) {
+      context.handle(
+        _urlMeta,
+        url.isAcceptableOrUnknown(data['url']!, _urlMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  RepoPrRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return RepoPrRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      repoKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_key'],
+      )!,
+      label: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}label'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
+      author: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}author'],
+      )!,
+      reviewState: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}review_state'],
+      )!,
+      ageDays: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}age_days'],
+      ),
+      draft: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}draft'],
+      )!,
+      url: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}url'],
+      ),
+    );
+  }
+
+  @override
+  $RepoPullsTable createAlias(String alias) {
+    return $RepoPullsTable(attachedDatabase, alias);
+  }
+}
+
+class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
+  final int id;
+  final String repoKey;
+  final String label;
+  final String title;
+  final String author;
+  final String reviewState;
+  final int? ageDays;
+  final bool draft;
+  final String? url;
+  const RepoPrRow({
+    required this.id,
+    required this.repoKey,
+    required this.label,
+    required this.title,
+    required this.author,
+    required this.reviewState,
+    this.ageDays,
+    required this.draft,
+    this.url,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['repo_key'] = Variable<String>(repoKey);
+    map['label'] = Variable<String>(label);
+    map['title'] = Variable<String>(title);
+    map['author'] = Variable<String>(author);
+    map['review_state'] = Variable<String>(reviewState);
+    if (!nullToAbsent || ageDays != null) {
+      map['age_days'] = Variable<int>(ageDays);
+    }
+    map['draft'] = Variable<bool>(draft);
+    if (!nullToAbsent || url != null) {
+      map['url'] = Variable<String>(url);
+    }
+    return map;
+  }
+
+  RepoPullsCompanion toCompanion(bool nullToAbsent) {
+    return RepoPullsCompanion(
+      id: Value(id),
+      repoKey: Value(repoKey),
+      label: Value(label),
+      title: Value(title),
+      author: Value(author),
+      reviewState: Value(reviewState),
+      ageDays: ageDays == null && nullToAbsent
+          ? const Value.absent()
+          : Value(ageDays),
+      draft: Value(draft),
+      url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+    );
+  }
+
+  factory RepoPrRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return RepoPrRow(
+      id: serializer.fromJson<int>(json['id']),
+      repoKey: serializer.fromJson<String>(json['repoKey']),
+      label: serializer.fromJson<String>(json['label']),
+      title: serializer.fromJson<String>(json['title']),
+      author: serializer.fromJson<String>(json['author']),
+      reviewState: serializer.fromJson<String>(json['reviewState']),
+      ageDays: serializer.fromJson<int?>(json['ageDays']),
+      draft: serializer.fromJson<bool>(json['draft']),
+      url: serializer.fromJson<String?>(json['url']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'repoKey': serializer.toJson<String>(repoKey),
+      'label': serializer.toJson<String>(label),
+      'title': serializer.toJson<String>(title),
+      'author': serializer.toJson<String>(author),
+      'reviewState': serializer.toJson<String>(reviewState),
+      'ageDays': serializer.toJson<int?>(ageDays),
+      'draft': serializer.toJson<bool>(draft),
+      'url': serializer.toJson<String?>(url),
+    };
+  }
+
+  RepoPrRow copyWith({
+    int? id,
+    String? repoKey,
+    String? label,
+    String? title,
+    String? author,
+    String? reviewState,
+    Value<int?> ageDays = const Value.absent(),
+    bool? draft,
+    Value<String?> url = const Value.absent(),
+  }) => RepoPrRow(
+    id: id ?? this.id,
+    repoKey: repoKey ?? this.repoKey,
+    label: label ?? this.label,
+    title: title ?? this.title,
+    author: author ?? this.author,
+    reviewState: reviewState ?? this.reviewState,
+    ageDays: ageDays.present ? ageDays.value : this.ageDays,
+    draft: draft ?? this.draft,
+    url: url.present ? url.value : this.url,
+  );
+  RepoPrRow copyWithCompanion(RepoPullsCompanion data) {
+    return RepoPrRow(
+      id: data.id.present ? data.id.value : this.id,
+      repoKey: data.repoKey.present ? data.repoKey.value : this.repoKey,
+      label: data.label.present ? data.label.value : this.label,
+      title: data.title.present ? data.title.value : this.title,
+      author: data.author.present ? data.author.value : this.author,
+      reviewState: data.reviewState.present
+          ? data.reviewState.value
+          : this.reviewState,
+      ageDays: data.ageDays.present ? data.ageDays.value : this.ageDays,
+      draft: data.draft.present ? data.draft.value : this.draft,
+      url: data.url.present ? data.url.value : this.url,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RepoPrRow(')
+          ..write('id: $id, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('label: $label, ')
+          ..write('title: $title, ')
+          ..write('author: $author, ')
+          ..write('reviewState: $reviewState, ')
+          ..write('ageDays: $ageDays, ')
+          ..write('draft: $draft, ')
+          ..write('url: $url')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    repoKey,
+    label,
+    title,
+    author,
+    reviewState,
+    ageDays,
+    draft,
+    url,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is RepoPrRow &&
+          other.id == this.id &&
+          other.repoKey == this.repoKey &&
+          other.label == this.label &&
+          other.title == this.title &&
+          other.author == this.author &&
+          other.reviewState == this.reviewState &&
+          other.ageDays == this.ageDays &&
+          other.draft == this.draft &&
+          other.url == this.url);
+}
+
+class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
+  final Value<int> id;
+  final Value<String> repoKey;
+  final Value<String> label;
+  final Value<String> title;
+  final Value<String> author;
+  final Value<String> reviewState;
+  final Value<int?> ageDays;
+  final Value<bool> draft;
+  final Value<String?> url;
+  const RepoPullsCompanion({
+    this.id = const Value.absent(),
+    this.repoKey = const Value.absent(),
+    this.label = const Value.absent(),
+    this.title = const Value.absent(),
+    this.author = const Value.absent(),
+    this.reviewState = const Value.absent(),
+    this.ageDays = const Value.absent(),
+    this.draft = const Value.absent(),
+    this.url = const Value.absent(),
+  });
+  RepoPullsCompanion.insert({
+    this.id = const Value.absent(),
+    required String repoKey,
+    required String label,
+    required String title,
+    required String author,
+    required String reviewState,
+    this.ageDays = const Value.absent(),
+    required bool draft,
+    this.url = const Value.absent(),
+  }) : repoKey = Value(repoKey),
+       label = Value(label),
+       title = Value(title),
+       author = Value(author),
+       reviewState = Value(reviewState),
+       draft = Value(draft);
+  static Insertable<RepoPrRow> custom({
+    Expression<int>? id,
+    Expression<String>? repoKey,
+    Expression<String>? label,
+    Expression<String>? title,
+    Expression<String>? author,
+    Expression<String>? reviewState,
+    Expression<int>? ageDays,
+    Expression<bool>? draft,
+    Expression<String>? url,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (repoKey != null) 'repo_key': repoKey,
+      if (label != null) 'label': label,
+      if (title != null) 'title': title,
+      if (author != null) 'author': author,
+      if (reviewState != null) 'review_state': reviewState,
+      if (ageDays != null) 'age_days': ageDays,
+      if (draft != null) 'draft': draft,
+      if (url != null) 'url': url,
+    });
+  }
+
+  RepoPullsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? repoKey,
+    Value<String>? label,
+    Value<String>? title,
+    Value<String>? author,
+    Value<String>? reviewState,
+    Value<int?>? ageDays,
+    Value<bool>? draft,
+    Value<String?>? url,
+  }) {
+    return RepoPullsCompanion(
+      id: id ?? this.id,
+      repoKey: repoKey ?? this.repoKey,
+      label: label ?? this.label,
+      title: title ?? this.title,
+      author: author ?? this.author,
+      reviewState: reviewState ?? this.reviewState,
+      ageDays: ageDays ?? this.ageDays,
+      draft: draft ?? this.draft,
+      url: url ?? this.url,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (repoKey.present) {
+      map['repo_key'] = Variable<String>(repoKey.value);
+    }
+    if (label.present) {
+      map['label'] = Variable<String>(label.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (author.present) {
+      map['author'] = Variable<String>(author.value);
+    }
+    if (reviewState.present) {
+      map['review_state'] = Variable<String>(reviewState.value);
+    }
+    if (ageDays.present) {
+      map['age_days'] = Variable<int>(ageDays.value);
+    }
+    if (draft.present) {
+      map['draft'] = Variable<bool>(draft.value);
+    }
+    if (url.present) {
+      map['url'] = Variable<String>(url.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RepoPullsCompanion(')
+          ..write('id: $id, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('label: $label, ')
+          ..write('title: $title, ')
+          ..write('author: $author, ')
+          ..write('reviewState: $reviewState, ')
+          ..write('ageDays: $ageDays, ')
+          ..write('draft: $draft, ')
+          ..write('url: $url')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $RepoRunsTable extends RepoRuns
+    with TableInfo<$RepoRunsTable, RepoRunRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $RepoRunsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _repoKeyMeta = const VerificationMeta(
+    'repoKey',
+  );
+  @override
+  late final GeneratedColumn<String> repoKey = GeneratedColumn<String>(
+    'repo_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _conclusionMeta = const VerificationMeta(
+    'conclusion',
+  );
+  @override
+  late final GeneratedColumn<String> conclusion = GeneratedColumn<String>(
+    'conclusion',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _branchMeta = const VerificationMeta('branch');
+  @override
+  late final GeneratedColumn<String> branch = GeneratedColumn<String>(
+    'branch',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _finishedAtMeta = const VerificationMeta(
+    'finishedAt',
+  );
+  @override
+  late final GeneratedColumn<int> finishedAt = GeneratedColumn<int>(
+    'finished_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _urlMeta = const VerificationMeta('url');
+  @override
+  late final GeneratedColumn<String> url = GeneratedColumn<String>(
+    'url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    repoKey,
+    name,
+    status,
+    conclusion,
+    branch,
+    finishedAt,
+    url,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'repo_runs';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<RepoRunRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('repo_key')) {
+      context.handle(
+        _repoKeyMeta,
+        repoKey.isAcceptableOrUnknown(data['repo_key']!, _repoKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_repoKeyMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('status')) {
+      context.handle(
+        _statusMeta,
+        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_statusMeta);
+    }
+    if (data.containsKey('conclusion')) {
+      context.handle(
+        _conclusionMeta,
+        conclusion.isAcceptableOrUnknown(data['conclusion']!, _conclusionMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_conclusionMeta);
+    }
+    if (data.containsKey('branch')) {
+      context.handle(
+        _branchMeta,
+        branch.isAcceptableOrUnknown(data['branch']!, _branchMeta),
+      );
+    }
+    if (data.containsKey('finished_at')) {
+      context.handle(
+        _finishedAtMeta,
+        finishedAt.isAcceptableOrUnknown(data['finished_at']!, _finishedAtMeta),
+      );
+    }
+    if (data.containsKey('url')) {
+      context.handle(
+        _urlMeta,
+        url.isAcceptableOrUnknown(data['url']!, _urlMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  RepoRunRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return RepoRunRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      repoKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_key'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      status: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status'],
+      )!,
+      conclusion: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}conclusion'],
+      )!,
+      branch: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}branch'],
+      ),
+      finishedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}finished_at'],
+      ),
+      url: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}url'],
+      ),
+    );
+  }
+
+  @override
+  $RepoRunsTable createAlias(String alias) {
+    return $RepoRunsTable(attachedDatabase, alias);
+  }
+}
+
+class RepoRunRow extends DataClass implements Insertable<RepoRunRow> {
+  final int id;
+  final String repoKey;
+  final String name;
+  final String status;
+  final String conclusion;
+  final String? branch;
+  final int? finishedAt;
+  final String? url;
+  const RepoRunRow({
+    required this.id,
+    required this.repoKey,
+    required this.name,
+    required this.status,
+    required this.conclusion,
+    this.branch,
+    this.finishedAt,
+    this.url,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['repo_key'] = Variable<String>(repoKey);
+    map['name'] = Variable<String>(name);
+    map['status'] = Variable<String>(status);
+    map['conclusion'] = Variable<String>(conclusion);
+    if (!nullToAbsent || branch != null) {
+      map['branch'] = Variable<String>(branch);
+    }
+    if (!nullToAbsent || finishedAt != null) {
+      map['finished_at'] = Variable<int>(finishedAt);
+    }
+    if (!nullToAbsent || url != null) {
+      map['url'] = Variable<String>(url);
+    }
+    return map;
+  }
+
+  RepoRunsCompanion toCompanion(bool nullToAbsent) {
+    return RepoRunsCompanion(
+      id: Value(id),
+      repoKey: Value(repoKey),
+      name: Value(name),
+      status: Value(status),
+      conclusion: Value(conclusion),
+      branch: branch == null && nullToAbsent
+          ? const Value.absent()
+          : Value(branch),
+      finishedAt: finishedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(finishedAt),
+      url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+    );
+  }
+
+  factory RepoRunRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return RepoRunRow(
+      id: serializer.fromJson<int>(json['id']),
+      repoKey: serializer.fromJson<String>(json['repoKey']),
+      name: serializer.fromJson<String>(json['name']),
+      status: serializer.fromJson<String>(json['status']),
+      conclusion: serializer.fromJson<String>(json['conclusion']),
+      branch: serializer.fromJson<String?>(json['branch']),
+      finishedAt: serializer.fromJson<int?>(json['finishedAt']),
+      url: serializer.fromJson<String?>(json['url']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'repoKey': serializer.toJson<String>(repoKey),
+      'name': serializer.toJson<String>(name),
+      'status': serializer.toJson<String>(status),
+      'conclusion': serializer.toJson<String>(conclusion),
+      'branch': serializer.toJson<String?>(branch),
+      'finishedAt': serializer.toJson<int?>(finishedAt),
+      'url': serializer.toJson<String?>(url),
+    };
+  }
+
+  RepoRunRow copyWith({
+    int? id,
+    String? repoKey,
+    String? name,
+    String? status,
+    String? conclusion,
+    Value<String?> branch = const Value.absent(),
+    Value<int?> finishedAt = const Value.absent(),
+    Value<String?> url = const Value.absent(),
+  }) => RepoRunRow(
+    id: id ?? this.id,
+    repoKey: repoKey ?? this.repoKey,
+    name: name ?? this.name,
+    status: status ?? this.status,
+    conclusion: conclusion ?? this.conclusion,
+    branch: branch.present ? branch.value : this.branch,
+    finishedAt: finishedAt.present ? finishedAt.value : this.finishedAt,
+    url: url.present ? url.value : this.url,
+  );
+  RepoRunRow copyWithCompanion(RepoRunsCompanion data) {
+    return RepoRunRow(
+      id: data.id.present ? data.id.value : this.id,
+      repoKey: data.repoKey.present ? data.repoKey.value : this.repoKey,
+      name: data.name.present ? data.name.value : this.name,
+      status: data.status.present ? data.status.value : this.status,
+      conclusion: data.conclusion.present
+          ? data.conclusion.value
+          : this.conclusion,
+      branch: data.branch.present ? data.branch.value : this.branch,
+      finishedAt: data.finishedAt.present
+          ? data.finishedAt.value
+          : this.finishedAt,
+      url: data.url.present ? data.url.value : this.url,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RepoRunRow(')
+          ..write('id: $id, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('name: $name, ')
+          ..write('status: $status, ')
+          ..write('conclusion: $conclusion, ')
+          ..write('branch: $branch, ')
+          ..write('finishedAt: $finishedAt, ')
+          ..write('url: $url')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    repoKey,
+    name,
+    status,
+    conclusion,
+    branch,
+    finishedAt,
+    url,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is RepoRunRow &&
+          other.id == this.id &&
+          other.repoKey == this.repoKey &&
+          other.name == this.name &&
+          other.status == this.status &&
+          other.conclusion == this.conclusion &&
+          other.branch == this.branch &&
+          other.finishedAt == this.finishedAt &&
+          other.url == this.url);
+}
+
+class RepoRunsCompanion extends UpdateCompanion<RepoRunRow> {
+  final Value<int> id;
+  final Value<String> repoKey;
+  final Value<String> name;
+  final Value<String> status;
+  final Value<String> conclusion;
+  final Value<String?> branch;
+  final Value<int?> finishedAt;
+  final Value<String?> url;
+  const RepoRunsCompanion({
+    this.id = const Value.absent(),
+    this.repoKey = const Value.absent(),
+    this.name = const Value.absent(),
+    this.status = const Value.absent(),
+    this.conclusion = const Value.absent(),
+    this.branch = const Value.absent(),
+    this.finishedAt = const Value.absent(),
+    this.url = const Value.absent(),
+  });
+  RepoRunsCompanion.insert({
+    this.id = const Value.absent(),
+    required String repoKey,
+    required String name,
+    required String status,
+    required String conclusion,
+    this.branch = const Value.absent(),
+    this.finishedAt = const Value.absent(),
+    this.url = const Value.absent(),
+  }) : repoKey = Value(repoKey),
+       name = Value(name),
+       status = Value(status),
+       conclusion = Value(conclusion);
+  static Insertable<RepoRunRow> custom({
+    Expression<int>? id,
+    Expression<String>? repoKey,
+    Expression<String>? name,
+    Expression<String>? status,
+    Expression<String>? conclusion,
+    Expression<String>? branch,
+    Expression<int>? finishedAt,
+    Expression<String>? url,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (repoKey != null) 'repo_key': repoKey,
+      if (name != null) 'name': name,
+      if (status != null) 'status': status,
+      if (conclusion != null) 'conclusion': conclusion,
+      if (branch != null) 'branch': branch,
+      if (finishedAt != null) 'finished_at': finishedAt,
+      if (url != null) 'url': url,
+    });
+  }
+
+  RepoRunsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? repoKey,
+    Value<String>? name,
+    Value<String>? status,
+    Value<String>? conclusion,
+    Value<String?>? branch,
+    Value<int?>? finishedAt,
+    Value<String?>? url,
+  }) {
+    return RepoRunsCompanion(
+      id: id ?? this.id,
+      repoKey: repoKey ?? this.repoKey,
+      name: name ?? this.name,
+      status: status ?? this.status,
+      conclusion: conclusion ?? this.conclusion,
+      branch: branch ?? this.branch,
+      finishedAt: finishedAt ?? this.finishedAt,
+      url: url ?? this.url,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (repoKey.present) {
+      map['repo_key'] = Variable<String>(repoKey.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (conclusion.present) {
+      map['conclusion'] = Variable<String>(conclusion.value);
+    }
+    if (branch.present) {
+      map['branch'] = Variable<String>(branch.value);
+    }
+    if (finishedAt.present) {
+      map['finished_at'] = Variable<int>(finishedAt.value);
+    }
+    if (url.present) {
+      map['url'] = Variable<String>(url.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RepoRunsCompanion(')
+          ..write('id: $id, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('name: $name, ')
+          ..write('status: $status, ')
+          ..write('conclusion: $conclusion, ')
+          ..write('branch: $branch, ')
+          ..write('finishedAt: $finishedAt, ')
+          ..write('url: $url')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $RepoReleasesTable extends RepoReleases
+    with TableInfo<$RepoReleasesTable, RepoReleaseRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $RepoReleasesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _repoKeyMeta = const VerificationMeta(
+    'repoKey',
+  );
+  @override
+  late final GeneratedColumn<String> repoKey = GeneratedColumn<String>(
+    'repo_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _tagMeta = const VerificationMeta('tag');
+  @override
+  late final GeneratedColumn<String> tag = GeneratedColumn<String>(
+    'tag',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _authorMeta = const VerificationMeta('author');
+  @override
+  late final GeneratedColumn<String> author = GeneratedColumn<String>(
+    'author',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _publishedAtMeta = const VerificationMeta(
+    'publishedAt',
+  );
+  @override
+  late final GeneratedColumn<int> publishedAt = GeneratedColumn<int>(
+    'published_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _urlMeta = const VerificationMeta('url');
+  @override
+  late final GeneratedColumn<String> url = GeneratedColumn<String>(
+    'url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    repoKey,
+    tag,
+    name,
+    author,
+    publishedAt,
+    url,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'repo_releases';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<RepoReleaseRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('repo_key')) {
+      context.handle(
+        _repoKeyMeta,
+        repoKey.isAcceptableOrUnknown(data['repo_key']!, _repoKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_repoKeyMeta);
+    }
+    if (data.containsKey('tag')) {
+      context.handle(
+        _tagMeta,
+        tag.isAcceptableOrUnknown(data['tag']!, _tagMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_tagMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    }
+    if (data.containsKey('author')) {
+      context.handle(
+        _authorMeta,
+        author.isAcceptableOrUnknown(data['author']!, _authorMeta),
+      );
+    }
+    if (data.containsKey('published_at')) {
+      context.handle(
+        _publishedAtMeta,
+        publishedAt.isAcceptableOrUnknown(
+          data['published_at']!,
+          _publishedAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('url')) {
+      context.handle(
+        _urlMeta,
+        url.isAcceptableOrUnknown(data['url']!, _urlMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  RepoReleaseRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return RepoReleaseRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      repoKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_key'],
+      )!,
+      tag: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}tag'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      ),
+      author: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}author'],
+      ),
+      publishedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}published_at'],
+      ),
+      url: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}url'],
+      ),
+    );
+  }
+
+  @override
+  $RepoReleasesTable createAlias(String alias) {
+    return $RepoReleasesTable(attachedDatabase, alias);
+  }
+}
+
+class RepoReleaseRow extends DataClass implements Insertable<RepoReleaseRow> {
+  final int id;
+  final String repoKey;
+  final String tag;
+  final String? name;
+  final String? author;
+  final int? publishedAt;
+  final String? url;
+  const RepoReleaseRow({
+    required this.id,
+    required this.repoKey,
+    required this.tag,
+    this.name,
+    this.author,
+    this.publishedAt,
+    this.url,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['repo_key'] = Variable<String>(repoKey);
+    map['tag'] = Variable<String>(tag);
+    if (!nullToAbsent || name != null) {
+      map['name'] = Variable<String>(name);
+    }
+    if (!nullToAbsent || author != null) {
+      map['author'] = Variable<String>(author);
+    }
+    if (!nullToAbsent || publishedAt != null) {
+      map['published_at'] = Variable<int>(publishedAt);
+    }
+    if (!nullToAbsent || url != null) {
+      map['url'] = Variable<String>(url);
+    }
+    return map;
+  }
+
+  RepoReleasesCompanion toCompanion(bool nullToAbsent) {
+    return RepoReleasesCompanion(
+      id: Value(id),
+      repoKey: Value(repoKey),
+      tag: Value(tag),
+      name: name == null && nullToAbsent ? const Value.absent() : Value(name),
+      author: author == null && nullToAbsent
+          ? const Value.absent()
+          : Value(author),
+      publishedAt: publishedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(publishedAt),
+      url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+    );
+  }
+
+  factory RepoReleaseRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return RepoReleaseRow(
+      id: serializer.fromJson<int>(json['id']),
+      repoKey: serializer.fromJson<String>(json['repoKey']),
+      tag: serializer.fromJson<String>(json['tag']),
+      name: serializer.fromJson<String?>(json['name']),
+      author: serializer.fromJson<String?>(json['author']),
+      publishedAt: serializer.fromJson<int?>(json['publishedAt']),
+      url: serializer.fromJson<String?>(json['url']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'repoKey': serializer.toJson<String>(repoKey),
+      'tag': serializer.toJson<String>(tag),
+      'name': serializer.toJson<String?>(name),
+      'author': serializer.toJson<String?>(author),
+      'publishedAt': serializer.toJson<int?>(publishedAt),
+      'url': serializer.toJson<String?>(url),
+    };
+  }
+
+  RepoReleaseRow copyWith({
+    int? id,
+    String? repoKey,
+    String? tag,
+    Value<String?> name = const Value.absent(),
+    Value<String?> author = const Value.absent(),
+    Value<int?> publishedAt = const Value.absent(),
+    Value<String?> url = const Value.absent(),
+  }) => RepoReleaseRow(
+    id: id ?? this.id,
+    repoKey: repoKey ?? this.repoKey,
+    tag: tag ?? this.tag,
+    name: name.present ? name.value : this.name,
+    author: author.present ? author.value : this.author,
+    publishedAt: publishedAt.present ? publishedAt.value : this.publishedAt,
+    url: url.present ? url.value : this.url,
+  );
+  RepoReleaseRow copyWithCompanion(RepoReleasesCompanion data) {
+    return RepoReleaseRow(
+      id: data.id.present ? data.id.value : this.id,
+      repoKey: data.repoKey.present ? data.repoKey.value : this.repoKey,
+      tag: data.tag.present ? data.tag.value : this.tag,
+      name: data.name.present ? data.name.value : this.name,
+      author: data.author.present ? data.author.value : this.author,
+      publishedAt: data.publishedAt.present
+          ? data.publishedAt.value
+          : this.publishedAt,
+      url: data.url.present ? data.url.value : this.url,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RepoReleaseRow(')
+          ..write('id: $id, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('tag: $tag, ')
+          ..write('name: $name, ')
+          ..write('author: $author, ')
+          ..write('publishedAt: $publishedAt, ')
+          ..write('url: $url')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, repoKey, tag, name, author, publishedAt, url);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is RepoReleaseRow &&
+          other.id == this.id &&
+          other.repoKey == this.repoKey &&
+          other.tag == this.tag &&
+          other.name == this.name &&
+          other.author == this.author &&
+          other.publishedAt == this.publishedAt &&
+          other.url == this.url);
+}
+
+class RepoReleasesCompanion extends UpdateCompanion<RepoReleaseRow> {
+  final Value<int> id;
+  final Value<String> repoKey;
+  final Value<String> tag;
+  final Value<String?> name;
+  final Value<String?> author;
+  final Value<int?> publishedAt;
+  final Value<String?> url;
+  const RepoReleasesCompanion({
+    this.id = const Value.absent(),
+    this.repoKey = const Value.absent(),
+    this.tag = const Value.absent(),
+    this.name = const Value.absent(),
+    this.author = const Value.absent(),
+    this.publishedAt = const Value.absent(),
+    this.url = const Value.absent(),
+  });
+  RepoReleasesCompanion.insert({
+    this.id = const Value.absent(),
+    required String repoKey,
+    required String tag,
+    this.name = const Value.absent(),
+    this.author = const Value.absent(),
+    this.publishedAt = const Value.absent(),
+    this.url = const Value.absent(),
+  }) : repoKey = Value(repoKey),
+       tag = Value(tag);
+  static Insertable<RepoReleaseRow> custom({
+    Expression<int>? id,
+    Expression<String>? repoKey,
+    Expression<String>? tag,
+    Expression<String>? name,
+    Expression<String>? author,
+    Expression<int>? publishedAt,
+    Expression<String>? url,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (repoKey != null) 'repo_key': repoKey,
+      if (tag != null) 'tag': tag,
+      if (name != null) 'name': name,
+      if (author != null) 'author': author,
+      if (publishedAt != null) 'published_at': publishedAt,
+      if (url != null) 'url': url,
+    });
+  }
+
+  RepoReleasesCompanion copyWith({
+    Value<int>? id,
+    Value<String>? repoKey,
+    Value<String>? tag,
+    Value<String?>? name,
+    Value<String?>? author,
+    Value<int?>? publishedAt,
+    Value<String?>? url,
+  }) {
+    return RepoReleasesCompanion(
+      id: id ?? this.id,
+      repoKey: repoKey ?? this.repoKey,
+      tag: tag ?? this.tag,
+      name: name ?? this.name,
+      author: author ?? this.author,
+      publishedAt: publishedAt ?? this.publishedAt,
+      url: url ?? this.url,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (repoKey.present) {
+      map['repo_key'] = Variable<String>(repoKey.value);
+    }
+    if (tag.present) {
+      map['tag'] = Variable<String>(tag.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (author.present) {
+      map['author'] = Variable<String>(author.value);
+    }
+    if (publishedAt.present) {
+      map['published_at'] = Variable<int>(publishedAt.value);
+    }
+    if (url.present) {
+      map['url'] = Variable<String>(url.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RepoReleasesCompanion(')
+          ..write('id: $id, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('tag: $tag, ')
+          ..write('name: $name, ')
+          ..write('author: $author, ')
+          ..write('publishedAt: $publishedAt, ')
+          ..write('url: $url')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -1889,6 +3380,9 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $AppMetaTable appMeta = $AppMetaTable(this);
   late final $ActivityEventsTable activityEvents = $ActivityEventsTable(this);
   late final $AttentionItemsTable attentionItems = $AttentionItemsTable(this);
+  late final $RepoPullsTable repoPulls = $RepoPullsTable(this);
+  late final $RepoRunsTable repoRuns = $RepoRunsTable(this);
+  late final $RepoReleasesTable repoReleases = $RepoReleasesTable(this);
   late final Index idxMetricSnapshotsRepoKey = Index(
     'idx_metric_snapshots_repo_key',
     'CREATE INDEX idx_metric_snapshots_repo_key ON metric_snapshots (repo_key)',
@@ -1909,6 +3403,18 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'idx_attention_items_repo_display',
     'CREATE INDEX idx_attention_items_repo_display ON attention_items (repo_display)',
   );
+  late final Index idxRepoPullsRepoKey = Index(
+    'idx_repo_pulls_repo_key',
+    'CREATE INDEX idx_repo_pulls_repo_key ON repo_pulls (repo_key)',
+  );
+  late final Index idxRepoRunsRepoKey = Index(
+    'idx_repo_runs_repo_key',
+    'CREATE INDEX idx_repo_runs_repo_key ON repo_runs (repo_key)',
+  );
+  late final Index idxRepoReleasesRepoKey = Index(
+    'idx_repo_releases_repo_key',
+    'CREATE INDEX idx_repo_releases_repo_key ON repo_releases (repo_key)',
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -1918,11 +3424,17 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     appMeta,
     activityEvents,
     attentionItems,
+    repoPulls,
+    repoRuns,
+    repoReleases,
     idxMetricSnapshotsRepoKey,
     idxActivityEventsRepoKey,
     idxActivityEventsOccurredAt,
     idxActivityEventsRepoEvent,
     idxAttentionItemsRepoDisplay,
+    idxRepoPullsRepoKey,
+    idxRepoRunsRepoKey,
+    idxRepoReleasesRepoKey,
   ];
 }
 
@@ -2905,6 +4417,761 @@ typedef $$AttentionItemsTableProcessedTableManager =
       AttentionItemRow,
       PrefetchHooks Function()
     >;
+typedef $$RepoPullsTableCreateCompanionBuilder =
+    RepoPullsCompanion Function({
+      Value<int> id,
+      required String repoKey,
+      required String label,
+      required String title,
+      required String author,
+      required String reviewState,
+      Value<int?> ageDays,
+      required bool draft,
+      Value<String?> url,
+    });
+typedef $$RepoPullsTableUpdateCompanionBuilder =
+    RepoPullsCompanion Function({
+      Value<int> id,
+      Value<String> repoKey,
+      Value<String> label,
+      Value<String> title,
+      Value<String> author,
+      Value<String> reviewState,
+      Value<int?> ageDays,
+      Value<bool> draft,
+      Value<String?> url,
+    });
+
+class $$RepoPullsTableFilterComposer
+    extends Composer<_$AppDatabase, $RepoPullsTable> {
+  $$RepoPullsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get label => $composableBuilder(
+    column: $table.label,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get author => $composableBuilder(
+    column: $table.author,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get reviewState => $composableBuilder(
+    column: $table.reviewState,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get ageDays => $composableBuilder(
+    column: $table.ageDays,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get draft => $composableBuilder(
+    column: $table.draft,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$RepoPullsTableOrderingComposer
+    extends Composer<_$AppDatabase, $RepoPullsTable> {
+  $$RepoPullsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get label => $composableBuilder(
+    column: $table.label,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get author => $composableBuilder(
+    column: $table.author,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get reviewState => $composableBuilder(
+    column: $table.reviewState,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get ageDays => $composableBuilder(
+    column: $table.ageDays,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get draft => $composableBuilder(
+    column: $table.draft,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$RepoPullsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $RepoPullsTable> {
+  $$RepoPullsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get repoKey =>
+      $composableBuilder(column: $table.repoKey, builder: (column) => column);
+
+  GeneratedColumn<String> get label =>
+      $composableBuilder(column: $table.label, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get author =>
+      $composableBuilder(column: $table.author, builder: (column) => column);
+
+  GeneratedColumn<String> get reviewState => $composableBuilder(
+    column: $table.reviewState,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get ageDays =>
+      $composableBuilder(column: $table.ageDays, builder: (column) => column);
+
+  GeneratedColumn<bool> get draft =>
+      $composableBuilder(column: $table.draft, builder: (column) => column);
+
+  GeneratedColumn<String> get url =>
+      $composableBuilder(column: $table.url, builder: (column) => column);
+}
+
+class $$RepoPullsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $RepoPullsTable,
+          RepoPrRow,
+          $$RepoPullsTableFilterComposer,
+          $$RepoPullsTableOrderingComposer,
+          $$RepoPullsTableAnnotationComposer,
+          $$RepoPullsTableCreateCompanionBuilder,
+          $$RepoPullsTableUpdateCompanionBuilder,
+          (
+            RepoPrRow,
+            BaseReferences<_$AppDatabase, $RepoPullsTable, RepoPrRow>,
+          ),
+          RepoPrRow,
+          PrefetchHooks Function()
+        > {
+  $$RepoPullsTableTableManager(_$AppDatabase db, $RepoPullsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$RepoPullsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$RepoPullsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$RepoPullsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> repoKey = const Value.absent(),
+                Value<String> label = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<String> author = const Value.absent(),
+                Value<String> reviewState = const Value.absent(),
+                Value<int?> ageDays = const Value.absent(),
+                Value<bool> draft = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+              }) => RepoPullsCompanion(
+                id: id,
+                repoKey: repoKey,
+                label: label,
+                title: title,
+                author: author,
+                reviewState: reviewState,
+                ageDays: ageDays,
+                draft: draft,
+                url: url,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String repoKey,
+                required String label,
+                required String title,
+                required String author,
+                required String reviewState,
+                Value<int?> ageDays = const Value.absent(),
+                required bool draft,
+                Value<String?> url = const Value.absent(),
+              }) => RepoPullsCompanion.insert(
+                id: id,
+                repoKey: repoKey,
+                label: label,
+                title: title,
+                author: author,
+                reviewState: reviewState,
+                ageDays: ageDays,
+                draft: draft,
+                url: url,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$RepoPullsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $RepoPullsTable,
+      RepoPrRow,
+      $$RepoPullsTableFilterComposer,
+      $$RepoPullsTableOrderingComposer,
+      $$RepoPullsTableAnnotationComposer,
+      $$RepoPullsTableCreateCompanionBuilder,
+      $$RepoPullsTableUpdateCompanionBuilder,
+      (RepoPrRow, BaseReferences<_$AppDatabase, $RepoPullsTable, RepoPrRow>),
+      RepoPrRow,
+      PrefetchHooks Function()
+    >;
+typedef $$RepoRunsTableCreateCompanionBuilder =
+    RepoRunsCompanion Function({
+      Value<int> id,
+      required String repoKey,
+      required String name,
+      required String status,
+      required String conclusion,
+      Value<String?> branch,
+      Value<int?> finishedAt,
+      Value<String?> url,
+    });
+typedef $$RepoRunsTableUpdateCompanionBuilder =
+    RepoRunsCompanion Function({
+      Value<int> id,
+      Value<String> repoKey,
+      Value<String> name,
+      Value<String> status,
+      Value<String> conclusion,
+      Value<String?> branch,
+      Value<int?> finishedAt,
+      Value<String?> url,
+    });
+
+class $$RepoRunsTableFilterComposer
+    extends Composer<_$AppDatabase, $RepoRunsTable> {
+  $$RepoRunsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get conclusion => $composableBuilder(
+    column: $table.conclusion,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get branch => $composableBuilder(
+    column: $table.branch,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get finishedAt => $composableBuilder(
+    column: $table.finishedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$RepoRunsTableOrderingComposer
+    extends Composer<_$AppDatabase, $RepoRunsTable> {
+  $$RepoRunsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get conclusion => $composableBuilder(
+    column: $table.conclusion,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get branch => $composableBuilder(
+    column: $table.branch,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get finishedAt => $composableBuilder(
+    column: $table.finishedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$RepoRunsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $RepoRunsTable> {
+  $$RepoRunsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get repoKey =>
+      $composableBuilder(column: $table.repoKey, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<String> get conclusion => $composableBuilder(
+    column: $table.conclusion,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get branch =>
+      $composableBuilder(column: $table.branch, builder: (column) => column);
+
+  GeneratedColumn<int> get finishedAt => $composableBuilder(
+    column: $table.finishedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get url =>
+      $composableBuilder(column: $table.url, builder: (column) => column);
+}
+
+class $$RepoRunsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $RepoRunsTable,
+          RepoRunRow,
+          $$RepoRunsTableFilterComposer,
+          $$RepoRunsTableOrderingComposer,
+          $$RepoRunsTableAnnotationComposer,
+          $$RepoRunsTableCreateCompanionBuilder,
+          $$RepoRunsTableUpdateCompanionBuilder,
+          (
+            RepoRunRow,
+            BaseReferences<_$AppDatabase, $RepoRunsTable, RepoRunRow>,
+          ),
+          RepoRunRow,
+          PrefetchHooks Function()
+        > {
+  $$RepoRunsTableTableManager(_$AppDatabase db, $RepoRunsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$RepoRunsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$RepoRunsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$RepoRunsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> repoKey = const Value.absent(),
+                Value<String> name = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<String> conclusion = const Value.absent(),
+                Value<String?> branch = const Value.absent(),
+                Value<int?> finishedAt = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+              }) => RepoRunsCompanion(
+                id: id,
+                repoKey: repoKey,
+                name: name,
+                status: status,
+                conclusion: conclusion,
+                branch: branch,
+                finishedAt: finishedAt,
+                url: url,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String repoKey,
+                required String name,
+                required String status,
+                required String conclusion,
+                Value<String?> branch = const Value.absent(),
+                Value<int?> finishedAt = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+              }) => RepoRunsCompanion.insert(
+                id: id,
+                repoKey: repoKey,
+                name: name,
+                status: status,
+                conclusion: conclusion,
+                branch: branch,
+                finishedAt: finishedAt,
+                url: url,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$RepoRunsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $RepoRunsTable,
+      RepoRunRow,
+      $$RepoRunsTableFilterComposer,
+      $$RepoRunsTableOrderingComposer,
+      $$RepoRunsTableAnnotationComposer,
+      $$RepoRunsTableCreateCompanionBuilder,
+      $$RepoRunsTableUpdateCompanionBuilder,
+      (RepoRunRow, BaseReferences<_$AppDatabase, $RepoRunsTable, RepoRunRow>),
+      RepoRunRow,
+      PrefetchHooks Function()
+    >;
+typedef $$RepoReleasesTableCreateCompanionBuilder =
+    RepoReleasesCompanion Function({
+      Value<int> id,
+      required String repoKey,
+      required String tag,
+      Value<String?> name,
+      Value<String?> author,
+      Value<int?> publishedAt,
+      Value<String?> url,
+    });
+typedef $$RepoReleasesTableUpdateCompanionBuilder =
+    RepoReleasesCompanion Function({
+      Value<int> id,
+      Value<String> repoKey,
+      Value<String> tag,
+      Value<String?> name,
+      Value<String?> author,
+      Value<int?> publishedAt,
+      Value<String?> url,
+    });
+
+class $$RepoReleasesTableFilterComposer
+    extends Composer<_$AppDatabase, $RepoReleasesTable> {
+  $$RepoReleasesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get tag => $composableBuilder(
+    column: $table.tag,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get author => $composableBuilder(
+    column: $table.author,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get publishedAt => $composableBuilder(
+    column: $table.publishedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$RepoReleasesTableOrderingComposer
+    extends Composer<_$AppDatabase, $RepoReleasesTable> {
+  $$RepoReleasesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get tag => $composableBuilder(
+    column: $table.tag,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get author => $composableBuilder(
+    column: $table.author,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get publishedAt => $composableBuilder(
+    column: $table.publishedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$RepoReleasesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $RepoReleasesTable> {
+  $$RepoReleasesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get repoKey =>
+      $composableBuilder(column: $table.repoKey, builder: (column) => column);
+
+  GeneratedColumn<String> get tag =>
+      $composableBuilder(column: $table.tag, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<String> get author =>
+      $composableBuilder(column: $table.author, builder: (column) => column);
+
+  GeneratedColumn<int> get publishedAt => $composableBuilder(
+    column: $table.publishedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get url =>
+      $composableBuilder(column: $table.url, builder: (column) => column);
+}
+
+class $$RepoReleasesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $RepoReleasesTable,
+          RepoReleaseRow,
+          $$RepoReleasesTableFilterComposer,
+          $$RepoReleasesTableOrderingComposer,
+          $$RepoReleasesTableAnnotationComposer,
+          $$RepoReleasesTableCreateCompanionBuilder,
+          $$RepoReleasesTableUpdateCompanionBuilder,
+          (
+            RepoReleaseRow,
+            BaseReferences<_$AppDatabase, $RepoReleasesTable, RepoReleaseRow>,
+          ),
+          RepoReleaseRow,
+          PrefetchHooks Function()
+        > {
+  $$RepoReleasesTableTableManager(_$AppDatabase db, $RepoReleasesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$RepoReleasesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$RepoReleasesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$RepoReleasesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> repoKey = const Value.absent(),
+                Value<String> tag = const Value.absent(),
+                Value<String?> name = const Value.absent(),
+                Value<String?> author = const Value.absent(),
+                Value<int?> publishedAt = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+              }) => RepoReleasesCompanion(
+                id: id,
+                repoKey: repoKey,
+                tag: tag,
+                name: name,
+                author: author,
+                publishedAt: publishedAt,
+                url: url,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String repoKey,
+                required String tag,
+                Value<String?> name = const Value.absent(),
+                Value<String?> author = const Value.absent(),
+                Value<int?> publishedAt = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+              }) => RepoReleasesCompanion.insert(
+                id: id,
+                repoKey: repoKey,
+                tag: tag,
+                name: name,
+                author: author,
+                publishedAt: publishedAt,
+                url: url,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$RepoReleasesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $RepoReleasesTable,
+      RepoReleaseRow,
+      $$RepoReleasesTableFilterComposer,
+      $$RepoReleasesTableOrderingComposer,
+      $$RepoReleasesTableAnnotationComposer,
+      $$RepoReleasesTableCreateCompanionBuilder,
+      $$RepoReleasesTableUpdateCompanionBuilder,
+      (
+        RepoReleaseRow,
+        BaseReferences<_$AppDatabase, $RepoReleasesTable, RepoReleaseRow>,
+      ),
+      RepoReleaseRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -2917,4 +5184,10 @@ class $AppDatabaseManager {
       $$ActivityEventsTableTableManager(_db, _db.activityEvents);
   $$AttentionItemsTableTableManager get attentionItems =>
       $$AttentionItemsTableTableManager(_db, _db.attentionItems);
+  $$RepoPullsTableTableManager get repoPulls =>
+      $$RepoPullsTableTableManager(_db, _db.repoPulls);
+  $$RepoRunsTableTableManager get repoRuns =>
+      $$RepoRunsTableTableManager(_db, _db.repoRuns);
+  $$RepoReleasesTableTableManager get repoReleases =>
+      $$RepoReleasesTableTableManager(_db, _db.repoReleases);
 }

--- a/lib/manage_repos_page.dart
+++ b/lib/manage_repos_page.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'register_github_repo.dart';
 import 'register_ado_repo.dart';
 import 'activity_event_store.dart';
+import 'repo_detail_store.dart';
 import 'ignore_store.dart';
 import 'manage_ignored_page.dart';
 import 'metric_store.dart';
@@ -201,6 +202,7 @@ class _ManageReposPageState extends State<ManageReposPage> {
       if (!stillMonitored) {
         await MetricStore.removeRepo(repoKey);
         await ActivityEventStore.removeRepo(repoKey);
+        await RepoDetailStore.removeRepo(repoKey);
         await TeamStore.removeRepoFromAll(repoKey);
       }
     }

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -112,7 +112,11 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       );
       if (!mounted || seq != _loadSeq) return;
       List<ActivityEvent> timeline = feed.events;
-      if (timeline.isEmpty) {
+      // Fall back to cached events only when the fresh fetch came back empty
+      // BECAUSE a source failed (offline/partial) — not when the repo is
+      // genuinely quiet, so a now-empty repo doesn't keep showing a stale
+      // timeline.
+      if (timeline.isEmpty && feed.failedSources > 0) {
         final cachedEvents = await ActivityEventStore.cached();
         if (!mounted || seq != _loadSeq) return;
         timeline = cachedEvents

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -65,14 +65,18 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       // Phase A: render cached detail + this repo's cached timeline events
       // immediately so a cold start / offline open isn't a blank spinner.
       if (!_hasContent) {
-        final cachedDetail = await RepoDetailStore.cached(
-          _repo.repoKey,
-          releasesSupported: _releasesSupported,
-        );
-        final repoEvents = await ActivityEventStore.cached(
-          repoKey: _repo.repoKey,
-        );
+        // Run the two cache reads concurrently to cut cold-start latency; the
+        // seq/mounted guards below still apply.
+        final cachedResults = await Future.wait([
+          RepoDetailStore.cached(
+            _repo.repoKey,
+            releasesSupported: _releasesSupported,
+          ),
+          ActivityEventStore.cached(repoKey: _repo.repoKey),
+        ]);
         if (!mounted || seq != _loadSeq) return;
+        final cachedDetail = cachedResults[0] as RepoDetailData;
+        final repoEvents = cachedResults[1] as List<ActivityEvent>;
         if (cachedDetail.pulls.isNotEmpty ||
             cachedDetail.ci.isNotEmpty ||
             cachedDetail.releases.isNotEmpty ||

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -69,11 +69,10 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
           _repo.repoKey,
           releasesSupported: _releasesSupported,
         );
-        final cachedEvents = await ActivityEventStore.cached();
+        final repoEvents = await ActivityEventStore.cached(
+          repoKey: _repo.repoKey,
+        );
         if (!mounted || seq != _loadSeq) return;
-        final repoEvents = cachedEvents
-            .where((e) => e.repoKey == _repo.repoKey)
-            .toList();
         if (cachedDetail.pulls.isNotEmpty ||
             cachedDetail.ci.isNotEmpty ||
             cachedDetail.releases.isNotEmpty ||
@@ -112,16 +111,13 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       );
       if (!mounted || seq != _loadSeq) return;
       List<ActivityEvent> timeline = feed.events;
-      // Fall back to cached events only when the fresh fetch came back empty
-      // BECAUSE a source failed (offline/partial) — not when the repo is
-      // genuinely quiet, so a now-empty repo doesn't keep showing a stale
-      // timeline.
+      // Fall back to the cached timeline only when the fresh fetch came back
+      // empty BECAUSE a source failed (offline/partial) — not when the repo is
+      // genuinely quiet, so a now-empty repo doesn't keep showing stale events.
+      // Reuse the events already on screen (loaded in Phase A, or a prior
+      // render) instead of re-querying the DB.
       if (timeline.isEmpty && feed.failedSources > 0) {
-        final cachedEvents = await ActivityEventStore.cached();
-        if (!mounted || seq != _loadSeq) return;
-        timeline = cachedEvents
-            .where((e) => e.repoKey == _repo.repoKey)
-            .toList();
+        timeline = _events;
       }
       setState(() {
         _data = RepoDetailData(

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -3,10 +3,12 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'activity_event.dart';
 import 'activity_event_list.dart';
+import 'activity_event_store.dart';
 import 'activity_feed_service.dart';
 import 'activity_service.dart';
 import 'app_http.dart';
 import 'repo_detail_service.dart';
+import 'repo_detail_store.dart';
 
 /// Per-repository drill-down: open pull requests (with review state), CI
 /// history, releases, and a recent-activity timeline, plus contributors.
@@ -24,10 +26,28 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
   List<ActivityEvent> _events = const [];
   int _feedFailed = 0;
   bool _feedTruncated = false;
-  bool _loading = true;
+
+  /// A load (cache render + network refresh) is in flight. Gates the manual
+  /// Refresh action so overlapping fetches can't stack; cache-first renders
+  /// still update the UI underneath.
+  bool _refreshing = true;
   String? _error;
 
+  // Guards against a stale in-flight load applying after a newer one.
+  int _loadSeq = 0;
+
   RepoActivity get _repo => widget.repo;
+
+  /// True once anything (detail or timeline) is on screen.
+  bool get _hasContent =>
+      _events.isNotEmpty ||
+      _data.pulls.isNotEmpty ||
+      _data.ci.isNotEmpty ||
+      _data.releases.isNotEmpty;
+
+  /// Full-screen spinner only while a load is in flight and nothing is cached
+  /// to show yet.
+  bool get _showSpinner => _refreshing && !_hasContent && _error == null;
 
   @override
   void initState() {
@@ -36,11 +56,36 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
   }
 
   Future<void> _load() async {
+    final seq = ++_loadSeq;
     setState(() {
-      _loading = true;
+      _refreshing = true;
       _error = null;
     });
     try {
+      // Phase A: render cached detail + this repo's cached timeline events
+      // immediately so a cold start / offline open isn't a blank spinner.
+      if (!_hasContent) {
+        final cachedDetail = await RepoDetailStore.cached(
+          _repo.repoKey,
+          releasesSupported: _releasesSupported,
+        );
+        final cachedEvents = await ActivityEventStore.cached();
+        if (!mounted || seq != _loadSeq) return;
+        final repoEvents = cachedEvents
+            .where((e) => e.repoKey == _repo.repoKey)
+            .toList();
+        if (cachedDetail.pulls.isNotEmpty ||
+            cachedDetail.ci.isNotEmpty ||
+            cachedDetail.releases.isNotEmpty ||
+            repoEvents.isNotEmpty) {
+          setState(() {
+            _data = cachedDetail;
+            _events = repoEvents;
+          });
+        }
+      }
+
+      // Phase B: refresh from the network and persist the detail snapshot.
       final detailFuture = RepoDetailService.load(
         repoKey: _repo.repoKey,
         provider: _repo.provider,
@@ -51,25 +96,65 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
         onlyRepoKeys: {_repo.repoKey},
       );
       final results = await Future.wait([detailFuture, feedFuture]);
-      if (!mounted) return;
+      if (!mounted || seq != _loadSeq) return;
+      final freshDetail = results[0] as RepoDetailData;
+      final feed = results[1] as ActivityFeedResult;
+      await RepoDetailStore.save(_repo.repoKey, freshDetail);
+      if (!mounted || seq != _loadSeq) return;
+      // Render the persisted detail (which keeps last-known-good rows for any
+      // source that failed this round) but carry the fresh per-source failure
+      // flags so each tab still shows "couldn't load". For the timeline, prefer
+      // the fresh scoped fetch and fall back to the cache when it's empty
+      // (offline), so it never blanks.
+      final mergedDetail = await RepoDetailStore.cached(
+        _repo.repoKey,
+        releasesSupported: _releasesSupported,
+      );
+      if (!mounted || seq != _loadSeq) return;
+      List<ActivityEvent> timeline = feed.events;
+      if (timeline.isEmpty) {
+        final cachedEvents = await ActivityEventStore.cached();
+        if (!mounted || seq != _loadSeq) return;
+        timeline = cachedEvents
+            .where((e) => e.repoKey == _repo.repoKey)
+            .toList();
+      }
       setState(() {
-        _data = results[0] as RepoDetailData;
-        final feed = results[1] as ActivityFeedResult;
-        _events = feed.events;
+        _data = RepoDetailData(
+          pulls: mergedDetail.pulls,
+          ci: mergedDetail.ci,
+          releases: mergedDetail.releases,
+          releasesSupported: _releasesSupported,
+          pullsFailed: freshDetail.pullsFailed,
+          ciFailed: freshDetail.ciFailed,
+          releasesFailed: freshDetail.releasesFailed,
+        );
+        _events = timeline;
         _feedFailed = feed.failedSources;
         _feedTruncated = feed.truncated;
-        _loading = false;
+        _refreshing = false;
       });
     } catch (e) {
       debugPrint('RepoDetail failed to load: $e');
-      if (!mounted) return;
+      if (!mounted || seq != _loadSeq) return;
       setState(() {
-        _error =
-            'Something went wrong while loading this repository. '
-            'Pull to retry.';
-        _loading = false;
+        // Keep any cached content from Phase A; only show the error screen when
+        // there's nothing to show.
+        if (!_hasContent) {
+          _error =
+              'Something went wrong while loading this repository. '
+              'Pull to retry.';
+        }
+        _refreshing = false;
       });
     }
+  }
+
+  /// Pull-to-refresh handler: ignore the pull if a load is already in flight so
+  /// it can't start a second concurrent fetch.
+  Future<void> _refresh() async {
+    if (_refreshing) return;
+    await _load();
   }
 
   int get _tabCount => _releasesSupported ? 4 : 3;
@@ -101,12 +186,12 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
             IconButton(
               icon: const Icon(Icons.refresh),
               tooltip: 'Refresh',
-              onPressed: _loading ? null : _load,
+              onPressed: _refreshing ? null : _load,
             ),
           ],
           bottom: TabBar(isScrollable: true, tabs: tabs),
         ),
-        body: _loading
+        body: _showSpinner
             ? const Center(child: CircularProgressIndicator())
             : Column(
                 children: [
@@ -183,7 +268,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       );
     }
     return RefreshIndicator(
-      onRefresh: _load,
+      onRefresh: _refresh,
       child: ListView.separated(
         physics: const AlwaysScrollableScrollPhysics(),
         itemCount: pulls.length,
@@ -226,7 +311,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       );
     }
     return RefreshIndicator(
-      onRefresh: _load,
+      onRefresh: _refresh,
       child: ListView.separated(
         physics: const AlwaysScrollableScrollPhysics(),
         itemCount: ci.length,
@@ -266,7 +351,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       );
     }
     return RefreshIndicator(
-      onRefresh: _load,
+      onRefresh: _refresh,
       child: ListView.separated(
         physics: const AlwaysScrollableScrollPhysics(),
         itemCount: releases.length,
@@ -306,7 +391,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       );
     }
     return RefreshIndicator(
-      onRefresh: _load,
+      onRefresh: _refresh,
       child: ActivityEventList(events: _events),
     );
   }
@@ -384,7 +469,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
 
   Widget _centeredMessage(String message) {
     return RefreshIndicator(
-      onRefresh: _load,
+      onRefresh: _refresh,
       child: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
         children: [
@@ -402,7 +487,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
 
   Widget _errorList() {
     return RefreshIndicator(
-      onRefresh: _load,
+      onRefresh: _refresh,
       child: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
         children: [

--- a/lib/repo_detail_store.dart
+++ b/lib/repo_detail_store.dart
@@ -1,0 +1,194 @@
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+
+import 'database/app_database.dart';
+import 'repo_detail_service.dart';
+
+/// Caches the per-repo detail (open PRs, CI runs, releases) on the local SQLite
+/// database (drift) so the repo drill-down renders instantly from disk on cold
+/// start / offline, with the network as a refresher (Phase 2c of the
+/// local-database roadmap).
+///
+/// Rows are keyed by `repoKey`; the autoincrement `id` preserves the provider's
+/// list order. [save] replaces a source's rows only when that source loaded
+/// successfully this round, so a transient/offline failure of one source (e.g.
+/// CI) keeps its last-known-good rows while the others refresh.
+class RepoDetailStore {
+  RepoDetailStore._();
+
+  static AppDatabase? _db;
+
+  static Future<void> _lock = SynchronousFuture<void>(null);
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  static AppDatabase get _database => _db ??= AppDatabase();
+
+  /// Test hook: back the store with an injected (e.g. in-memory) database and
+  /// reset the mutation lock.
+  @visibleForTesting
+  static void debugUseDatabase(AppDatabase db) {
+    _db = db;
+    _lock = SynchronousFuture<void>(null);
+  }
+
+  /// Reads the cached detail for [repoKey]. Failure flags are always false —
+  /// the cache is last-known-good; the caller supplies [releasesSupported]
+  /// (derived from the provider, not persisted).
+  static Future<RepoDetailData> cached(
+    String repoKey, {
+    required bool releasesSupported,
+  }) async {
+    final db = _database;
+    final pulls =
+        await (db.select(db.repoPulls)
+              ..where((t) => t.repoKey.equals(repoKey))
+              ..orderBy([(t) => OrderingTerm(expression: t.id)]))
+            .get();
+    final runs =
+        await (db.select(db.repoRuns)
+              ..where((t) => t.repoKey.equals(repoKey))
+              ..orderBy([(t) => OrderingTerm(expression: t.id)]))
+            .get();
+    final releases =
+        await (db.select(db.repoReleases)
+              ..where((t) => t.repoKey.equals(repoKey))
+              ..orderBy([(t) => OrderingTerm(expression: t.id)]))
+            .get();
+    return RepoDetailData(
+      pulls: pulls.map(_toPr).toList(),
+      ci: runs.map(_toRun).toList(),
+      releases: releases.map(_toRelease).toList(),
+      releasesSupported: releasesSupported,
+    );
+  }
+
+  /// Persists [data] for [repoKey]. Each source (pulls / CI / releases) is
+  /// replaced only when it did NOT fail this round; a failed source keeps its
+  /// cached rows so an offline/partial refresh never blanks it. Releases are
+  /// only touched when the provider supports them.
+  static Future<void> save(String repoKey, RepoDetailData data) async {
+    await _runLocked(() async {
+      final db = _database;
+      await db.transaction(() async {
+        if (!data.pullsFailed) {
+          await (db.delete(
+            db.repoPulls,
+          )..where((t) => t.repoKey.equals(repoKey))).go();
+          for (final pr in data.pulls) {
+            await db.into(db.repoPulls).insert(_prCompanion(repoKey, pr));
+          }
+        }
+        if (!data.ciFailed) {
+          await (db.delete(
+            db.repoRuns,
+          )..where((t) => t.repoKey.equals(repoKey))).go();
+          for (final run in data.ci) {
+            await db.into(db.repoRuns).insert(_runCompanion(repoKey, run));
+          }
+        }
+        if (data.releasesSupported && !data.releasesFailed) {
+          await (db.delete(
+            db.repoReleases,
+          )..where((t) => t.repoKey.equals(repoKey))).go();
+          for (final release in data.releases) {
+            await db
+                .into(db.repoReleases)
+                .insert(_releaseCompanion(repoKey, release));
+          }
+        }
+      });
+    });
+  }
+
+  /// Drops all cached detail for [repoKey] (e.g. after the repo is removed from
+  /// monitoring).
+  static Future<void> removeRepo(String repoKey) async {
+    final key = repoKey.trim();
+    if (key.isEmpty) return;
+    await _runLocked(() async {
+      final db = _database;
+      await db.transaction(() async {
+        await (db.delete(
+          db.repoPulls,
+        )..where((t) => t.repoKey.equals(key))).go();
+        await (db.delete(
+          db.repoRuns,
+        )..where((t) => t.repoKey.equals(key))).go();
+        await (db.delete(
+          db.repoReleases,
+        )..where((t) => t.repoKey.equals(key))).go();
+      });
+    });
+  }
+
+  static RepoPr _toPr(RepoPrRow row) => RepoPr(
+    label: row.label,
+    title: row.title,
+    author: row.author,
+    reviewState: row.reviewState,
+    ageDays: row.ageDays,
+    draft: row.draft,
+    url: row.url,
+  );
+
+  static RepoRun _toRun(RepoRunRow row) => RepoRun(
+    name: row.name,
+    status: row.status,
+    conclusion: row.conclusion,
+    branch: row.branch,
+    finishedAt: row.finishedAt == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(row.finishedAt!, isUtc: true),
+    url: row.url,
+  );
+
+  static RepoRelease _toRelease(RepoReleaseRow row) => RepoRelease(
+    tag: row.tag,
+    name: row.name,
+    author: row.author,
+    publishedAt: row.publishedAt == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(row.publishedAt!, isUtc: true),
+    url: row.url,
+  );
+
+  static RepoPullsCompanion _prCompanion(String repoKey, RepoPr pr) =>
+      RepoPullsCompanion.insert(
+        repoKey: repoKey,
+        label: pr.label,
+        title: pr.title,
+        author: pr.author,
+        reviewState: pr.reviewState,
+        ageDays: Value(pr.ageDays),
+        draft: pr.draft,
+        url: Value(pr.url),
+      );
+
+  static RepoRunsCompanion _runCompanion(String repoKey, RepoRun run) =>
+      RepoRunsCompanion.insert(
+        repoKey: repoKey,
+        name: run.name,
+        status: run.status,
+        conclusion: run.conclusion,
+        branch: Value(run.branch),
+        finishedAt: Value(run.finishedAt?.toUtc().millisecondsSinceEpoch),
+        url: Value(run.url),
+      );
+
+  static RepoReleasesCompanion _releaseCompanion(
+    String repoKey,
+    RepoRelease release,
+  ) => RepoReleasesCompanion.insert(
+    repoKey: repoKey,
+    tag: release.tag,
+    name: Value(release.name),
+    author: Value(release.author),
+    publishedAt: Value(release.publishedAt?.toUtc().millisecondsSinceEpoch),
+    url: Value(release.url),
+  );
+}

--- a/lib/repo_detail_store.dart
+++ b/lib/repo_detail_store.dart
@@ -42,29 +42,35 @@ class RepoDetailStore {
   static Future<RepoDetailData> cached(
     String repoKey, {
     required bool releasesSupported,
-  }) async {
-    final db = _database;
-    final pulls =
-        await (db.select(db.repoPulls)
-              ..where((t) => t.repoKey.equals(repoKey))
-              ..orderBy([(t) => OrderingTerm(expression: t.id)]))
-            .get();
-    final runs =
-        await (db.select(db.repoRuns)
-              ..where((t) => t.repoKey.equals(repoKey))
-              ..orderBy([(t) => OrderingTerm(expression: t.id)]))
-            .get();
-    final releases =
-        await (db.select(db.repoReleases)
-              ..where((t) => t.repoKey.equals(repoKey))
-              ..orderBy([(t) => OrderingTerm(expression: t.id)]))
-            .get();
-    return RepoDetailData(
-      pulls: pulls.map(_toPr).toList(),
-      ci: runs.map(_toRun).toList(),
-      releases: releases.map(_toRelease).toList(),
-      releasesSupported: releasesSupported,
-    );
+  }) {
+    // Read all three tables under the same lock the mutators use, so a
+    // concurrent save/removeRepo can't interleave between the SELECTs and yield
+    // an inconsistent composite (e.g. pulls from before a save, runs from
+    // after).
+    return _runLocked(() async {
+      final db = _database;
+      final pulls =
+          await (db.select(db.repoPulls)
+                ..where((t) => t.repoKey.equals(repoKey))
+                ..orderBy([(t) => OrderingTerm(expression: t.id)]))
+              .get();
+      final runs =
+          await (db.select(db.repoRuns)
+                ..where((t) => t.repoKey.equals(repoKey))
+                ..orderBy([(t) => OrderingTerm(expression: t.id)]))
+              .get();
+      final releases =
+          await (db.select(db.repoReleases)
+                ..where((t) => t.repoKey.equals(repoKey))
+                ..orderBy([(t) => OrderingTerm(expression: t.id)]))
+              .get();
+      return RepoDetailData(
+        pulls: pulls.map(_toPr).toList(),
+        ci: runs.map(_toRun).toList(),
+        releases: releases.map(_toRelease).toList(),
+        releasesSupported: releasesSupported,
+      );
+    });
   }
 
   /// Persists [data] for [repoKey]. Each source (pulls / CI / releases) is

--- a/test/activity_event_store_test.dart
+++ b/test/activity_event_store_test.dart
@@ -262,6 +262,24 @@ void main() {
     );
   });
 
+  test('cached(repoKey:) returns only that repo\'s events', () async {
+    await ActivityEventStore.save([
+      _event(id: '1', repoKey: 'github:a/a', occurredAt: now),
+      _event(id: '2', repoKey: 'github:b/b', occurredAt: now),
+      _event(
+        id: '3',
+        repoKey: 'github:a/a',
+        occurredAt: now.subtract(const Duration(hours: 1)),
+      ),
+    ], now: now);
+
+    final cached = await ActivityEventStore.cached(
+      repoKey: 'github:a/a',
+      now: now,
+    );
+    expect(cached.map((e) => e.id).toList(), ['1', '3']);
+  });
+
   test('removeRepo drops only the given repo', () async {
     await ActivityEventStore.save([
       _event(id: '1', repoKey: 'github:a/a', occurredAt: now),

--- a/test/manage_repos_test.dart
+++ b/test/manage_repos_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:kode_radar/database/app_database.dart';
 import 'package:kode_radar/activity_event_store.dart';
+import 'package:kode_radar/repo_detail_store.dart';
 import 'package:kode_radar/manage_repos_page.dart';
 import 'package:kode_radar/metric_store.dart';
 import 'package:kode_radar/team_store.dart';
@@ -19,6 +20,7 @@ void main() {
     db = AppDatabase.forExecutor(NativeDatabase.memory());
     MetricStore.debugUseDatabase(db);
     ActivityEventStore.debugUseDatabase(db);
+    RepoDetailStore.debugUseDatabase(db);
   });
 
   tearDown(() async {

--- a/test/repo_detail_store_test.dart
+++ b/test/repo_detail_store_test.dart
@@ -1,0 +1,174 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/database/app_database.dart';
+import 'package:kode_radar/repo_detail_service.dart';
+import 'package:kode_radar/repo_detail_store.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+RepoPr _pr(String label, {String reviewState = 'waiting'}) => RepoPr(
+  label: label,
+  title: 'title $label',
+  author: 'octocat',
+  reviewState: reviewState,
+  ageDays: 3,
+  url: 'https://example.com/$label',
+);
+
+RepoRun _run(String name, {String conclusion = 'success'}) => RepoRun(
+  name: name,
+  status: 'completed',
+  conclusion: conclusion,
+  branch: 'main',
+  finishedAt: DateTime.utc(2026, 1, 2, 3, 4),
+  url: 'https://example.com/run/$name',
+);
+
+RepoRelease _release(String tag) => RepoRelease(
+  tag: tag,
+  name: 'Release $tag',
+  author: 'octocat',
+  publishedAt: DateTime.utc(2026, 1, 1),
+  url: 'https://example.com/rel/$tag',
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  const repo = 'github:owner/name';
+
+  setUp(() {
+    db = AppDatabase.forExecutor(NativeDatabase.memory());
+    RepoDetailStore.debugUseDatabase(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test(
+    'save then cached round-trips pulls, CI and releases in order',
+    () async {
+      await RepoDetailStore.save(
+        repo,
+        RepoDetailData(
+          pulls: [
+            _pr('PR #1'),
+            _pr('PR #2', reviewState: 'approved'),
+          ],
+          ci: [_run('build')],
+          releases: [_release('v1.0'), _release('v0.9')],
+        ),
+      );
+
+      final cached = await RepoDetailStore.cached(
+        repo,
+        releasesSupported: true,
+      );
+      expect(cached.pulls.map((p) => p.label).toList(), ['PR #1', 'PR #2']);
+      expect(cached.pulls[1].reviewState, 'approved');
+      expect(cached.ci.single.name, 'build');
+      expect(cached.ci.single.finishedAt, DateTime.utc(2026, 1, 2, 3, 4));
+      expect(cached.releases.map((r) => r.tag).toList(), ['v1.0', 'v0.9']);
+      // Failure flags are always false for a cache read.
+      expect(cached.failedSources, 0);
+    },
+  );
+
+  test('cached is scoped to the requested repo', () async {
+    await RepoDetailStore.save(repo, RepoDetailData(pulls: [_pr('PR #1')]));
+    await RepoDetailStore.save(
+      'github:other/repo',
+      RepoDetailData(pulls: [_pr('PR #9')]),
+    );
+
+    final cached = await RepoDetailStore.cached(repo, releasesSupported: true);
+    expect(cached.pulls.map((p) => p.label).toList(), ['PR #1']);
+  });
+
+  test('a successful source replaces its cached rows', () async {
+    await RepoDetailStore.save(repo, RepoDetailData(pulls: [_pr('PR #1')]));
+    await RepoDetailStore.save(repo, RepoDetailData(pulls: [_pr('PR #2')]));
+
+    final cached = await RepoDetailStore.cached(repo, releasesSupported: true);
+    expect(cached.pulls.map((p) => p.label).toList(), ['PR #2']);
+  });
+
+  test('a failed source keeps its last-known-good rows', () async {
+    await RepoDetailStore.save(
+      repo,
+      RepoDetailData(pulls: [_pr('PR #1')], ci: [_run('build')]),
+    );
+    // Next refresh: pulls succeed (updated), CI failed (should retain).
+    await RepoDetailStore.save(
+      repo,
+      RepoDetailData(pulls: [_pr('PR #2')], ci: const [], ciFailed: true),
+    );
+
+    final cached = await RepoDetailStore.cached(repo, releasesSupported: true);
+    expect(cached.pulls.map((p) => p.label).toList(), ['PR #2']);
+    // CI retained from the prior successful load.
+    expect(cached.ci.map((r) => r.name).toList(), ['build']);
+  });
+
+  test('releases are untouched for providers without releases support', () async {
+    // A GitHub-cached release, then an ADO-style save (releasesSupported: false)
+    // must not wipe the cached releases.
+    await RepoDetailStore.save(
+      repo,
+      RepoDetailData(releases: [_release('v1')]),
+    );
+    await RepoDetailStore.save(
+      repo,
+      const RepoDetailData(releasesSupported: false),
+    );
+
+    final cached = await RepoDetailStore.cached(repo, releasesSupported: true);
+    expect(cached.releases.map((r) => r.tag).toList(), ['v1']);
+  });
+
+  test('removeRepo drops all detail for the repo only', () async {
+    await RepoDetailStore.save(
+      repo,
+      RepoDetailData(
+        pulls: [_pr('PR #1')],
+        ci: [_run('build')],
+        releases: [_release('v1')],
+      ),
+    );
+    await RepoDetailStore.save(
+      'github:other/repo',
+      RepoDetailData(pulls: [_pr('PR #9')]),
+    );
+
+    await RepoDetailStore.removeRepo(repo);
+
+    final gone = await RepoDetailStore.cached(repo, releasesSupported: true);
+    expect(gone.pulls, isEmpty);
+    expect(gone.ci, isEmpty);
+    expect(gone.releases, isEmpty);
+    final other = await RepoDetailStore.cached(
+      'github:other/repo',
+      releasesSupported: true,
+    );
+    expect(other.pulls.map((p) => p.label).toList(), ['PR #9']);
+  });
+
+  test('v3 -> v4 upgrade creates working repo-detail tables', () async {
+    // Set user_version = 3 so opening AppDatabase runs onUpgrade(3 -> 4) rather
+    // than onCreate; the other tables aren't materialized because the v4 step
+    // (repo-detail tables) is independent of them.
+    final native = sqlite3.openInMemory();
+    native.execute('PRAGMA user_version = 3;');
+    final upgraded = AppDatabase.forExecutor(
+      NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+    );
+    RepoDetailStore.debugUseDatabase(upgraded);
+
+    await RepoDetailStore.save(repo, RepoDetailData(pulls: [_pr('PR #1')]));
+    final cached = await RepoDetailStore.cached(repo, releasesSupported: true);
+    expect(cached.pulls.map((p) => p.label).toList(), ['PR #1']);
+
+    await upgraded.close();
+  });
+}


### PR DESCRIPTION
## What

Local-database **Phase 2c** — persist the per-repo drill-down (open PRs, CI runs, releases) on the local SQLite/drift database so the repo screen renders instantly on cold start (and offline), network as refresher. Completes the Phase-2 domain cache after #26 (feed) and #27 (attention).

## Design

`RepoDetailData` is a per-repo composite of three ordered lists (`RepoPr`/`RepoRun`/`RepoRelease`) with independent per-source failure flags, so the cache uses a **per-source merge**:

- **`RepoDetailStore.save(repoKey, data)`** (one transaction): a source that failed this round keeps its cached rows; a successful source is replaced (delete-by-repoKey + insert in order, order preserved by the autoincrement `id`). Releases are only touched when `releasesSupported` (GitHub). `removeRepo(repoKey)` drops all three tables.
- **`cached(repoKey, {releasesSupported})`** reads the three tables ordered by id (`releasesSupported` is derived from provider, not persisted).
- **`RepoDetailPage._load()`** is cache-first: render cached detail + the repo's cached timeline events (reusing the Phase-2a `ActivityEventStore`, filtered by repoKey) immediately, then refresh and render the persisted **merged** detail carrying the **fresh** per-source failure flags (so each tab still shows "couldn't load"). The timeline prefers the fresh repo-scoped feed and falls back to the cache when empty, so it never blanks offline. Loading split into `_refreshing` (gates Refresh + pull-to-refresh) and `_showSpinner`; a `_loadSeq` guard makes the newest load win.
- **Schema**: `repo_pulls`/`repo_runs`/`repo_releases` (repoKey + index each); `schemaVersion` 3→4 idempotent `onUpgrade`.

## Testing

- `test/repo_detail_store_test.dart`: round-trip + order, repo scoping, replace-on-success, failed-source retain, releases-untouched-for-ADO, removeRepo, and a **v3→v4 upgrade** test.
- `flutter test` (292), `flutter analyze --fatal-infos`, `dart format` all clean.

## Notes

- The repo-scoped feed fetch is read-only against the shared cache (not persisted) to avoid the store's global `maxEvents` trim / unmonitored purge affecting other repos; the main feed page keeps that cache fresh.
- A source that *permanently* errors keeps its last rows until it recovers or the repo is removed (visible via the per-tab failure indicator) — same accepted trade-off as Phase 2b.