### PR TITLE
Recompute cached repo-PR ages on read so they don't freeze offline

### DIFF
--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -239,16 +239,29 @@ class AppDatabase extends _$AppDatabase {
         await m.createTable(syncState);
       }
       // v6 adds `created_at` to repo_pulls so a cached PR's age can be recomputed
-      // on read (Phase 3b). repo_pulls is a cache, so drop & recreate it with the
-      // new schema (idempotent DDL; the next refresh repopulates) rather than a
-      // non-idempotent `ALTER TABLE ... ADD COLUMN`.
+      // on read (Phase 3b). Ensure the table exists first (real upgrades have it
+      // from v4, but keep this step self-contained), then add the column with a
+      // single `ALTER TABLE ADD COLUMN`. This avoids a multi-statement
+      // drop+recreate (whose interleaving across isolates could crash on a
+      // half-recreated table) and keeps existing cached rows. A concurrent
+      // migrator — or a jump from <4, where `createTable` already built the
+      // current schema — may have already added it, so tolerate "duplicate
+      // column".
       if (from < 6) {
-        await customStatement('DROP TABLE IF EXISTS repo_pulls');
         await m.createTable(repoPulls);
         await customStatement(
           'CREATE INDEX IF NOT EXISTS idx_repo_pulls_repo_key '
           'ON repo_pulls (repo_key)',
         );
+        try {
+          await customStatement(
+            'ALTER TABLE repo_pulls ADD COLUMN created_at INTEGER',
+          );
+        } on Exception catch (e) {
+          if (!e.toString().toLowerCase().contains('duplicate column')) {
+            rethrow;
+          }
+        }
       }
     },
   );

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -91,6 +91,7 @@ class RepoPulls extends Table {
   TextColumn get author => text()();
   TextColumn get reviewState => text()();
   IntColumn get ageDays => integer().nullable()();
+  IntColumn get createdAt => integer().nullable()();
   BoolColumn get draft => boolean()();
   TextColumn get url => text().nullable()();
 }
@@ -170,7 +171,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -236,6 +237,18 @@ class AppDatabase extends _$AppDatabase {
       // `CREATE TABLE IF NOT EXISTS`, so no secondary index is needed.
       if (from < 5) {
         await m.createTable(syncState);
+      }
+      // v6 adds `created_at` to repo_pulls so a cached PR's age can be recomputed
+      // on read (Phase 3b). repo_pulls is a cache, so drop & recreate it with the
+      // new schema (idempotent DDL; the next refresh repopulates) rather than a
+      // non-idempotent `ALTER TABLE ... ADD COLUMN`.
+      if (from < 6) {
+        await customStatement('DROP TABLE IF EXISTS repo_pulls');
+        await m.createTable(repoPulls);
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_repo_pulls_repo_key '
+          'ON repo_pulls (repo_key)',
+        );
       }
     },
   );

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -1959,6 +1959,17 @@ class $RepoPullsTable extends RepoPulls
     type: DriftSqlType.int,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<int> createdAt = GeneratedColumn<int>(
+    'created_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _draftMeta = const VerificationMeta('draft');
   @override
   late final GeneratedColumn<bool> draft = GeneratedColumn<bool>(
@@ -1989,6 +2000,7 @@ class $RepoPullsTable extends RepoPulls
     author,
     reviewState,
     ageDays,
+    createdAt,
     draft,
     url,
   ];
@@ -2056,6 +2068,12 @@ class $RepoPullsTable extends RepoPulls
         ageDays.isAcceptableOrUnknown(data['age_days']!, _ageDaysMeta),
       );
     }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
     if (data.containsKey('draft')) {
       context.handle(
         _draftMeta,
@@ -2107,6 +2125,10 @@ class $RepoPullsTable extends RepoPulls
         DriftSqlType.int,
         data['${effectivePrefix}age_days'],
       ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}created_at'],
+      ),
       draft: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}draft'],
@@ -2132,6 +2154,7 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
   final String author;
   final String reviewState;
   final int? ageDays;
+  final int? createdAt;
   final bool draft;
   final String? url;
   const RepoPrRow({
@@ -2142,6 +2165,7 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
     required this.author,
     required this.reviewState,
     this.ageDays,
+    this.createdAt,
     required this.draft,
     this.url,
   });
