### PR TITLE
Make the Activity Feed reactive via a drift watch() stream

### DIFF
--- a/lib/activity_event_store.dart
+++ b/lib/activity_event_store.dart
@@ -63,6 +63,32 @@ class ActivityEventStore {
     DateTime? now,
     String? repoKey,
   }) async {
+    final rows = await _selectCached(
+      lookback: lookback,
+      now: now,
+      repoKey: repoKey,
+    ).get();
+    return rows.map(_toEvent).toList();
+  }
+
+  /// A reactive stream of the cached events (same shape as [cached]) that
+  /// re-emits whenever the `activity_events` table changes — so a page bound to
+  /// it updates automatically when a refresh (or another writer) persists new
+  /// data. [now]/[lookback] fix the window at subscription time.
+  static Stream<List<ActivityEvent>> watch({
+    Duration lookback = ActivityFeedService.defaultLookback,
+    DateTime? now,
+    String? repoKey,
+  }) {
+    return _selectCached(
+      lookback: lookback,
+      now: now,
+      repoKey: repoKey,
+    ).watch().map((rows) => rows.map(_toEvent).toList());
+  }
+
+  static SimpleSelectStatement<$ActivityEventsTable, ActivityEventRow>
+  _selectCached({required Duration lookback, DateTime? now, String? repoKey}) {
     final since = (now ?? DateTime.now()).toUtc().subtract(lookback);
     final db = _database;
     final query = db.select(db.activityEvents)
@@ -72,18 +98,13 @@ class ActivityEventStore {
     if (repoKey != null) {
       query.where((t) => t.repoKey.equals(repoKey));
     }
-    final rows =
-        await (query
-              ..orderBy([
-                (t) => OrderingTerm(
-                  expression: t.occurredAt,
-                  mode: OrderingMode.desc,
-                ),
-                (t) => OrderingTerm(expression: t.id, mode: OrderingMode.desc),
-              ])
-              ..limit(ActivityFeedService.maxEvents))
-            .get();
-    return rows.map(_toEvent).toList();
+    query
+      ..orderBy([
+        (t) => OrderingTerm(expression: t.occurredAt, mode: OrderingMode.desc),
+        (t) => OrderingTerm(expression: t.id, mode: OrderingMode.desc),
+      ])
+      ..limit(ActivityFeedService.maxEvents);
+    return query;
   }
 
   /// Upserts [events] into the cache (keyed by `(repoKey, eventId)`), prunes

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -89,9 +89,18 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
   /// persists, or a repo delete prunes) update the list automatically.
   void _subscribe(Duration lookback) {
     _eventsSub?.cancel();
-    _eventsSub = ActivityEventStore.watch(lookback: lookback).listen((events) {
-      if (mounted) setState(() => _events = events);
-    });
+    _eventsSub = ActivityEventStore.watch(lookback: lookback).listen(
+      (events) {
+        if (!mounted) return;
+        setState(() {
+          _events = events;
+          // A late cache emission should clear a stale error screen that a
+          // failed refresh set before the cache arrived.
+          if (events.isNotEmpty) _error = null;
+        });
+      },
+      onError: (Object e) => debugPrint('ActivityFeed watch stream error: $e'),
+    );
   }
 
   Future<void> _load() async {
@@ -121,11 +130,9 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
         SyncStateStore.feedScope,
       );
       if (!mounted || seq != _loadSeq) return;
-      // (Re)subscribe the reactive cache stream on first load or a lookback
-      // change; the stream drives `_events` from here on.
-      if (_eventsSub == null || appPrefs.feedLookbackDays != _lookbackDays) {
-        _subscribe(lookback);
-      }
+      // Re-subscribe every load with a fresh cutoff so the "last N days" window
+      // slides as time passes (not just when the configured lookback changes).
+      _subscribe(lookback);
       setState(() {
         _teams = teams;
         _lookbackDays = appPrefs.feedLookbackDays;

--- a/lib/activity_feed_page.dart
+++ b/lib/activity_feed_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'activity_event.dart';
@@ -53,6 +55,11 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
   // config-triggered reload); the newest load always wins.
   int _loadSeq = 0;
 
+  /// Reactive subscription to the cached events: drives `_events` (instant
+  /// cache on cold start, and auto-updates whenever a refresh persists new
+  /// data). Re-subscribed when the lookback window changes.
+  StreamSubscription<List<ActivityEvent>>? _eventsSub;
+
   /// Selected type groups; empty means "all kinds".
   final Set<String> _groups = <String>{};
 
@@ -68,6 +75,7 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
 
   @override
   void dispose() {
+    _eventsSub?.cancel();
     configRevision.removeListener(_onConfigChanged);
     super.dispose();
   }
@@ -76,11 +84,25 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
     if (mounted) _load();
   }
 
+  /// (Re)subscribes the reactive cache stream for [lookback]. The initial
+  /// emission renders the cache instantly; later emissions (e.g. after a refresh
+  /// persists, or a repo delete prunes) update the list automatically.
+  void _subscribe(Duration lookback) {
+    _eventsSub?.cancel();
+    _eventsSub = ActivityEventStore.watch(lookback: lookback).listen((events) {
+      if (mounted) setState(() => _events = events);
+    });
+  }
+
   Future<void> _load() async {
     final seq = ++_loadSeq;
     setState(() {
       _refreshing = true;
       _error = null;
+      // Clear any stale source-health notice while the new refresh is in
+      // flight; it's set fresh from the network result below.
+      _failedSources = 0;
+      _truncated = false;
     });
     try {
       // Capture the previous last-seen once (so "new" highlights stay stable
@@ -95,41 +117,27 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
       final selfAdo = await IdentityStore.selfAdoNames();
       final appPrefs = await PreferencesStore.load();
       final lookback = Duration(days: appPrefs.feedLookbackDays);
-
-      // Phase A: render the cached feed immediately so a cold start isn't a
-      // blank spinner while the network fetch runs (or if it's offline). Only
-      // meaningful when we don't already have events on screen.
-      if (_events.isEmpty) {
-        final cached = await ActivityEventStore.cached(lookback: lookback);
-        final lastSynced = await SyncStateStore.lastSuccess(
-          SyncStateStore.feedScope,
-        );
-        if (!mounted || seq != _loadSeq) return;
-        // Set the provenance label even when the cache is empty (a scope that
-        // synced successfully but had nothing to show), so its "updated" time
-        // survives a restart/offline open.
-        if (cached.isNotEmpty || lastSynced != null) {
-          setState(() {
-            if (cached.isNotEmpty) {
-              _events = cached;
-              // The cached render carries no source-health signal, so clear any
-              // stale failed/truncated notice from a previous refresh while the
-              // new network refresh is still in flight.
-              _failedSources = 0;
-              _truncated = false;
-            }
-            _teams = teams;
-            _lookbackDays = appPrefs.feedLookbackDays;
-            _lastSynced = lastSynced;
-            if (_teamId != null && !teams.any((t) => t.id == _teamId)) {
-              _teamId = null;
-            }
-            _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
-          });
-        }
+      final lastSynced = await SyncStateStore.lastSuccess(
+        SyncStateStore.feedScope,
+      );
+      if (!mounted || seq != _loadSeq) return;
+      // (Re)subscribe the reactive cache stream on first load or a lookback
+      // change; the stream drives `_events` from here on.
+      if (_eventsSub == null || appPrefs.feedLookbackDays != _lookbackDays) {
+        _subscribe(lookback);
       }
+      setState(() {
+        _teams = teams;
+        _lookbackDays = appPrefs.feedLookbackDays;
+        _lastSynced = lastSynced;
+        if (_teamId != null && !teams.any((t) => t.id == _teamId)) {
+          _teamId = null;
+        }
+        _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
+      });
 
-      // Phase B: refresh from the network and persist the result to the cache.
+      // Refresh from the network and persist the result; the stream then emits
+      // the merged cache and updates `_events` automatically.
       final result = await ActivityFeedService.computeAll(
         client: AppHttp.client,
         selfGithubLogins: selfGithub,
@@ -138,12 +146,6 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
       );
       if (!mounted || seq != _loadSeq) return;
       await ActivityEventStore.save(result.events, restrictToMonitored: true);
-      if (!mounted || seq != _loadSeq) return;
-      // Render the persisted cache (not `result.events` directly) so a fully
-      // offline load — where per-source failures yield an empty result rather
-      // than an exception — keeps showing cached events instead of blanking,
-      // and a partial failure shows the union of fresh + still-cached events.
-      final merged = await ActivityEventStore.cached(lookback: lookback);
       if (!mounted || seq != _loadSeq) return;
       // Advance the watermark to the newest event this network refresh
       // returned — a provider timestamp, so device-clock skew can't poison it,
@@ -167,16 +169,8 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
         if (!mounted || seq != _loadSeq) return;
       }
       setState(() {
-        _events = merged;
         _failedSources = result.failedSources;
         _truncated = result.truncated;
-        _lookbackDays = appPrefs.feedLookbackDays;
-        _teams = teams;
-        // Drop a stale team filter if the team was deleted.
-        if (_teamId != null && !teams.any((t) => t.id == _teamId)) {
-          _teamId = null;
-        }
-        _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
         if (syncedOk) _lastSynced = DateTime.now();
         _refreshing = false;
       });
@@ -184,9 +178,8 @@ class _ActivityFeedPageState extends State<ActivityFeedPage> {
       debugPrint('ActivityFeed failed to load: $e');
       if (!mounted || seq != _loadSeq) return;
       setState(() {
-        // If we already rendered cached events (Phase A), keep them on screen
-        // rather than replacing them with an error state; the refresh simply
-        // didn't land this time. Only show the error when we have nothing.
+        // Keep any cached events (the stream drives them) rather than replacing
+        // them with an error state; only show the error when we have nothing.
         if (_events.isEmpty) {
           _error =
               'Something went wrong while loading the feed. Pull down to try again.';

--- a/test/activity_event_store_test.dart
+++ b/test/activity_event_store_test.dart
@@ -280,6 +280,23 @@ void main() {
     expect(cached.map((e) => e.id).toList(), ['1', '3']);
   });
 
+  test('watch emits the cache and re-emits after a save', () async {
+    final emissions = <List<String>>[];
+    final sub = ActivityEventStore.watch(now: now).listen((events) {
+      emissions.add(events.map((e) => e.id).toList());
+    });
+    // Initial emission (empty cache).
+    await pumpEventQueue();
+    await ActivityEventStore.save([
+      _event(id: 'a', repoKey: 'github:owner/name', occurredAt: now),
+    ], now: now);
+    await pumpEventQueue();
+    await sub.cancel();
+
+    expect(emissions.first, isEmpty);
+    expect(emissions.last, ['a']);
+  });
+
   test('removeRepo drops only the given repo', () async {
     await ActivityEventStore.save([
       _event(id: '1', repoKey: 'github:a/a', occurredAt: now),


### PR DESCRIPTION
## What

Local-database **Phase 3c** (feed slice) — the Activity Feed's cached list is now driven by a reactive drift `watch()` stream instead of imperative cache reads. It renders instantly on cold start and **auto-updates whenever the cache changes** (a refresh persists new events, or a repo delete prunes them).

## Changes

- **`ActivityEventStore`**: extracted the query into `_selectCached(...)` and added `watch(...)` → `Stream<List<ActivityEvent>>` via drift's `.watch()`; `cached(...)` shares the builder.
- **`ActivityFeedPage`**: a `StreamSubscription` on `ActivityEventStore.watch(lookback:)` drives `_events`. `_load()` (re)subscribes on first load / lookback change, sets provenance/teams/identity/failure flags, fetches the network and `save()`s (which triggers the stream to re-emit the merged cache), advances the seen watermark, and marks sync success — it no longer sets `_events` directly. Subscription cancelled in `dispose()`.

## Behavior preserved

- Cold-start instant cache (initial stream emission), offline non-blank (stream keeps the cache when a refresh yields nothing), the "Updated Xh ago" provenance, the source-health notice (cleared-then-set), the seen-watermark, and the `_loadSeq` guard (now protecting the flag writes).

## Testing

- `test/activity_event_store_test.dart`: `watch` emits the cache and re-emits after a save.
- `flutter test` (303), `flutter analyze --fatal-infos`, `dart format` all clean.

## Scope

- Attention (its snooze filter is dynamic, not a watched DB column, so it needs per-emission filtering by a live snooze set) and repo-detail (a 3-table composite) reactive conversions are deferred as remaining 3c work.