### PR TITLE
Add sync provenance: honest 'Updated Xh ago' instead of 'just now' over stale cache

### DIFF
--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -105,17 +105,22 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
           SyncStateStore.feedScope,
         );
         if (!mounted || seq != _loadSeq) return;
-        if (cached.isNotEmpty) {
+        // Set the provenance label even when the cache is empty (a scope that
+        // synced successfully but had nothing to show), so its "updated" time
+        // survives a restart/offline open.
+        if (cached.isNotEmpty || lastSynced != null) {
           setState(() {
-            _events = cached;
+            if (cached.isNotEmpty) {
+              _events = cached;
+              // The cached render carries no source-health signal, so clear any
+              // stale failed/truncated notice from a previous refresh while the
+              // new network refresh is still in flight.
+              _failedSources = 0;
+              _truncated = false;
+            }
             _teams = teams;
             _lookbackDays = appPrefs.feedLookbackDays;
             _lastSynced = lastSynced;
-            // The cached render carries no source-health signal, so clear any
-            // stale failed/truncated notice from a previous refresh while the
-            // new network refresh is still in flight.
-            _failedSources = 0;
-            _truncated = false;
             if (_teamId != null && !teams.any((t) => t.id == _teamId)) {
               _teamId = null;
             }
@@ -151,10 +156,12 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
         );
         if (!mounted || seq != _loadSeq) return;
       }
-      // The refresh counts as a successful sync unless it came back empty
-      // *because* sources failed (fully offline). Record it so the "updated"
-      // label reflects the last real sync, not a cache render.
-      final syncedOk = result.events.isNotEmpty || result.failedSources == 0;
+      // The refresh counts as a successful sync when at least one source loaded
+      // (or the whole fleet is clean) — NOT when it came back empty because
+      // every source failed (fully offline). Using okSources (not emptiness)
+      // means a persistently-failing repo alongside a quiet fleet doesn't
+      // freeze the "updated" label.
+      final syncedOk = result.failedSources == 0 || result.okSources > 0;
       if (syncedOk) {
         await SyncStateStore.markSuccess(SyncStateStore.feedScope);
         if (!mounted || seq != _loadSeq) return;

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -11,6 +11,7 @@ import 'identity_store.dart';
 import 'preferences_store.dart';
 import 'saved_view_store.dart';
 import 'seen_store.dart';
+import 'sync_state_store.dart';
 import 'team.dart';
 import 'team_store.dart';
 
@@ -39,7 +40,10 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
   bool _truncated = false;
   int _lookbackDays = ActivityFeedService.defaultLookback.inDays;
   String? _error;
-  DateTime? _lastChecked;
+
+  /// When the feed last refreshed successfully from the network (persisted), so
+  /// the "updated" label stays honest while showing stale cache offline.
+  DateTime? _lastSynced;
 
   /// The previous "last seen" time, captured once, used to flag new events.
   DateTime? _newSince;
@@ -97,12 +101,16 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
       // meaningful when we don't already have events on screen.
       if (_events.isEmpty) {
         final cached = await ActivityEventStore.cached(lookback: lookback);
+        final lastSynced = await SyncStateStore.lastSuccess(
+          SyncStateStore.feedScope,
+        );
         if (!mounted || seq != _loadSeq) return;
         if (cached.isNotEmpty) {
           setState(() {
             _events = cached;
             _teams = teams;
             _lookbackDays = appPrefs.feedLookbackDays;
+            _lastSynced = lastSynced;
             // The cached render carries no source-health signal, so clear any
             // stale failed/truncated notice from a previous refresh while the
             // new network refresh is still in flight.
@@ -143,6 +151,14 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
         );
         if (!mounted || seq != _loadSeq) return;
       }
+      // The refresh counts as a successful sync unless it came back empty
+      // *because* sources failed (fully offline). Record it so the "updated"
+      // label reflects the last real sync, not a cache render.
+      final syncedOk = result.events.isNotEmpty || result.failedSources == 0;
+      if (syncedOk) {
+        await SyncStateStore.markSuccess(SyncStateStore.feedScope);
+        if (!mounted || seq != _loadSeq) return;
+      }
       setState(() {
         _events = merged;
         _failedSources = result.failedSources;
@@ -154,7 +170,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
           _teamId = null;
         }
         _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
-        _lastChecked = DateTime.now();
+        if (syncedOk) _lastSynced = DateTime.now();
         _refreshing = false;
       });
     } catch (e) {
@@ -483,9 +499,9 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
         const SizedBox(height: 6),
         Center(
           child: Text(
-            _lastChecked == null
+            _lastSynced == null
                 ? 'Pull down to refresh.'
-                : 'Checked ${activityRelativeTime(_lastChecked!)} · pull down to refresh.',
+                : 'Updated ${activityRelativeTime(_lastSynced!)} · pull down to refresh.',
             style: TextStyle(color: Colors.grey[600], fontSize: 12),
           ),
         ),

--- a/lib/activity_feed_service.dart
+++ b/lib/activity_feed_service.dart
@@ -16,6 +16,7 @@ class ActivityFeedResult {
   const ActivityFeedResult({
     required this.events,
     this.failedSources = 0,
+    this.okSources = 0,
     this.truncated = false,
   });
 
@@ -23,6 +24,11 @@ class ActivityFeedResult {
 
   /// Number of source fetches that errored or returned a non-200 status.
   final int failedSources;
+
+  /// Number of per-repo source fetches that succeeded (returned data or an
+  /// empty-but-clean result). Zero when the whole fetch was offline/failed;
+  /// lets callers tell "genuinely quiet" from "nothing loaded" for provenance.
+  final int okSources;
 
   /// True when at least one history source returned a full page, so older
   /// in-window events may have been omitted.
@@ -539,6 +545,12 @@ class ActivityFeedService {
 
       final outcomes = await _runBounded(tasks, concurrency);
       final combined = _FetchOutcome.merge(outcomes);
+      // A repo source counts as "ok" if it fully succeeded or returned some
+      // events (i.e. it wasn't a total failure), so provenance can distinguish
+      // a fully-offline fetch from a quiet-but-successful one.
+      final okSources = outcomes
+          .where((o) => o.failedCount == 0 || o.events.isNotEmpty)
+          .length;
       // Apply person/repo scoping BEFORE the maxEvents cap so a quiet person or
       // team can't be evicted by unrelated high-volume repositories.
       var events = combined.events;
@@ -555,6 +567,7 @@ class ActivityFeedService {
       return ActivityFeedResult(
         events: mergeAndWindow(events, since),
         failedSources: combined.failedCount,
+        okSources: okSources,
         truncated: combined.truncated,
       );
     } finally {

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'app_http.dart';
@@ -9,7 +10,9 @@ import 'attention_store.dart';
 import 'config_revision.dart';
 import 'home_menu.dart';
 import 'identity_store.dart';
+import 'monitored_repos.dart';
 import 'notification_service.dart';
+import 'repo_store.dart';
 import 'snooze_store.dart';
 import 'sync_state_store.dart';
 
@@ -94,9 +97,12 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
           SyncStateStore.attentionScope,
         );
         if (!mounted || seq != _loadSeq) return;
-        if (cachedItems.isNotEmpty) {
+        // Set the provenance label even when the cache is empty (a clean inbox
+        // that synced successfully), so its "checked" time survives a
+        // restart/offline open.
+        if (cachedItems.isNotEmpty || lastSynced != null) {
           setState(() {
-            _items = cachedItems;
+            if (cachedItems.isNotEmpty) _items = cachedItems;
             _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
             _lastSynced = lastSynced;
           });
@@ -126,16 +132,21 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       // repos couldn't load.
       final cachedReal = await AttentionStore.cached(snoozedIds: freshSnoozed);
       if (!mounted || seq != _loadSeq) return;
-      // A successful sync = we got real items, or a genuinely clean fleet (no
-      // errors). Fully offline (all error items, no real ones) does not count,
-      // so the "checked" label reflects the last real refresh.
-      final hasReal = computed.any(
-        (i) => i.category != AttentionStore.errorCategory,
-      );
-      final hasError = computed.any(
-        (i) => i.category == AttentionStore.errorCategory,
-      );
-      final syncedOk = hasReal || !hasError;
+      // A successful sync = at least one monitored repo was fetched without an
+      // error (it had real items or was cleanly empty). Compare the number of
+      // errored repos (one error item each) to the monitored count so a
+      // persistently-failing repo alongside an empty (healthy) inbox doesn't
+      // freeze the "checked" label. Fully offline (every repo errored) = not ok.
+      final erroredRepos = computed
+          .where((i) => i.category == AttentionStore.errorCategory)
+          .length;
+      final prefs = await SharedPreferences.getInstance();
+      if (!mounted || seq != _loadSeq) return;
+      final monitoredCount = parseMonitoredRepos(
+        prefs.getStringList(RepoStore.githubKey) ?? const <String>[],
+        prefs.getStringList(RepoStore.adoKey) ?? const <String>[],
+      ).length;
+      final syncedOk = monitoredCount == 0 || erroredRepos < monitoredCount;
       if (syncedOk) {
         await SyncStateStore.markSuccess(SyncStateStore.attentionScope);
         if (!mounted || seq != _loadSeq) return;

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -11,6 +11,7 @@ import 'home_menu.dart';
 import 'identity_store.dart';
 import 'notification_service.dart';
 import 'snooze_store.dart';
+import 'sync_state_store.dart';
 
 /// Shows a ranked list of items that need the user's attention across all
 /// monitored repositories (PRs waiting on review, changes requested, stale PRs,
@@ -33,7 +34,10 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
   String? _categoryFilter;
   bool _identitySet = false;
   String? _error;
-  DateTime? _lastChecked;
+
+  /// When the inbox last refreshed successfully from the network (persisted), so
+  /// the "checked" label stays honest while showing stale cache offline.
+  DateTime? _lastSynced;
 
   // Guards against a stale in-flight load applying after a newer one.
   int _loadSeq = 0;
@@ -86,11 +90,15 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       // meaningful when we don't already have items on screen.
       if (_items.isEmpty) {
         final cachedItems = await AttentionStore.cached(snoozedIds: snoozed);
+        final lastSynced = await SyncStateStore.lastSuccess(
+          SyncStateStore.attentionScope,
+        );
         if (!mounted || seq != _loadSeq) return;
         if (cachedItems.isNotEmpty) {
           setState(() {
             _items = cachedItems;
             _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
+            _lastSynced = lastSynced;
           });
         }
       }
@@ -118,6 +126,20 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       // repos couldn't load.
       final cachedReal = await AttentionStore.cached(snoozedIds: freshSnoozed);
       if (!mounted || seq != _loadSeq) return;
+      // A successful sync = we got real items, or a genuinely clean fleet (no
+      // errors). Fully offline (all error items, no real ones) does not count,
+      // so the "checked" label reflects the last real refresh.
+      final hasReal = computed.any(
+        (i) => i.category != AttentionStore.errorCategory,
+      );
+      final hasError = computed.any(
+        (i) => i.category == AttentionStore.errorCategory,
+      );
+      final syncedOk = hasReal || !hasError;
+      if (syncedOk) {
+        await SyncStateStore.markSuccess(SyncStateStore.attentionScope);
+        if (!mounted || seq != _loadSeq) return;
+      }
       final errors = computed
           .where(
             (i) =>
@@ -137,7 +159,7 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       setState(() {
         _items = merged;
         _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
-        _lastChecked = DateTime.now();
+        if (syncedOk) _lastSynced = DateTime.now();
         _refreshing = false;
       });
       // Notify on the fresh, snooze-filtered set (error items are additionally
@@ -321,9 +343,9 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         const SizedBox(height: 6),
         Center(
           child: Text(
-            _lastChecked == null
+            _lastSynced == null
                 ? 'Pull down to refresh.'
-                : 'Checked ${_relativeTime(_lastChecked!)} · pull down to refresh.',
+                : 'Updated ${_relativeTime(_lastSynced!)} · pull down to refresh.',
             style: TextStyle(color: Colors.grey[600], fontSize: 12),
           ),
         ),
@@ -339,7 +361,7 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
       child: Text(
-        '$label${_lastChecked == null ? '' : ' · checked ${_relativeTime(_lastChecked!)}'}',
+        '$label${_lastSynced == null ? '' : ' · updated ${_relativeTime(_lastSynced!)}'}',
         style: TextStyle(color: Colors.grey[600], fontSize: 12),
       ),
     );

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -120,6 +120,22 @@ class RepoReleases extends Table {
   TextColumn get url => text().nullable()();
 }
 
+/// Per-scope sync provenance (Phase 3): when a cache scope was last refreshed
+/// successfully from the network, so the UI can show an accurate "updated Xh
+/// ago" instead of "just now" when it's actually displaying stale cached data.
+/// `scope` is a stable key like `feed`, `attention`, or `repo:<repoKey>`.
+/// `etag`/`cursor` are reserved for later conditional-GET / pagination slices.
+@DataClassName('SyncStateRow')
+class SyncState extends Table {
+  TextColumn get scope => text()();
+  IntColumn get lastSuccessAt => integer().nullable()();
+  TextColumn get etag => text().nullable()();
+  TextColumn get cursor => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {scope};
+}
+
 /// Small key/value table for database-local bookkeeping (e.g. one-time
 /// migration markers that must commit atomically with the data they guard).
 @DataClassName('AppMetaRow')
@@ -143,6 +159,7 @@ class AppMeta extends Table {
     RepoPulls,
     RepoRuns,
     RepoReleases,
+    SyncState,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -153,7 +170,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -214,6 +231,11 @@ class AppDatabase extends _$AppDatabase {
           'CREATE INDEX IF NOT EXISTS idx_repo_releases_repo_key '
           'ON repo_releases (repo_key)',
         );
+      }
+      // v5 adds the sync-provenance table (Phase 3). Its PK index is part of
+      // `CREATE TABLE IF NOT EXISTS`, so no secondary index is needed.
+      if (from < 5) {
+        await m.createTable(syncState);
       }
     },
   );

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -3371,6 +3371,323 @@ class RepoReleasesCompanion extends UpdateCompanion<RepoReleaseRow> {
   }
 }
 
+class $SyncStateTable extends SyncState
+    with TableInfo<$SyncStateTable, SyncStateRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $SyncStateTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _scopeMeta = const VerificationMeta('scope');
+  @override
+  late final GeneratedColumn<String> scope = GeneratedColumn<String>(
+    'scope',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _lastSuccessAtMeta = const VerificationMeta(
+    'lastSuccessAt',
+  );
+  @override
+  late final GeneratedColumn<int> lastSuccessAt = GeneratedColumn<int>(
+    'last_success_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _etagMeta = const VerificationMeta('etag');
+  @override
+  late final GeneratedColumn<String> etag = GeneratedColumn<String>(
+    'etag',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _cursorMeta = const VerificationMeta('cursor');
+  @override
+  late final GeneratedColumn<String> cursor = GeneratedColumn<String>(
+    'cursor',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [scope, lastSuccessAt, etag, cursor];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'sync_state';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<SyncStateRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('scope')) {
+      context.handle(
+        _scopeMeta,
+        scope.isAcceptableOrUnknown(data['scope']!, _scopeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_scopeMeta);
+    }
+    if (data.containsKey('last_success_at')) {
+      context.handle(
+        _lastSuccessAtMeta,
+        lastSuccessAt.isAcceptableOrUnknown(
+          data['last_success_at']!,
+          _lastSuccessAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('etag')) {
+      context.handle(
+        _etagMeta,
+        etag.isAcceptableOrUnknown(data['etag']!, _etagMeta),
+      );
+    }
+    if (data.containsKey('cursor')) {
+      context.handle(
+        _cursorMeta,
+        cursor.isAcceptableOrUnknown(data['cursor']!, _cursorMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {scope};
+  @override
+  SyncStateRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return SyncStateRow(
+      scope: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}scope'],
+      )!,
+      lastSuccessAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_success_at'],
+      ),
+      etag: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}etag'],
+      ),
+      cursor: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}cursor'],
+      ),
+    );
+  }
+
+  @override
+  $SyncStateTable createAlias(String alias) {
+    return $SyncStateTable(attachedDatabase, alias);
+  }
+}
+
+class SyncStateRow extends DataClass implements Insertable<SyncStateRow> {
+  final String scope;
+  final int? lastSuccessAt;
+  final String? etag;
+  final String? cursor;
+  const SyncStateRow({
+    required this.scope,
+    this.lastSuccessAt,
+    this.etag,
+    this.cursor,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['scope'] = Variable<String>(scope);
+    if (!nullToAbsent || lastSuccessAt != null) {
+      map['last_success_at'] = Variable<int>(lastSuccessAt);
+    }
+    if (!nullToAbsent || etag != null) {
+      map['etag'] = Variable<String>(etag);
+    }
+    if (!nullToAbsent || cursor != null) {
+      map['cursor'] = Variable<String>(cursor);
+    }
+    return map;
+  }
+
+  SyncStateCompanion toCompanion(bool nullToAbsent) {
+    return SyncStateCompanion(
+      scope: Value(scope),
+      lastSuccessAt: lastSuccessAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastSuccessAt),
+      etag: etag == null && nullToAbsent ? const Value.absent() : Value(etag),
+      cursor: cursor == null && nullToAbsent
+          ? const Value.absent()
+          : Value(cursor),
+    );
+  }
+
+  factory SyncStateRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return SyncStateRow(
+      scope: serializer.fromJson<String>(json['scope']),
+      lastSuccessAt: serializer.fromJson<int?>(json['lastSuccessAt']),
+      etag: serializer.fromJson<String?>(json['etag']),
+      cursor: serializer.fromJson<String?>(json['cursor']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'scope': serializer.toJson<String>(scope),
+      'lastSuccessAt': serializer.toJson<int?>(lastSuccessAt),
+      'etag': serializer.toJson<String?>(etag),
+      'cursor': serializer.toJson<String?>(cursor),
+    };
+  }
+
+  SyncStateRow copyWith({
+    String? scope,
+    Value<int?> lastSuccessAt = const Value.absent(),
+    Value<String?> etag = const Value.absent(),
+    Value<String?> cursor = const Value.absent(),
+  }) => SyncStateRow(
+    scope: scope ?? this.scope,
+    lastSuccessAt: lastSuccessAt.present
+        ? lastSuccessAt.value
+        : this.lastSuccessAt,
+    etag: etag.present ? etag.value : this.etag,
+    cursor: cursor.present ? cursor.value : this.cursor,
+  );
+  SyncStateRow copyWithCompanion(SyncStateCompanion data) {
+    return SyncStateRow(
+      scope: data.scope.present ? data.scope.value : this.scope,
+      lastSuccessAt: data.lastSuccessAt.present
+          ? data.lastSuccessAt.value
+          : this.lastSuccessAt,
+      etag: data.etag.present ? data.etag.value : this.etag,
+      cursor: data.cursor.present ? data.cursor.value : this.cursor,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SyncStateRow(')
+          ..write('scope: $scope, ')
+          ..write('lastSuccessAt: $lastSuccessAt, ')
+          ..write('etag: $etag, ')
+          ..write('cursor: $cursor')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(scope, lastSuccessAt, etag, cursor);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SyncStateRow &&
+          other.scope == this.scope &&
+          other.lastSuccessAt == this.lastSuccessAt &&
+          other.etag == this.etag &&
+          other.cursor == this.cursor);
+}
+
+class SyncStateCompanion extends UpdateCompanion<SyncStateRow> {
+  final Value<String> scope;
+  final Value<int?> lastSuccessAt;
+  final Value<String?> etag;
+  final Value<String?> cursor;
+  final Value<int> rowid;
+  const SyncStateCompanion({
+    this.scope = const Value.absent(),
+    this.lastSuccessAt = const Value.absent(),
+    this.etag = const Value.absent(),
+    this.cursor = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  SyncStateCompanion.insert({
+    required String scope,
+    this.lastSuccessAt = const Value.absent(),
+    this.etag = const Value.absent(),
+    this.cursor = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : scope = Value(scope);
+  static Insertable<SyncStateRow> custom({
+    Expression<String>? scope,
+    Expression<int>? lastSuccessAt,
+    Expression<String>? etag,
+    Expression<String>? cursor,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (scope != null) 'scope': scope,
+      if (lastSuccessAt != null) 'last_success_at': lastSuccessAt,
+      if (etag != null) 'etag': etag,
+      if (cursor != null) 'cursor': cursor,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  SyncStateCompanion copyWith({
+    Value<String>? scope,
+    Value<int?>? lastSuccessAt,
+    Value<String?>? etag,
+    Value<String?>? cursor,
+    Value<int>? rowid,
+  }) {
+    return SyncStateCompanion(
+      scope: scope ?? this.scope,
+      lastSuccessAt: lastSuccessAt ?? this.lastSuccessAt,
+      etag: etag ?? this.etag,
+      cursor: cursor ?? this.cursor,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (scope.present) {
+      map['scope'] = Variable<String>(scope.value);
+    }
+    if (lastSuccessAt.present) {
+      map['last_success_at'] = Variable<int>(lastSuccessAt.value);
+    }
+    if (etag.present) {
+      map['etag'] = Variable<String>(etag.value);
+    }
+    if (cursor.present) {
+      map['cursor'] = Variable<String>(cursor.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SyncStateCompanion(')
+          ..write('scope: $scope, ')
+          ..write('lastSuccessAt: $lastSuccessAt, ')
+          ..write('etag: $etag, ')
+          ..write('cursor: $cursor, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -3383,6 +3700,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $RepoPullsTable repoPulls = $RepoPullsTable(this);
   late final $RepoRunsTable repoRuns = $RepoRunsTable(this);
   late final $RepoReleasesTable repoReleases = $RepoReleasesTable(this);
+  late final $SyncStateTable syncState = $SyncStateTable(this);
   late final Index idxMetricSnapshotsRepoKey = Index(
     'idx_metric_snapshots_repo_key',
     'CREATE INDEX idx_metric_snapshots_repo_key ON metric_snapshots (repo_key)',
@@ -3427,6 +3745,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     repoPulls,
     repoRuns,
     repoReleases,
+    syncState,
     idxMetricSnapshotsRepoKey,
     idxActivityEventsRepoKey,
     idxActivityEventsOccurredAt,
@@ -5172,6 +5491,189 @@ typedef $$RepoReleasesTableProcessedTableManager =
       RepoReleaseRow,
       PrefetchHooks Function()
     >;
+typedef $$SyncStateTableCreateCompanionBuilder =
+    SyncStateCompanion Function({
+      required String scope,
+      Value<int?> lastSuccessAt,
+      Value<String?> etag,
+      Value<String?> cursor,
+      Value<int> rowid,
+    });
+typedef $$SyncStateTableUpdateCompanionBuilder =
+    SyncStateCompanion Function({
+      Value<String> scope,
+      Value<int?> lastSuccessAt,
+      Value<String?> etag,
+      Value<String?> cursor,
+      Value<int> rowid,
+    });
+
+class $$SyncStateTableFilterComposer
+    extends Composer<_$AppDatabase, $SyncStateTable> {
+  $$SyncStateTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get scope => $composableBuilder(
+    column: $table.scope,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastSuccessAt => $composableBuilder(
+    column: $table.lastSuccessAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get etag => $composableBuilder(
+    column: $table.etag,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get cursor => $composableBuilder(
+    column: $table.cursor,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$SyncStateTableOrderingComposer
+    extends Composer<_$AppDatabase, $SyncStateTable> {
+  $$SyncStateTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get scope => $composableBuilder(
+    column: $table.scope,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get lastSuccessAt => $composableBuilder(
+    column: $table.lastSuccessAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get etag => $composableBuilder(
+    column: $table.etag,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get cursor => $composableBuilder(
+    column: $table.cursor,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$SyncStateTableAnnotationComposer
+    extends Composer<_$AppDatabase, $SyncStateTable> {
+  $$SyncStateTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get scope =>
+      $composableBuilder(column: $table.scope, builder: (column) => column);
+
+  GeneratedColumn<int> get lastSuccessAt => $composableBuilder(
+    column: $table.lastSuccessAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get etag =>
+      $composableBuilder(column: $table.etag, builder: (column) => column);
+
+  GeneratedColumn<String> get cursor =>
+      $composableBuilder(column: $table.cursor, builder: (column) => column);
+}
+
+class $$SyncStateTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $SyncStateTable,
+          SyncStateRow,
+          $$SyncStateTableFilterComposer,
+          $$SyncStateTableOrderingComposer,
+          $$SyncStateTableAnnotationComposer,
+          $$SyncStateTableCreateCompanionBuilder,
+          $$SyncStateTableUpdateCompanionBuilder,
+          (
+            SyncStateRow,
+            BaseReferences<_$AppDatabase, $SyncStateTable, SyncStateRow>,
+          ),
+          SyncStateRow,
+          PrefetchHooks Function()
+        > {
+  $$SyncStateTableTableManager(_$AppDatabase db, $SyncStateTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$SyncStateTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$SyncStateTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$SyncStateTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> scope = const Value.absent(),
+                Value<int?> lastSuccessAt = const Value.absent(),
+                Value<String?> etag = const Value.absent(),
+                Value<String?> cursor = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => SyncStateCompanion(
+                scope: scope,
+                lastSuccessAt: lastSuccessAt,
+                etag: etag,
+                cursor: cursor,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String scope,
+                Value<int?> lastSuccessAt = const Value.absent(),
+                Value<String?> etag = const Value.absent(),
+                Value<String?> cursor = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => SyncStateCompanion.insert(
+                scope: scope,
+                lastSuccessAt: lastSuccessAt,
+                etag: etag,
+                cursor: cursor,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$SyncStateTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $SyncStateTable,
+      SyncStateRow,
+      $$SyncStateTableFilterComposer,
+      $$SyncStateTableOrderingComposer,
+      $$SyncStateTableAnnotationComposer,
+      $$SyncStateTableCreateCompanionBuilder,
+      $$SyncStateTableUpdateCompanionBuilder,
+      (
+        SyncStateRow,
+        BaseReferences<_$AppDatabase, $SyncStateTable, SyncStateRow>,
+      ),
+      SyncStateRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -5190,4 +5692,6 @@ class $AppDatabaseManager {
       $$RepoRunsTableTableManager(_db, _db.repoRuns);
   $$RepoReleasesTableTableManager get repoReleases =>
       $$RepoReleasesTableTableManager(_db, _db.repoReleases);
+  $$SyncStateTableTableManager get syncState =>
+      $$SyncStateTableTableManager(_db, _db.syncState);
 }

--- a/lib/manage_repos_page.dart
+++ b/lib/manage_repos_page.dart
@@ -7,6 +7,7 @@ import 'register_github_repo.dart';
 import 'register_ado_repo.dart';
 import 'activity_event_store.dart';
 import 'repo_detail_store.dart';
+import 'sync_state_store.dart';
 import 'ignore_store.dart';
 import 'manage_ignored_page.dart';
 import 'metric_store.dart';
@@ -203,6 +204,7 @@ class _ManageReposPageState extends State<ManageReposPage> {
         await MetricStore.removeRepo(repoKey);
         await ActivityEventStore.removeRepo(repoKey);
         await RepoDetailStore.removeRepo(repoKey);
+        await SyncStateStore.remove(SyncStateStore.repoScope(repoKey));
         await TeamStore.removeRepoFromAll(repoKey);
       }
     }

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -9,6 +9,7 @@ import 'activity_service.dart';
 import 'app_http.dart';
 import 'repo_detail_service.dart';
 import 'repo_detail_store.dart';
+import 'sync_state_store.dart';
 
 /// Per-repository drill-down: open pull requests (with review state), CI
 /// history, releases, and a recent-activity timeline, plus contributors.
@@ -32,6 +33,10 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
   /// still update the UI underneath.
   bool _refreshing = true;
   String? _error;
+
+  /// When this repo last refreshed successfully from the network (persisted), so
+  /// the header's "updated" label stays honest while showing stale cache.
+  DateTime? _lastSynced;
 
   // Guards against a stale in-flight load applying after a newer one.
   int _loadSeq = 0;
@@ -73,10 +78,12 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
             releasesSupported: _releasesSupported,
           ),
           ActivityEventStore.cached(repoKey: _repo.repoKey),
+          SyncStateStore.lastSuccess(SyncStateStore.repoScope(_repo.repoKey)),
         ]);
         if (!mounted || seq != _loadSeq) return;
         final cachedDetail = cachedResults[0] as RepoDetailData;
         final repoEvents = cachedResults[1] as List<ActivityEvent>;
+        final lastSynced = cachedResults[2] as DateTime?;
         if (cachedDetail.pulls.isNotEmpty ||
             cachedDetail.ci.isNotEmpty ||
             cachedDetail.releases.isNotEmpty ||
@@ -84,6 +91,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
           setState(() {
             _data = cachedDetail;
             _events = repoEvents;
+            _lastSynced = lastSynced;
           });
         }
       }
@@ -123,6 +131,20 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       if (timeline.isEmpty && feed.failedSources > 0) {
         timeline = _events;
       }
+      // A successful sync = at least one source refreshed without failing.
+      // Fully offline (every source failed) does not count, so the header's
+      // "updated" label reflects the last real refresh.
+      final syncedOk =
+          !freshDetail.pullsFailed ||
+          !freshDetail.ciFailed ||
+          (_releasesSupported && !freshDetail.releasesFailed) ||
+          feed.failedSources == 0;
+      if (syncedOk) {
+        await SyncStateStore.markSuccess(
+          SyncStateStore.repoScope(_repo.repoKey),
+        );
+        if (!mounted || seq != _loadSeq) return;
+      }
       setState(() {
         _data = RepoDetailData(
           pulls: mergedDetail.pulls,
@@ -136,6 +158,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
         _events = timeline;
         _feedFailed = feed.failedSources;
         _feedTruncated = feed.truncated;
+        if (syncedOk) _lastSynced = DateTime.now();
         _refreshing = false;
       });
     } catch (e) {
@@ -240,6 +263,16 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
               overflow: TextOverflow.ellipsis,
             ),
           ),
+          if (_lastSynced != null) ...[
+            const SizedBox(width: 8),
+            Text(
+              'Updated ${activityRelativeTime(_lastSynced!.toLocal())}',
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -84,13 +84,20 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
         final cachedDetail = cachedResults[0] as RepoDetailData;
         final repoEvents = cachedResults[1] as List<ActivityEvent>;
         final lastSynced = cachedResults[2] as DateTime?;
-        if (cachedDetail.pulls.isNotEmpty ||
+        final hasCache =
+            cachedDetail.pulls.isNotEmpty ||
             cachedDetail.ci.isNotEmpty ||
             cachedDetail.releases.isNotEmpty ||
-            repoEvents.isNotEmpty) {
+            repoEvents.isNotEmpty;
+        // Set the provenance label even when there's no cached content (a scope
+        // that synced successfully but had nothing to show), so its "updated"
+        // time survives a restart/offline open.
+        if (hasCache || lastSynced != null) {
           setState(() {
-            _data = cachedDetail;
-            _events = repoEvents;
+            if (hasCache) {
+              _data = cachedDetail;
+              _events = repoEvents;
+            }
             _lastSynced = lastSynced;
           });
         }
@@ -131,14 +138,15 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       if (timeline.isEmpty && feed.failedSources > 0) {
         timeline = _events;
       }
-      // A successful sync = at least one source refreshed without failing.
-      // Fully offline (every source failed) does not count, so the header's
-      // "updated" label reflects the last real refresh.
+      // A successful sync = at least one *persisted* detail source (pulls / CI /
+      // releases) refreshed without failing. The timeline isn't part of this
+      // cache (it reuses the shared feed cache), so it doesn't gate provenance —
+      // otherwise the "updated" time could advance while the persisted tabs show
+      // stale data. Fully offline (every detail source failed) does not count.
       final syncedOk =
           !freshDetail.pullsFailed ||
           !freshDetail.ciFailed ||
-          (_releasesSupported && !freshDetail.releasesFailed) ||
-          feed.failedSources == 0;
+          (_releasesSupported && !freshDetail.releasesFailed);
       if (syncedOk) {
         await SyncStateStore.markSuccess(
           SyncStateStore.repoScope(_repo.repoKey),

--- a/lib/sync_state_store.dart
+++ b/lib/sync_state_store.dart
@@ -1,0 +1,75 @@
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+
+import 'database/app_database.dart';
+
+/// Records when each cache "scope" was last refreshed successfully from the
+/// network (Phase 3 provenance), so the UI can show an accurate "updated Xh
+/// ago" instead of "just now" when it's actually displaying stale cached data
+/// after a failed/offline refresh.
+///
+/// Scopes are stable keys: [feedScope], [attentionScope], or
+/// `repoScope(repoKey)` for a repo drill-down.
+class SyncStateStore {
+  SyncStateStore._();
+
+  static const String feedScope = 'feed';
+  static const String attentionScope = 'attention';
+
+  static String repoScope(String repoKey) => 'repo:$repoKey';
+
+  static AppDatabase? _db;
+
+  static Future<void> _lock = SynchronousFuture<void>(null);
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  static AppDatabase get _database => _db ??= AppDatabase();
+
+  /// Test hook: back the store with an injected (e.g. in-memory) database and
+  /// reset the mutation lock.
+  @visibleForTesting
+  static void debugUseDatabase(AppDatabase db) {
+    _db = db;
+    _lock = SynchronousFuture<void>(null);
+  }
+
+  /// Records that [scope] just refreshed successfully (defaults to now).
+  static Future<void> markSuccess(String scope, {DateTime? now}) async {
+    final at = (now ?? DateTime.now()).toUtc().millisecondsSinceEpoch;
+    await _runLocked(() async {
+      final db = _database;
+      await db
+          .into(db.syncState)
+          .insert(
+            SyncStateCompanion.insert(scope: scope, lastSuccessAt: Value(at)),
+            onConflict: DoUpdate(
+              (_) => SyncStateCompanion(lastSuccessAt: Value(at)),
+            ),
+          );
+    });
+  }
+
+  /// The last successful-sync time for [scope], or null if it has never synced.
+  static Future<DateTime?> lastSuccess(String scope) async {
+    final db = _database;
+    final row = await (db.select(
+      db.syncState,
+    )..where((t) => t.scope.equals(scope))).getSingleOrNull();
+    final at = row?.lastSuccessAt;
+    if (at == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(at, isUtc: true);
+  }
+
+  /// Drops the provenance row for [scope] (e.g. a repo removed from monitoring).
+  static Future<void> remove(String scope) async {
+    await _runLocked(() async {
+      final db = _database;
+      await (db.delete(db.syncState)..where((t) => t.scope.equals(scope))).go();
+    });
+  }
+}

--- a/test/manage_repos_test.dart
+++ b/test/manage_repos_test.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:kode_radar/database/app_database.dart';
 import 'package:kode_radar/activity_event_store.dart';
 import 'package:kode_radar/repo_detail_store.dart';
+import 'package:kode_radar/sync_state_store.dart';
 import 'package:kode_radar/manage_repos_page.dart';
 import 'package:kode_radar/metric_store.dart';
 import 'package:kode_radar/team_store.dart';
@@ -21,6 +22,7 @@ void main() {
     MetricStore.debugUseDatabase(db);
     ActivityEventStore.debugUseDatabase(db);
     RepoDetailStore.debugUseDatabase(db);
+    SyncStateStore.debugUseDatabase(db);
   });
 
   tearDown(() async {

--- a/test/sync_state_store_test.dart
+++ b/test/sync_state_store_test.dart
@@ -1,0 +1,80 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/database/app_database.dart';
+import 'package:kode_radar/sync_state_store.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forExecutor(NativeDatabase.memory());
+    SyncStateStore.debugUseDatabase(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('lastSuccess is null before any sync', () async {
+    expect(await SyncStateStore.lastSuccess(SyncStateStore.feedScope), isNull);
+  });
+
+  test('markSuccess records and lastSuccess round-trips (UTC)', () async {
+    final at = DateTime.utc(2026, 1, 2, 3, 4, 5);
+    await SyncStateStore.markSuccess(SyncStateStore.feedScope, now: at);
+
+    final got = await SyncStateStore.lastSuccess(SyncStateStore.feedScope);
+    expect(got, at);
+    expect(got!.isUtc, isTrue);
+  });
+
+  test('markSuccess upserts (updates the same scope in place)', () async {
+    final t1 = DateTime.utc(2026, 1, 1);
+    final t2 = DateTime.utc(2026, 1, 2);
+    await SyncStateStore.markSuccess(SyncStateStore.attentionScope, now: t1);
+    await SyncStateStore.markSuccess(SyncStateStore.attentionScope, now: t2);
+
+    expect(await SyncStateStore.lastSuccess(SyncStateStore.attentionScope), t2);
+  });
+
+  test('scopes are independent', () async {
+    final at = DateTime.utc(2026, 5, 5);
+    await SyncStateStore.markSuccess(SyncStateStore.feedScope, now: at);
+
+    expect(await SyncStateStore.lastSuccess(SyncStateStore.feedScope), at);
+    expect(
+      await SyncStateStore.lastSuccess(SyncStateStore.attentionScope),
+      isNull,
+    );
+  });
+
+  test('repoScope keys by repo and remove clears it', () async {
+    final scope = SyncStateStore.repoScope('github:owner/name');
+    await SyncStateStore.markSuccess(scope, now: DateTime.utc(2026, 1, 1));
+    expect(await SyncStateStore.lastSuccess(scope), isNotNull);
+
+    await SyncStateStore.remove(scope);
+    expect(await SyncStateStore.lastSuccess(scope), isNull);
+  });
+
+  test('v4 -> v5 upgrade creates a working sync_state table', () async {
+    // Set user_version = 4 so opening AppDatabase runs onUpgrade(4 -> 5) rather
+    // than onCreate; the other tables aren't materialized because the v5 step
+    // (sync_state) is independent of them.
+    final native = sqlite3.openInMemory();
+    native.execute('PRAGMA user_version = 4;');
+    final upgraded = AppDatabase.forExecutor(
+      NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+    );
+    SyncStateStore.debugUseDatabase(upgraded);
+
+    final at = DateTime.utc(2026, 7, 1);
+    await SyncStateStore.markSuccess(SyncStateStore.feedScope, now: at);
+    expect(await SyncStateStore.lastSuccess(SyncStateStore.feedScope), at);
+
+    await upgraded.close();
+  });
+}


### PR DESCRIPTION
## What

Local-database **Phase 3a** — record per-scope last-successful-sync time and surface it, so the offline caches (#26/#27/#28) stop claiming data was "checked just now" when they're actually showing stale cached data after a failed/offline refresh (a follow-up both reviewers flagged repeatedly).

## Changes

- **`sync_state` table**: `scope` PK, `lastSuccessAt` (ms epoch UTC), reserved `etag`/`cursor`. `schemaVersion` 4→5 idempotent `onUpgrade`.
- **`SyncStateStore`**: `markSuccess(scope)` (upsert), `lastSuccess(scope)`, `remove(scope)`; scopes `feed` / `attention` / `repo:<repoKey>`.
- **Feed / attention / repo-detail**: replaced the ephemeral `_lastChecked = now` (set even on cache renders) with a persisted `_lastSynced` loaded in the cache-first Phase A and updated **only when the refresh actually succeeded** (a per-page `syncedOk` predicate distinguishes a real/partial refresh from fully-offline). The labels now read **"Updated Xh ago"**. Repo detail also gains an "Updated" line in its header.
- **Repo delete** prunes the repo's provenance scope.

## Testing

- `test/sync_state_store_test.dart`: null-before-sync, round-trip UTC, upsert-in-place, scope independence, `repoScope`+`remove`, and a **v4→v5 upgrade** test.
- `flutter test` (299), `flutter analyze --fatal-infos`, `dart format` all clean.

## Scope

- ETag conditional-GET is intentionally **not** here — `AppHttp`'s `CachedHttpClient` already does ETag/If-None-Match + rate-limit backoff at the HTTP layer; the `etag`/`cursor` columns are reserved for a later pagination slice.
- **3b** (persist creation timestamps → recompute `ageDays` on read so cached ages don't freeze) and **3c** (reactive drift streams) are deferred.