@@ -2156,6 +2180,9 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
     map['review_state'] = Variable<String>(reviewState);
     if (!nullToAbsent || ageDays != null) {
       map['age_days'] = Variable<int>(ageDays);
+    }
+    if (!nullToAbsent || createdAt != null) {
+      map['created_at'] = Variable<int>(createdAt);
     }
     map['draft'] = Variable<bool>(draft);
     if (!nullToAbsent || url != null) {
@@ -2175,6 +2202,9 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
       ageDays: ageDays == null && nullToAbsent
           ? const Value.absent()
           : Value(ageDays),
+      createdAt: createdAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(createdAt),
       draft: Value(draft),
       url: url == null && nullToAbsent ? const Value.absent() : Value(url),
     );
@@ -2193,6 +2223,7 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
       author: serializer.fromJson<String>(json['author']),
       reviewState: serializer.fromJson<String>(json['reviewState']),
       ageDays: serializer.fromJson<int?>(json['ageDays']),
+      createdAt: serializer.fromJson<int?>(json['createdAt']),
       draft: serializer.fromJson<bool>(json['draft']),
       url: serializer.fromJson<String?>(json['url']),
     );
@@ -2208,6 +2239,7 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
       'author': serializer.toJson<String>(author),
       'reviewState': serializer.toJson<String>(reviewState),
       'ageDays': serializer.toJson<int?>(ageDays),
+      'createdAt': serializer.toJson<int?>(createdAt),
       'draft': serializer.toJson<bool>(draft),
       'url': serializer.toJson<String?>(url),
     };
@@ -2221,6 +2253,7 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
     String? author,
     String? reviewState,
     Value<int?> ageDays = const Value.absent(),
+    Value<int?> createdAt = const Value.absent(),
     bool? draft,
     Value<String?> url = const Value.absent(),
   }) => RepoPrRow(
@@ -2231,6 +2264,7 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
     author: author ?? this.author,
     reviewState: reviewState ?? this.reviewState,
     ageDays: ageDays.present ? ageDays.value : this.ageDays,
+    createdAt: createdAt.present ? createdAt.value : this.createdAt,
     draft: draft ?? this.draft,
     url: url.present ? url.value : this.url,
   );
@@ -2245,6 +2279,7 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
           ? data.reviewState.value
           : this.reviewState,
       ageDays: data.ageDays.present ? data.ageDays.value : this.ageDays,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       draft: data.draft.present ? data.draft.value : this.draft,
       url: data.url.present ? data.url.value : this.url,
     );
@@ -2260,6 +2295,7 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
           ..write('author: $author, ')
           ..write('reviewState: $reviewState, ')
           ..write('ageDays: $ageDays, ')
+          ..write('createdAt: $createdAt, ')
           ..write('draft: $draft, ')
           ..write('url: $url')
           ..write(')'))
@@ -2275,6 +2311,7 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
     author,
     reviewState,
     ageDays,
+    createdAt,
     draft,
     url,
   );
@@ -2289,6 +2326,7 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
           other.author == this.author &&
           other.reviewState == this.reviewState &&
           other.ageDays == this.ageDays &&
+          other.createdAt == this.createdAt &&
           other.draft == this.draft &&
           other.url == this.url);
 }
@@ -2301,6 +2339,7 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
   final Value<String> author;
   final Value<String> reviewState;
   final Value<int?> ageDays;
+  final Value<int?> createdAt;
   final Value<bool> draft;
   final Value<String?> url;
   const RepoPullsCompanion({
@@ -2311,6 +2350,7 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
     this.author = const Value.absent(),
     this.reviewState = const Value.absent(),
     this.ageDays = const Value.absent(),
+    this.createdAt = const Value.absent(),
     this.draft = const Value.absent(),
     this.url = const Value.absent(),
   });
@@ -2322,6 +2362,7 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
     required String author,
     required String reviewState,
     this.ageDays = const Value.absent(),
+    this.createdAt = const Value.absent(),
     required bool draft,
     this.url = const Value.absent(),
   }) : repoKey = Value(repoKey),
@@ -2338,6 +2379,7 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
     Expression<String>? author,
     Expression<String>? reviewState,
     Expression<int>? ageDays,
+    Expression<int>? createdAt,
     Expression<bool>? draft,
     Expression<String>? url,
   }) {
@@ -2349,6 +2391,7 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
       if (author != null) 'author': author,
       if (reviewState != null) 'review_state': reviewState,
       if (ageDays != null) 'age_days': ageDays,
+      if (createdAt != null) 'created_at': createdAt,
       if (draft != null) 'draft': draft,
       if (url != null) 'url': url,
     });
@@ -2362,6 +2405,7 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
     Value<String>? author,
     Value<String>? reviewState,
     Value<int?>? ageDays,
+    Value<int?>? createdAt,
     Value<bool>? draft,
     Value<String?>? url,
   }) {
@@ -2373,6 +2417,7 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
       author: author ?? this.author,
       reviewState: reviewState ?? this.reviewState,
       ageDays: ageDays ?? this.ageDays,
+      createdAt: createdAt ?? this.createdAt,
       draft: draft ?? this.draft,
       url: url ?? this.url,
     );
@@ -2402,6 +2447,9 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
     if (ageDays.present) {
       map['age_days'] = Variable<int>(ageDays.value);
     }
+    if (createdAt.present) {
+      map['created_at'] = Variable<int>(createdAt.value);
+    }
     if (draft.present) {
       map['draft'] = Variable<bool>(draft.value);
     }
@@ -2421,6 +2469,7 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
           ..write('author: $author, ')
           ..write('reviewState: $reviewState, ')
           ..write('ageDays: $ageDays, ')
+          ..write('createdAt: $createdAt, ')
           ..write('draft: $draft, ')
           ..write('url: $url')
           ..write(')'))
@@ -4745,6 +4794,7 @@ typedef $$RepoPullsTableCreateCompanionBuilder =
       required String author,
       required String reviewState,
       Value<int?> ageDays,
+      Value<int?> createdAt,
       required bool draft,
       Value<String?> url,
     });
@@ -4757,6 +4807,7 @@ typedef $$RepoPullsTableUpdateCompanionBuilder =
       Value<String> author,
       Value<String> reviewState,
       Value<int?> ageDays,
+      Value<int?> createdAt,
       Value<bool> draft,
       Value<String?> url,
     });
@@ -4802,6 +4853,11 @@ class $$RepoPullsTableFilterComposer
 
   ColumnFilters<int> get ageDays => $composableBuilder(
     column: $table.ageDays,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -4860,6 +4916,11 @@ class $$RepoPullsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get draft => $composableBuilder(
     column: $table.draft,
     builder: (column) => ColumnOrderings(column),
@@ -4902,6 +4963,9 @@ class $$RepoPullsTableAnnotationComposer
 
   GeneratedColumn<int> get ageDays =>
       $composableBuilder(column: $table.ageDays, builder: (column) => column);
+
+  GeneratedColumn<int> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
 
   GeneratedColumn<bool> get draft =>
       $composableBuilder(column: $table.draft, builder: (column) => column);
@@ -4948,6 +5012,7 @@ class $$RepoPullsTableTableManager
                 Value<String> author = const Value.absent(),
                 Value<String> reviewState = const Value.absent(),
                 Value<int?> ageDays = const Value.absent(),
+                Value<int?> createdAt = const Value.absent(),
                 Value<bool> draft = const Value.absent(),
                 Value<String?> url = const Value.absent(),
               }) => RepoPullsCompanion(
@@ -4958,6 +5023,7 @@ class $$RepoPullsTableTableManager
                 author: author,
                 reviewState: reviewState,
                 ageDays: ageDays,
+                createdAt: createdAt,
                 draft: draft,
                 url: url,
               ),
@@ -4970,6 +5036,7 @@ class $$RepoPullsTableTableManager
                 required String author,
                 required String reviewState,
                 Value<int?> ageDays = const Value.absent(),
+                Value<int?> createdAt = const Value.absent(),
                 required bool draft,
                 Value<String?> url = const Value.absent(),
               }) => RepoPullsCompanion.insert(
@@ -4980,6 +5047,7 @@ class $$RepoPullsTableTableManager
                 author: author,
                 reviewState: reviewState,
                 ageDays: ageDays,
+                createdAt: createdAt,
                 draft: draft,
                 url: url,
               ),

--- a/lib/repo_detail_service.dart
+++ b/lib/repo_detail_service.dart
@@ -24,6 +24,7 @@ class RepoPr {
     required this.author,
     required this.reviewState,
     this.ageDays,
+    this.createdAt,
     this.draft = false,
     this.url,
   });
@@ -33,6 +34,10 @@ class RepoPr {
   final String author;
   final String reviewState; // one of PrReviewState
   final int? ageDays;
+
+  /// When the PR was opened (UTC). Persisted so a cached PR's age can be
+  /// recomputed on read instead of freezing at its fetch-time value.
+  final DateTime? createdAt;
   final bool draft;
   final String? url;
 }
@@ -154,6 +159,7 @@ class RepoDetailService {
             pending,
           ),
           ageDays: _ageDays(pr['createdAt'], now),
+          createdAt: _parseDate(pr['createdAt']),
           draft: pr['isDraft'] == true,
           url: _str(pr, 'url'),
         ),
@@ -239,6 +245,7 @@ class RepoDetailService {
           author: author,
           reviewState: state,
           ageDays: _ageDays(pr['creationDate'], now),
+          createdAt: _parseDate(pr['creationDate']),
           draft: draft,
           url: url,
         ),

--- a/lib/repo_detail_store.dart
+++ b/lib/repo_detail_store.dart
@@ -42,7 +42,9 @@ class RepoDetailStore {
   static Future<RepoDetailData> cached(
     String repoKey, {
     required bool releasesSupported,
+    DateTime? now,
   }) {
+    final at = now ?? DateTime.now();
     // Read all three tables under the same lock the mutators use, so a
     // concurrent save/removeRepo can't interleave between the SELECTs and yield
     // an inconsistent composite (e.g. pulls from before a save, runs from
@@ -65,7 +67,7 @@ class RepoDetailStore {
                 ..orderBy([(t) => OrderingTerm(expression: t.id)]))
               .get();
       return RepoDetailData(
-        pulls: pulls.map(_toPr).toList(),
+        pulls: pulls.map((row) => _toPr(row, at)).toList(),
         ci: runs.map(_toRun).toList(),
         releases: releases.map(_toRelease).toList(),
         releasesSupported: releasesSupported,
@@ -132,15 +134,31 @@ class RepoDetailStore {
     });
   }
 
-  static RepoPr _toPr(RepoPrRow row) => RepoPr(
-    label: row.label,
-    title: row.title,
-    author: row.author,
-    reviewState: row.reviewState,
-    ageDays: row.ageDays,
-    draft: row.draft,
-    url: row.url,
-  );
+  static RepoPr _toPr(RepoPrRow row, DateTime now) {
+    final createdAt = row.createdAt == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(row.createdAt!, isUtc: true);
+    // Recompute age from the stored creation time so a cached PR's age reflects
+    // "now" on read instead of freezing at its fetch-time value. Fall back to
+    // the stored ageDays for rows written before created_at was persisted.
+    final int? ageDays;
+    if (createdAt == null) {
+      ageDays = row.ageDays;
+    } else {
+      final diff = now.difference(createdAt).inDays;
+      ageDays = diff < 0 ? 0 : diff;
+    }
+    return RepoPr(
+      label: row.label,
+      title: row.title,
+      author: row.author,
+      reviewState: row.reviewState,
+      ageDays: ageDays,
+      createdAt: createdAt,
+      draft: row.draft,
+      url: row.url,
+    );
+  }
 
   static RepoRun _toRun(RepoRunRow row) => RepoRun(
     name: row.name,
@@ -171,6 +189,7 @@ class RepoDetailStore {
         author: pr.author,
         reviewState: pr.reviewState,
         ageDays: Value(pr.ageDays),
+        createdAt: Value(pr.createdAt?.toUtc().millisecondsSinceEpoch),
         draft: pr.draft,
         url: Value(pr.url),
       );

--- a/test/repo_detail_store_test.dart
+++ b/test/repo_detail_store_test.dart
@@ -208,11 +208,11 @@ void main() {
     await upgraded.close();
   });
 
-  test('v5 -> v6 upgrade recreates repo_pulls with created_at', () async {
+  test('v5 -> v6 upgrade adds created_at to repo_pulls', () async {
     // Build a v5-era database by hand: repo_pulls WITHOUT created_at (plus the
     // sibling tables cached() reads), holding a stale row. Opening AppDatabase
-    // runs onUpgrade(5 -> 6), which drops & recreates repo_pulls with the new
-    // created_at column (clearing the stale row).
+    // runs onUpgrade(5 -> 6), which ADDs the created_at column (keeping the
+    // table); the stale row is later replaced by save().
     final native = sqlite3.openInMemory();
     native.execute(
       'CREATE TABLE repo_pulls (id INTEGER PRIMARY KEY AUTOINCREMENT, '
@@ -252,8 +252,8 @@ void main() {
       releasesSupported: true,
       now: created.add(const Duration(days: 5)),
     );
-    // Stale row dropped by the migration; new row's age recomputed from
-    // created_at.
+    // save() replaced the repo's rows (stale row gone); the new row's age is
+    // recomputed from the created_at added by the migration.
     expect(cached.pulls.map((p) => p.label).toList(), ['PR #1']);
     expect(cached.pulls.single.ageDays, 5);
 

--- a/test/repo_detail_store_test.dart
+++ b/test/repo_detail_store_test.dart
@@ -5,12 +5,17 @@ import 'package:kode_radar/repo_detail_service.dart';
 import 'package:kode_radar/repo_detail_store.dart';
 import 'package:sqlite3/sqlite3.dart';
 
-RepoPr _pr(String label, {String reviewState = 'waiting'}) => RepoPr(
+RepoPr _pr(
+  String label, {
+  String reviewState = 'waiting',
+  DateTime? createdAt,
+}) => RepoPr(
   label: label,
   title: 'title $label',
   author: 'octocat',
   reviewState: reviewState,
   ageDays: 3,
+  createdAt: createdAt,
   url: 'https://example.com/$label',
 );
 
@@ -154,6 +159,37 @@ void main() {
     expect(other.pulls.map((p) => p.label).toList(), ['PR #9']);
   });
 
+  test('cached recomputes PR age from createdAt at read time', () async {
+    final created = DateTime.utc(2026, 1, 1);
+    await RepoDetailStore.save(
+      repo,
+      RepoDetailData(pulls: [_pr('PR #1', createdAt: created)]),
+    );
+
+    // 10 days after creation.
+    final ten = await RepoDetailStore.cached(
+      repo,
+      releasesSupported: true,
+      now: created.add(const Duration(days: 10)),
+    );
+    expect(ten.pulls.single.ageDays, 10);
+
+    // 40 days after creation — the age advances without a re-save (doesn't
+    // freeze at the fetch-time value of 3).
+    final forty = await RepoDetailStore.cached(
+      repo,
+      releasesSupported: true,
+      now: created.add(const Duration(days: 40)),
+    );
+    expect(forty.pulls.single.ageDays, 40);
+  });
+
+  test('cached falls back to stored ageDays when createdAt is null', () async {
+    await RepoDetailStore.save(repo, RepoDetailData(pulls: [_pr('PR #1')]));
+    final cached = await RepoDetailStore.cached(repo, releasesSupported: true);
+    expect(cached.pulls.single.ageDays, 3);
+  });
+
   test('v3 -> v4 upgrade creates working repo-detail tables', () async {
     // Set user_version = 3 so opening AppDatabase runs onUpgrade(3 -> 4) rather
     // than onCreate; the other tables aren't materialized because the v4 step
@@ -168,6 +204,58 @@ void main() {
     await RepoDetailStore.save(repo, RepoDetailData(pulls: [_pr('PR #1')]));
     final cached = await RepoDetailStore.cached(repo, releasesSupported: true);
     expect(cached.pulls.map((p) => p.label).toList(), ['PR #1']);
+
+    await upgraded.close();
+  });
+
+  test('v5 -> v6 upgrade recreates repo_pulls with created_at', () async {
+    // Build a v5-era database by hand: repo_pulls WITHOUT created_at (plus the
+    // sibling tables cached() reads), holding a stale row. Opening AppDatabase
+    // runs onUpgrade(5 -> 6), which drops & recreates repo_pulls with the new
+    // created_at column (clearing the stale row).
+    final native = sqlite3.openInMemory();
+    native.execute(
+      'CREATE TABLE repo_pulls (id INTEGER PRIMARY KEY AUTOINCREMENT, '
+      'repo_key TEXT NOT NULL, label TEXT NOT NULL, title TEXT NOT NULL, '
+      'author TEXT NOT NULL, review_state TEXT NOT NULL, age_days INTEGER, '
+      'draft INTEGER NOT NULL, url TEXT)',
+    );
+    native.execute(
+      'CREATE TABLE repo_runs (id INTEGER PRIMARY KEY AUTOINCREMENT, '
+      'repo_key TEXT NOT NULL, name TEXT NOT NULL, status TEXT NOT NULL, '
+      'conclusion TEXT NOT NULL, branch TEXT, finished_at INTEGER, url TEXT)',
+    );
+    native.execute(
+      'CREATE TABLE repo_releases (id INTEGER PRIMARY KEY AUTOINCREMENT, '
+      'repo_key TEXT NOT NULL, tag TEXT NOT NULL, name TEXT, author TEXT, '
+      'published_at INTEGER, url TEXT)',
+    );
+    native.execute(
+      "INSERT INTO repo_pulls (repo_key, label, title, author, review_state, "
+      "age_days, draft, url) VALUES "
+      "('$repo', 'PR #stale', 't', 'a', 'waiting', 3, 0, NULL)",
+    );
+    native.execute('PRAGMA user_version = 5;');
+
+    final upgraded = AppDatabase.forExecutor(
+      NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+    );
+    RepoDetailStore.debugUseDatabase(upgraded);
+
+    final created = DateTime.utc(2026, 2, 1);
+    await RepoDetailStore.save(
+      repo,
+      RepoDetailData(pulls: [_pr('PR #1', createdAt: created)]),
+    );
+    final cached = await RepoDetailStore.cached(
+      repo,
+      releasesSupported: true,
+      now: created.add(const Duration(days: 5)),
+    );
+    // Stale row dropped by the migration; new row's age recomputed from
+    // created_at.
+    expect(cached.pulls.map((p) => p.label).toList(), ['PR #1']);
+    expect(cached.pulls.single.ageDays, 5);
 
     await upgraded.close();
   });


### PR DESCRIPTION
## What

Local-database **Phase 3b** — a cached PR's `ageDays` was computed at fetch time and stored, so an offline repo-detail view showed a frozen "opened 3 days ago" indefinitely. This persists the PR `created_at` and recomputes the age on read.

## Changes

- **`RepoPr`** gains a `createdAt` (UTC) field; both the GitHub and ADO parsers set it from the same field they already use for `ageDays`.
- **`repo_pulls`** table gains a nullable `created_at`. `schemaVersion` 5→6 migration is **monotonic and concurrency-safe**: ensure the table exists (`createTable` = CREATE TABLE IF NOT EXISTS + `CREATE INDEX IF NOT EXISTS`), then a single `ALTER TABLE repo_pulls ADD COLUMN created_at` tolerating "duplicate column". No `DROP` (so a concurrent isolate migration can't crash on a half-recreated table), and existing cached rows are kept.
- **`RepoDetailStore.cached(repoKey, {releasesSupported, now})`** recomputes `ageDays = max(0, now - createdAt in days)` when `created_at` is present, else falls back to the stored value (pre-existing rows). The page renders `_ageText(pr.ageDays)` at build, so the age advances with the current date.

## Testing

- `test/repo_detail_store_test.dart`: recompute-on-read (age advances with `now`), null-`createdAt` fallback, and a realistic **v5→v6 upgrade** that hand-builds an old (no `created_at`) `repo_pulls` + sibling tables and asserts the migration adds the column and the recompute works. The v3→v6 chain test also exercises the duplicate-column tolerance.
- `flutter test` (302), `flutter analyze --fatal-infos`, `dart format` all clean.

## Scope

- Attention items bake their age into display strings (subtitle/title), so cleanly unfreezing those needs a model refactor — deferred as a follow-up. Phase 3a's "Updated Xh ago" already contextualizes their staleness.
- CI/releases show absolute timestamps (not relative age), so they don't need this.