### PR TITLE
Move the notification seen-set to the DB to fix the cross-isolate race

### DIFF
--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -141,9 +141,11 @@ class SyncState extends Table {
 /// `SharedPreferences` so the resident foreground and the background-sync
 /// isolate no longer read-modify-write the same blob and clobber each other.
 /// One row per already-notified attention id; inserts are additive
-/// (INSERT OR IGNORE on the unique `seenId`), so two isolates recording
-/// concurrently union rather than overwrite. The autoincrement `id` orders rows
-/// for oldest-first pruning.
+/// (`INSERT OR REPLACE` on the unique `seenId` — which keeps the id present but
+/// bumps it to a fresh, newest autoincrement `id`), so two isolates recording
+/// concurrently union rather than overwrite, and a still-current id is never
+/// pruned as "oldest". The autoincrement `id` orders rows for oldest-first
+/// pruning.
 @DataClassName('NotificationSeenRow')
 @TableIndex(
   name: 'idx_notification_seen_seen_id',

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -137,6 +137,34 @@ class SyncState extends Table {
   Set<Column> get primaryKey => {scope};
 }
 
+/// The attention notification "seen" baseline (Phase 4), moved off
+/// `SharedPreferences` so the resident foreground and the background-sync
+/// isolate no longer read-modify-write the same blob and clobber each other.
+/// One row per already-notified attention id; inserts are additive
+/// (INSERT OR IGNORE on the unique `seenId`), so two isolates recording
+/// concurrently union rather than overwrite. The autoincrement `id` orders rows
+/// for oldest-first pruning.
+@DataClassName('NotificationSeenRow')
+@TableIndex(
+  name: 'idx_notification_seen_seen_id',
+  columns: {#seenId},
+  unique: true,
+)
+class NotificationSeen extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get seenId => text()();
+}
+
+/// Repos whose existing attention backlog has been seeded silently (Phase 4);
+/// keyed by `repoDisplay` so inserts are additive across isolates.
+@DataClassName('NotificationKnownRepoRow')
+class NotificationKnownRepos extends Table {
+  TextColumn get repoDisplay => text()();
+
+  @override
+  Set<Column> get primaryKey => {repoDisplay};
+}
+
 /// Small key/value table for database-local bookkeeping (e.g. one-time
 /// migration markers that must commit atomically with the data they guard).
 @DataClassName('AppMetaRow')
@@ -161,6 +189,8 @@ class AppMeta extends Table {
     RepoRuns,
     RepoReleases,
     SyncState,
+    NotificationSeen,
+    NotificationKnownRepos,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -171,7 +201,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 6;
+  int get schemaVersion => 7;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -262,6 +292,17 @@ class AppDatabase extends _$AppDatabase {
             rethrow;
           }
         }
+      }
+      // v7 adds the notification "seen" baseline tables (Phase 4). Idempotent
+      // DDL as elsewhere; the known-repos PK index is part of `CREATE TABLE`, so
+      // only the seen unique index needs an explicit statement.
+      if (from < 7) {
+        await m.createTable(notificationSeen);
+        await customStatement(
+          'CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_seen_seen_id '
+          'ON notification_seen (seen_id)',
+        );
+        await m.createTable(notificationKnownRepos);
       }
     },
   );

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -3737,6 +3737,381 @@ class SyncStateCompanion extends UpdateCompanion<SyncStateRow> {
   }
 }
 
+class $NotificationSeenTable extends NotificationSeen
+    with TableInfo<$NotificationSeenTable, NotificationSeenRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $NotificationSeenTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _seenIdMeta = const VerificationMeta('seenId');
+  @override
+  late final GeneratedColumn<String> seenId = GeneratedColumn<String>(
+    'seen_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, seenId];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'notification_seen';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<NotificationSeenRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('seen_id')) {
+      context.handle(
+        _seenIdMeta,
+        seenId.isAcceptableOrUnknown(data['seen_id']!, _seenIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_seenIdMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  NotificationSeenRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return NotificationSeenRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      seenId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}seen_id'],
+      )!,
+    );
+  }
+
+  @override
+  $NotificationSeenTable createAlias(String alias) {
+    return $NotificationSeenTable(attachedDatabase, alias);
+  }
+}
+
+class NotificationSeenRow extends DataClass
+    implements Insertable<NotificationSeenRow> {
+  final int id;
+  final String seenId;
+  const NotificationSeenRow({required this.id, required this.seenId});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['seen_id'] = Variable<String>(seenId);
+    return map;
+  }
+
+  NotificationSeenCompanion toCompanion(bool nullToAbsent) {
+    return NotificationSeenCompanion(id: Value(id), seenId: Value(seenId));
+  }
+
+  factory NotificationSeenRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return NotificationSeenRow(
+      id: serializer.fromJson<int>(json['id']),
+      seenId: serializer.fromJson<String>(json['seenId']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'seenId': serializer.toJson<String>(seenId),
+    };
+  }
+
+  NotificationSeenRow copyWith({int? id, String? seenId}) =>
+      NotificationSeenRow(id: id ?? this.id, seenId: seenId ?? this.seenId);
+  NotificationSeenRow copyWithCompanion(NotificationSeenCompanion data) {
+    return NotificationSeenRow(
+      id: data.id.present ? data.id.value : this.id,
+      seenId: data.seenId.present ? data.seenId.value : this.seenId,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('NotificationSeenRow(')
+          ..write('id: $id, ')
+          ..write('seenId: $seenId')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, seenId);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is NotificationSeenRow &&
+          other.id == this.id &&
+          other.seenId == this.seenId);
+}
+
+class NotificationSeenCompanion extends UpdateCompanion<NotificationSeenRow> {
+  final Value<int> id;
+  final Value<String> seenId;
+  const NotificationSeenCompanion({
+    this.id = const Value.absent(),
+    this.seenId = const Value.absent(),
+  });
+  NotificationSeenCompanion.insert({
+    this.id = const Value.absent(),
+    required String seenId,
+  }) : seenId = Value(seenId);
+  static Insertable<NotificationSeenRow> custom({
+    Expression<int>? id,
+    Expression<String>? seenId,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (seenId != null) 'seen_id': seenId,
+    });
+  }
+
+  NotificationSeenCompanion copyWith({Value<int>? id, Value<String>? seenId}) {
+    return NotificationSeenCompanion(
+      id: id ?? this.id,
+      seenId: seenId ?? this.seenId,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (seenId.present) {
+      map['seen_id'] = Variable<String>(seenId.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('NotificationSeenCompanion(')
+          ..write('id: $id, ')
+          ..write('seenId: $seenId')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $NotificationKnownReposTable extends NotificationKnownRepos
+    with TableInfo<$NotificationKnownReposTable, NotificationKnownRepoRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $NotificationKnownReposTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _repoDisplayMeta = const VerificationMeta(
+    'repoDisplay',
+  );
+  @override
+  late final GeneratedColumn<String> repoDisplay = GeneratedColumn<String>(
+    'repo_display',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [repoDisplay];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'notification_known_repos';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<NotificationKnownRepoRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('repo_display')) {
+      context.handle(
+        _repoDisplayMeta,
+        repoDisplay.isAcceptableOrUnknown(
+          data['repo_display']!,
+          _repoDisplayMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_repoDisplayMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {repoDisplay};
+  @override
+  NotificationKnownRepoRow map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return NotificationKnownRepoRow(
+      repoDisplay: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_display'],
+      )!,
+    );
+  }
+
+  @override
+  $NotificationKnownReposTable createAlias(String alias) {
+    return $NotificationKnownReposTable(attachedDatabase, alias);
+  }
+}
+
+class NotificationKnownRepoRow extends DataClass
+    implements Insertable<NotificationKnownRepoRow> {
+  final String repoDisplay;
+  const NotificationKnownRepoRow({required this.repoDisplay});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['repo_display'] = Variable<String>(repoDisplay);
+    return map;
+  }
+
+  NotificationKnownReposCompanion toCompanion(bool nullToAbsent) {
+    return NotificationKnownReposCompanion(repoDisplay: Value(repoDisplay));
+  }
+
+  factory NotificationKnownRepoRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return NotificationKnownRepoRow(
+      repoDisplay: serializer.fromJson<String>(json['repoDisplay']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'repoDisplay': serializer.toJson<String>(repoDisplay),
+    };
+  }
+
+  NotificationKnownRepoRow copyWith({String? repoDisplay}) =>
+      NotificationKnownRepoRow(repoDisplay: repoDisplay ?? this.repoDisplay);
+  NotificationKnownRepoRow copyWithCompanion(
+    NotificationKnownReposCompanion data,
+  ) {
+    return NotificationKnownRepoRow(
+      repoDisplay: data.repoDisplay.present
+          ? data.repoDisplay.value
+          : this.repoDisplay,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('NotificationKnownRepoRow(')
+          ..write('repoDisplay: $repoDisplay')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => repoDisplay.hashCode;
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is NotificationKnownRepoRow &&
+          other.repoDisplay == this.repoDisplay);
+}
+
+class NotificationKnownReposCompanion
+    extends UpdateCompanion<NotificationKnownRepoRow> {
+  final Value<String> repoDisplay;
+  final Value<int> rowid;
+  const NotificationKnownReposCompanion({
+    this.repoDisplay = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  NotificationKnownReposCompanion.insert({
+    required String repoDisplay,
+    this.rowid = const Value.absent(),
+  }) : repoDisplay = Value(repoDisplay);
+  static Insertable<NotificationKnownRepoRow> custom({
+    Expression<String>? repoDisplay,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (repoDisplay != null) 'repo_display': repoDisplay,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  NotificationKnownReposCompanion copyWith({
+    Value<String>? repoDisplay,
+    Value<int>? rowid,
+  }) {
+    return NotificationKnownReposCompanion(
+      repoDisplay: repoDisplay ?? this.repoDisplay,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (repoDisplay.present) {
+      map['repo_display'] = Variable<String>(repoDisplay.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('NotificationKnownReposCompanion(')
+          ..write('repoDisplay: $repoDisplay, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -3750,6 +4125,11 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $RepoRunsTable repoRuns = $RepoRunsTable(this);
   late final $RepoReleasesTable repoReleases = $RepoReleasesTable(this);
   late final $SyncStateTable syncState = $SyncStateTable(this);
+  late final $NotificationSeenTable notificationSeen = $NotificationSeenTable(
+    this,
+  );
+  late final $NotificationKnownReposTable notificationKnownRepos =
+      $NotificationKnownReposTable(this);
   late final Index idxMetricSnapshotsRepoKey = Index(
     'idx_metric_snapshots_repo_key',
     'CREATE INDEX idx_metric_snapshots_repo_key ON metric_snapshots (repo_key)',
@@ -3782,6 +4162,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'idx_repo_releases_repo_key',
     'CREATE INDEX idx_repo_releases_repo_key ON repo_releases (repo_key)',
   );
+  late final Index idxNotificationSeenSeenId = Index(
+    'idx_notification_seen_seen_id',
+    'CREATE UNIQUE INDEX idx_notification_seen_seen_id ON notification_seen (seen_id)',
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -3795,6 +4179,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     repoRuns,
     repoReleases,
     syncState,
+    notificationSeen,
+    notificationKnownRepos,
     idxMetricSnapshotsRepoKey,
     idxActivityEventsRepoKey,
     idxActivityEventsOccurredAt,
@@ -3803,6 +4189,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     idxRepoPullsRepoKey,
     idxRepoRunsRepoKey,
     idxRepoReleasesRepoKey,
+    idxNotificationSeenSeenId,
   ];
 }
 
@@ -5742,6 +6129,286 @@ typedef $$SyncStateTableProcessedTableManager =
       SyncStateRow,
       PrefetchHooks Function()
     >;
+typedef $$NotificationSeenTableCreateCompanionBuilder =
+    NotificationSeenCompanion Function({Value<int> id, required String seenId});
+typedef $$NotificationSeenTableUpdateCompanionBuilder =
+    NotificationSeenCompanion Function({Value<int> id, Value<String> seenId});
+
+class $$NotificationSeenTableFilterComposer
+    extends Composer<_$AppDatabase, $NotificationSeenTable> {
+  $$NotificationSeenTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get seenId => $composableBuilder(
+    column: $table.seenId,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$NotificationSeenTableOrderingComposer
+    extends Composer<_$AppDatabase, $NotificationSeenTable> {
+  $$NotificationSeenTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get seenId => $composableBuilder(
+    column: $table.seenId,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$NotificationSeenTableAnnotationComposer
+    extends Composer<_$AppDatabase, $NotificationSeenTable> {
+  $$NotificationSeenTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get seenId =>
+      $composableBuilder(column: $table.seenId, builder: (column) => column);
+}
+
+class $$NotificationSeenTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $NotificationSeenTable,
+          NotificationSeenRow,
+          $$NotificationSeenTableFilterComposer,
+          $$NotificationSeenTableOrderingComposer,
+          $$NotificationSeenTableAnnotationComposer,
+          $$NotificationSeenTableCreateCompanionBuilder,
+          $$NotificationSeenTableUpdateCompanionBuilder,
+          (
+            NotificationSeenRow,
+            BaseReferences<
+              _$AppDatabase,
+              $NotificationSeenTable,
+              NotificationSeenRow
+            >,
+          ),
+          NotificationSeenRow,
+          PrefetchHooks Function()
+        > {
+  $$NotificationSeenTableTableManager(
+    _$AppDatabase db,
+    $NotificationSeenTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$NotificationSeenTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$NotificationSeenTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$NotificationSeenTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> seenId = const Value.absent(),
+              }) => NotificationSeenCompanion(id: id, seenId: seenId),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String seenId,
+              }) => NotificationSeenCompanion.insert(id: id, seenId: seenId),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$NotificationSeenTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $NotificationSeenTable,
+      NotificationSeenRow,
+      $$NotificationSeenTableFilterComposer,
+      $$NotificationSeenTableOrderingComposer,
+      $$NotificationSeenTableAnnotationComposer,
+      $$NotificationSeenTableCreateCompanionBuilder,
+      $$NotificationSeenTableUpdateCompanionBuilder,
+      (
+        NotificationSeenRow,
+        BaseReferences<
+          _$AppDatabase,
+          $NotificationSeenTable,
+          NotificationSeenRow
+        >,
+      ),
+      NotificationSeenRow,
+      PrefetchHooks Function()
+    >;
+typedef $$NotificationKnownReposTableCreateCompanionBuilder =
+    NotificationKnownReposCompanion Function({
+      required String repoDisplay,
+      Value<int> rowid,
+    });
+typedef $$NotificationKnownReposTableUpdateCompanionBuilder =
+    NotificationKnownReposCompanion Function({
+      Value<String> repoDisplay,
+      Value<int> rowid,
+    });
+
+class $$NotificationKnownReposTableFilterComposer
+    extends Composer<_$AppDatabase, $NotificationKnownReposTable> {
+  $$NotificationKnownReposTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$NotificationKnownReposTableOrderingComposer
+    extends Composer<_$AppDatabase, $NotificationKnownReposTable> {
+  $$NotificationKnownReposTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$NotificationKnownReposTableAnnotationComposer
+    extends Composer<_$AppDatabase, $NotificationKnownReposTable> {
+  $$NotificationKnownReposTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => column,
+  );
+}
+
+class $$NotificationKnownReposTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $NotificationKnownReposTable,
+          NotificationKnownRepoRow,
+          $$NotificationKnownReposTableFilterComposer,
+          $$NotificationKnownReposTableOrderingComposer,
+          $$NotificationKnownReposTableAnnotationComposer,
+          $$NotificationKnownReposTableCreateCompanionBuilder,
+          $$NotificationKnownReposTableUpdateCompanionBuilder,
+          (
+            NotificationKnownRepoRow,
+            BaseReferences<
+              _$AppDatabase,
+              $NotificationKnownReposTable,
+              NotificationKnownRepoRow
+            >,
+          ),
+          NotificationKnownRepoRow,
+          PrefetchHooks Function()
+        > {
+  $$NotificationKnownReposTableTableManager(
+    _$AppDatabase db,
+    $NotificationKnownReposTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$NotificationKnownReposTableFilterComposer(
+                $db: db,
+                $table: table,
+              ),
+          createOrderingComposer: () =>
+              $$NotificationKnownReposTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$NotificationKnownReposTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> repoDisplay = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => NotificationKnownReposCompanion(
+                repoDisplay: repoDisplay,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String repoDisplay,
+                Value<int> rowid = const Value.absent(),
+              }) => NotificationKnownReposCompanion.insert(
+                repoDisplay: repoDisplay,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$NotificationKnownReposTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $NotificationKnownReposTable,
+      NotificationKnownRepoRow,
+      $$NotificationKnownReposTableFilterComposer,
+      $$NotificationKnownReposTableOrderingComposer,
+      $$NotificationKnownReposTableAnnotationComposer,
+      $$NotificationKnownReposTableCreateCompanionBuilder,
+      $$NotificationKnownReposTableUpdateCompanionBuilder,
+      (
+        NotificationKnownRepoRow,
+        BaseReferences<
+          _$AppDatabase,
+          $NotificationKnownReposTable,
+          NotificationKnownRepoRow
+        >,
+      ),
+      NotificationKnownRepoRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -5762,4 +6429,11 @@ class $AppDatabaseManager {
       $$RepoReleasesTableTableManager(_db, _db.repoReleases);
   $$SyncStateTableTableManager get syncState =>
       $$SyncStateTableTableManager(_db, _db.syncState);
+  $$NotificationSeenTableTableManager get notificationSeen =>
+      $$NotificationSeenTableTableManager(_db, _db.notificationSeen);
+  $$NotificationKnownReposTableTableManager get notificationKnownRepos =>
+      $$NotificationKnownReposTableTableManager(
+        _db,
+        _db.notificationKnownRepos,
+      );
 }

--- a/lib/notification_seen_store.dart
+++ b/lib/notification_seen_store.dart
@@ -1,0 +1,190 @@
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'database/app_database.dart';
+
+/// The attention notification "seen" baseline, persisted on the local SQLite
+/// database (Phase 4) instead of `SharedPreferences`.
+///
+/// The resident foreground and the background-sync isolate both record the
+/// baseline; on `SharedPreferences` they read-modify-write the same blob and can
+/// clobber each other (last-writer-win). Here [recordBaseline] does additive
+/// `INSERT OR IGNORE`s inside one transaction, so concurrent isolates union
+/// their ids instead of overwriting — an atomic, race-free baseline.
+///
+/// The legacy `SharedPreferences` baseline is imported once, transparently, on
+/// first use (see [_ensureImported]).
+class NotificationSeenStore {
+  NotificationSeenStore._();
+
+  /// Legacy `SharedPreferences` keys, retained only for the one-time import.
+  static const String _legacySeenKey = 'seen_attention';
+  static const String _legacyKnownReposKey = 'known_attention_repos';
+
+  /// `app_meta` markers (kept in the DB so they commit atomically with the data
+  /// they guard).
+  static const String _importedFlag = 'notif_seen_imported';
+  static const String _seededFlag = 'notif_seeded';
+
+  /// Bounds the seen set; the oldest ids beyond this are pruned.
+  static const int maxSeenIds = 5000;
+
+  static AppDatabase? _db;
+  static Future<void>? _migration;
+
+  static Future<void> _lock = SynchronousFuture<void>(null);
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  static AppDatabase get _database => _db ??= AppDatabase();
+
+  @visibleForTesting
+  static void debugUseDatabase(AppDatabase db) {
+    _db = db;
+    _migration = null;
+    _lock = SynchronousFuture<void>(null);
+  }
+
+  /// The already-notified attention ids.
+  static Future<Set<String>> seenIds() async {
+    await _ensureImported();
+    final rows = await _database.select(_database.notificationSeen).get();
+    return rows.map((r) => r.seenId).toSet();
+  }
+
+  /// The repos whose existing backlog has been seeded silently.
+  static Future<Set<String>> knownRepos() async {
+    await _ensureImported();
+    final rows = await _database.select(_database.notificationKnownRepos).get();
+    return rows.map((r) => r.repoDisplay).toSet();
+  }
+
+  /// Whether a baseline has been established (was: the legacy `seen_attention`
+  /// key existing). False means the next record is a silent first-run seed.
+  static Future<bool> isSeeded() async {
+    await _ensureImported();
+    return _hasMeta(_database, _seededFlag);
+  }
+
+  /// Records the new baseline atomically: unions [currentIds] into the seen set
+  /// (pruning to [maxSeenIds] newest), unions [monitoredRepos] into the known
+  /// set, and marks the baseline seeded. Additive inserts make this safe against
+  /// a concurrent isolate doing the same.
+  static Future<void> recordBaseline(
+    Set<String> currentIds,
+    Set<String> monitoredRepos,
+  ) async {
+    await _ensureImported();
+    await _runLocked(() async {
+      final db = _database;
+      await db.transaction(() async {
+        for (final id in currentIds) {
+          await db
+              .into(db.notificationSeen)
+              .insert(
+                NotificationSeenCompanion.insert(seenId: id),
+                mode: InsertMode.insertOrIgnore,
+              );
+        }
+        await _pruneSeen(db);
+        for (final repo in monitoredRepos) {
+          await db
+              .into(db.notificationKnownRepos)
+              .insert(
+                NotificationKnownReposCompanion.insert(repoDisplay: repo),
+                mode: InsertMode.insertOrIgnore,
+              );
+        }
+        await _setMeta(db, _seededFlag, '1');
+      });
+    });
+  }
+
+  /// Keeps only the newest [maxSeenIds] seen rows (by insertion order).
+  static Future<void> _pruneSeen(AppDatabase db) async {
+    final ids =
+        await (db.selectOnly(db.notificationSeen)
+              ..addColumns([db.notificationSeen.id])
+              ..orderBy([
+                OrderingTerm(
+                  expression: db.notificationSeen.id,
+                  mode: OrderingMode.desc,
+                ),
+              ]))
+            .map((row) => row.read(db.notificationSeen.id)!)
+            .get();
+    if (ids.length <= maxSeenIds) return;
+    final toDelete = ids.sublist(maxSeenIds);
+    await (db.delete(
+      db.notificationSeen,
+    )..where((t) => t.id.isIn(toDelete))).go();
+  }
+
+  /// Imports the legacy `SharedPreferences` baseline into the DB exactly once.
+  static Future<void> _ensureImported() {
+    return _migration ??= _migrate().catchError((Object e, StackTrace st) {
+      _migration = null;
+      Error.throwWithStackTrace(e, st);
+    });
+  }
+
+  static Future<void> _migrate() async {
+    final db = _database;
+    if (await _hasMeta(db, _importedFlag)) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final hadBaseline = prefs.containsKey(_legacySeenKey);
+    final seen = prefs.getStringList(_legacySeenKey) ?? const <String>[];
+    final known = prefs.getStringList(_legacyKnownReposKey) ?? const <String>[];
+
+    await db.transaction(() async {
+      // Re-check inside the (serialized) transaction so a concurrent isolate
+      // can't double-import.
+      if (await _hasMeta(db, _importedFlag)) return;
+      for (final id in seen) {
+        await db
+            .into(db.notificationSeen)
+            .insert(
+              NotificationSeenCompanion.insert(seenId: id),
+              mode: InsertMode.insertOrIgnore,
+            );
+      }
+      for (final repo in known) {
+        await db
+            .into(db.notificationKnownRepos)
+            .insert(
+              NotificationKnownReposCompanion.insert(repoDisplay: repo),
+              mode: InsertMode.insertOrIgnore,
+            );
+      }
+      // A pre-existing legacy key means a baseline was established, so preserve
+      // "not first run" across the migration.
+      if (hadBaseline) await _setMeta(db, _seededFlag, '1');
+      await _setMeta(db, _importedFlag, '1');
+    });
+
+    // Safe once the import marker is committed.
+    await prefs.remove(_legacySeenKey);
+    await prefs.remove(_legacyKnownReposKey);
+  }
+
+  static Future<bool> _hasMeta(AppDatabase db, String key) async {
+    final row = await (db.select(
+      db.appMeta,
+    )..where((t) => t.key.equals(key))).getSingleOrNull();
+    return row != null;
+  }
+
+  static Future<void> _setMeta(AppDatabase db, String key, String value) {
+    return db
+        .into(db.appMeta)
+        .insertOnConflictUpdate(
+          AppMetaCompanion.insert(key: key, value: value),
+        );
+  }
+}

--- a/lib/notification_seen_store.dart
+++ b/lib/notification_seen_store.dart
@@ -10,8 +10,10 @@ import 'database/app_database.dart';
 /// The resident foreground and the background-sync isolate both record the
 /// baseline; on `SharedPreferences` they read-modify-write the same blob and can
 /// clobber each other (last-writer-win). Here [recordBaseline] does additive
-/// `INSERT OR IGNORE`s inside one transaction, so concurrent isolates union
-/// their ids instead of overwriting — an atomic, race-free baseline.
+/// upserts inside one transaction (`INSERT OR REPLACE` for seen ids — so a
+/// re-seen id is bumped to newest and never wrongly pruned — and `INSERT OR
+/// IGNORE` for known repos), so concurrent isolates union rather than overwrite:
+/// an atomic, race-free baseline.
 ///
 /// The legacy `SharedPreferences` baseline is imported once, transparently, on
 /// first use (see [_ensureImported]).
@@ -109,24 +111,14 @@ class NotificationSeenStore {
     });
   }
 
-  /// Keeps only the newest [maxSeenIds] seen rows (by insertion order).
+  /// Keeps only the newest [maxSeenIds] seen rows (by insertion order). Deletes
+  /// via a subquery so no large `IN (...)` list is materialized.
   static Future<void> _pruneSeen(AppDatabase db) async {
-    final ids =
-        await (db.selectOnly(db.notificationSeen)
-              ..addColumns([db.notificationSeen.id])
-              ..orderBy([
-                OrderingTerm(
-                  expression: db.notificationSeen.id,
-                  mode: OrderingMode.desc,
-                ),
-              ]))
-            .map((row) => row.read(db.notificationSeen.id)!)
-            .get();
-    if (ids.length <= maxSeenIds) return;
-    final toDelete = ids.sublist(maxSeenIds);
-    await (db.delete(
-      db.notificationSeen,
-    )..where((t) => t.id.isIn(toDelete))).go();
+    await db.customStatement(
+      'DELETE FROM notification_seen WHERE id NOT IN '
+      '(SELECT id FROM notification_seen ORDER BY id DESC LIMIT ?)',
+      [maxSeenIds],
+    );
   }
 
   /// Imports the legacy `SharedPreferences` baseline into the DB exactly once.

--- a/lib/notification_seen_store.dart
+++ b/lib/notification_seen_store.dart
@@ -85,27 +85,29 @@ class NotificationSeenStore {
     await _runLocked(() async {
       final db = _database;
       await db.transaction(() async {
-        for (final id in currentIds) {
-          // OR REPLACE (not IGNORE) so a re-seen id is bumped to a fresh, newest
-          // autoincrement id — a continuously-current item then never falls into
-          // the oldest-pruned tail and can't be spuriously re-notified. Still
-          // additive across isolates (the id stays present).
-          await db
-              .into(db.notificationSeen)
-              .insert(
-                NotificationSeenCompanion.insert(seenId: id),
-                mode: InsertMode.insertOrReplace,
-              );
-        }
+        // OR REPLACE (not IGNORE) so a re-seen id is bumped to a fresh, newest
+        // autoincrement id — a continuously-current item then never falls into
+        // the oldest-pruned tail and can't be spuriously re-notified. Still
+        // additive across isolates (the id stays present). Batched so N ids are
+        // one round-trip, not N.
+        await db.batch((batch) {
+          batch.insertAll(
+            db.notificationSeen,
+            currentIds.map(
+              (id) => NotificationSeenCompanion.insert(seenId: id),
+            ),
+            mode: InsertMode.insertOrReplace,
+          );
+          batch.insertAll(
+            db.notificationKnownRepos,
+            monitoredRepos.map(
+              (repo) =>
+                  NotificationKnownReposCompanion.insert(repoDisplay: repo),
+            ),
+            mode: InsertMode.insertOrIgnore,
+          );
+        });
         await _pruneSeen(db);
-        for (final repo in monitoredRepos) {
-          await db
-              .into(db.notificationKnownRepos)
-              .insert(
-                NotificationKnownReposCompanion.insert(repoDisplay: repo),
-                mode: InsertMode.insertOrIgnore,
-              );
-        }
         await _setMeta(db, _seededFlag, '1');
       });
     });
@@ -134,6 +136,10 @@ class NotificationSeenStore {
     if (await _hasMeta(db, _importedFlag)) return;
 
     final prefs = await SharedPreferences.getInstance();
+    // Freshen from disk before reading the legacy blobs, so a reused isolate
+    // with a stale cache doesn't import an empty set and then clear the real
+    // legacy keys.
+    await prefs.reload();
     final hadBaseline = prefs.containsKey(_legacySeenKey);
     final seen = prefs.getStringList(_legacySeenKey) ?? const <String>[];
     final known = prefs.getStringList(_legacyKnownReposKey) ?? const <String>[];
@@ -142,22 +148,20 @@ class NotificationSeenStore {
       // Re-check inside the (serialized) transaction so a concurrent isolate
       // can't double-import.
       if (await _hasMeta(db, _importedFlag)) return;
-      for (final id in seen) {
-        await db
-            .into(db.notificationSeen)
-            .insert(
-              NotificationSeenCompanion.insert(seenId: id),
-              mode: InsertMode.insertOrIgnore,
-            );
-      }
-      for (final repo in known) {
-        await db
-            .into(db.notificationKnownRepos)
-            .insert(
-              NotificationKnownReposCompanion.insert(repoDisplay: repo),
-              mode: InsertMode.insertOrIgnore,
-            );
-      }
+      await db.batch((batch) {
+        batch.insertAll(
+          db.notificationSeen,
+          seen.map((id) => NotificationSeenCompanion.insert(seenId: id)),
+          mode: InsertMode.insertOrIgnore,
+        );
+        batch.insertAll(
+          db.notificationKnownRepos,
+          known.map(
+            (repo) => NotificationKnownReposCompanion.insert(repoDisplay: repo),
+          ),
+          mode: InsertMode.insertOrIgnore,
+        );
+      });
       // A pre-existing legacy key means a baseline was established, so preserve
       // "not first run" across the migration.
       if (hadBaseline) await _setMeta(db, _seededFlag, '1');

--- a/lib/notification_seen_store.dart
+++ b/lib/notification_seen_store.dart
@@ -84,11 +84,15 @@ class NotificationSeenStore {
       final db = _database;
       await db.transaction(() async {
         for (final id in currentIds) {
+          // OR REPLACE (not IGNORE) so a re-seen id is bumped to a fresh, newest
+          // autoincrement id — a continuously-current item then never falls into
+          // the oldest-pruned tail and can't be spuriously re-notified. Still
+          // additive across isolates (the id stays present).
           await db
               .into(db.notificationSeen)
               .insert(
                 NotificationSeenCompanion.insert(seenId: id),
-                mode: InsertMode.insertOrIgnore,
+                mode: InsertMode.insertOrReplace,
               );
         }
         await _pruneSeen(db);

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -63,6 +63,12 @@ class NotificationService {
           .toList();
       final currentIds = attention.map((item) => item.id).toSet();
       final prefs = await SharedPreferences.getInstance();
+      // Freshen the cached prefs from disk: the seen baseline is now atomic in
+      // the DB, but the repo lists and notification settings are still read from
+      // SharedPreferences here, so a reused background isolate should still pick
+      // up foreground config changes (e.g. a repo added, or notifications
+      // disabled) before deciding.
+      await prefs.reload();
       // Mark every monitored repo "known" — including ones that currently have
       // zero attention items — so adding a repo silences only its existing
       // backlog while the first attention item that later appears in a
@@ -74,7 +80,12 @@ class NotificationService {
       );
       // The seen baseline lives in the DB (Phase 4): the foreground and the
       // background-sync isolate record it additively, so neither clobbers the
-      // other's snapshot (no `prefs.reload()` dance needed).
+      // other's snapshot. (The notification *decision* itself — read baseline,
+      // notify, then record — is still per-isolate, so a truly-simultaneous
+      // foreground+background run could each notify the same item once; that is
+      // rare because the background task runs while the app is suspended and not
+      // actively notifying, and the additive baseline prevents any re-notify on
+      // the following cycle.)
       final firstRun = !await NotificationSeenStore.isSeeded();
       final seen = await NotificationSeenStore.seenIds();
       final knownRepos = await NotificationSeenStore.knownRepos();

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -5,22 +5,12 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'attention_service.dart';
+import 'notification_seen_store.dart';
 import 'preferences_store.dart';
 import 'repo_store.dart';
 
 class NotificationService {
   NotificationService._();
-
-  static const String _seenKey = 'seen_attention';
-
-  /// Repos whose first snapshot has been seeded, so adding a repo doesn't
-  /// replay its whole existing backlog as "new".
-  static const String _knownReposKey = 'known_attention_repos';
-
-  /// Safety cap on the monotonic seen-id set (the baseline only grows via
-  /// union); a very long uptime resets to the current snapshot rather than
-  /// growing without bound.
-  static const int _maxSeenIds = 5000;
 
   static const int _summaryNotificationId = 42001;
   static const String _channelId = 'attention_inbox';
@@ -73,29 +63,21 @@ class NotificationService {
           .toList();
       final currentIds = attention.map((item) => item.id).toSet();
       final prefs = await SharedPreferences.getInstance();
-      // Refresh the in-memory cache from disk first: the background-sync isolate
-      // and the resident foreground isolate each cache prefs independently, so
-      // without this a resident foreground could re-notify items the background
-      // sync already alerted on (and clobber its advanced baseline). This closes
-      // the common sequential case; a truly-simultaneous foreground+background
-      // notify could still last-writer-win (rare — the background task runs when
-      // the app is suspended and not actively notifying). A fully atomic
-      // cross-isolate baseline would move the seen set into the DB (follow-up).
-      await prefs.reload();
       // Mark every monitored repo "known" — including ones that currently have
       // zero attention items — so adding a repo silences only its existing
       // backlog while the first attention item that later appears in a
-      // quiet-at-add repo still notifies.
+      // quiet-at-add repo still notifies. (Repo lists remain configuration in
+      // SharedPreferences.)
       final monitoredRepos = monitoredRepoDisplays(
         prefs.getStringList(RepoStore.githubKey) ?? const <String>[],
         prefs.getStringList(RepoStore.adoKey) ?? const <String>[],
       );
-      // On the very first run there is no baseline, so seed silently instead of
-      // notifying for every existing item.
-      final firstRun = !prefs.containsKey(_seenKey);
-      final seen = (prefs.getStringList(_seenKey) ?? const <String>[]).toSet();
-      final knownRepos =
-          (prefs.getStringList(_knownReposKey) ?? const <String>[]).toSet();
+      // The seen baseline lives in the DB (Phase 4): the foreground and the
+      // background-sync isolate record it additively, so neither clobbers the
+      // other's snapshot (no `prefs.reload()` dance needed).
+      final firstRun = !await NotificationSeenStore.isSeeded();
+      final seen = await NotificationSeenStore.seenIds();
+      final knownRepos = await NotificationSeenStore.knownRepos();
       final newIds = pendingIds(
         seen: seen,
         knownRepos: knownRepos,
@@ -131,18 +113,11 @@ class NotificationService {
         firstRun: firstRun,
         inQuietHours: inQuietHours,
       )) {
-        // Union so ids are never dropped: a transiently-failed repo keeps its
-        // baseline (recovery doesn't re-notify) and one caller's snapshot can't
-        // clobber another's. Repos are recorded so their first appearance is
-        // only ever seeded once.
-        await prefs.setStringList(
-          _seenKey,
-          mergeSeen(seen, currentIds).toList()..sort(),
-        );
-        await prefs.setStringList(
-          _knownReposKey,
-          knownRepos.union(monitoredRepos).toList()..sort(),
-        );
+        // Additive, atomic union in the DB: ids are never dropped (a
+        // transiently-failed repo keeps its baseline) and concurrent isolates
+        // can't clobber each other's snapshot. Repos are recorded so their first
+        // appearance is only ever seeded once.
+        await NotificationSeenStore.recordBaseline(currentIds, monitoredRepos);
       }
     } catch (e) {
       debugPrint('Failed to process attention notifications: $e');
@@ -173,15 +148,6 @@ class NotificationService {
         .map((item) => item.id)
         .toSet();
     return diffNew(seen, currentIds).difference(newRepoItemIds);
-  }
-
-  /// The next baseline: the union of the existing [seen] set and the current
-  /// snapshot, so ids are never dropped. A very large set (long uptime) resets
-  /// to the current snapshot to bound growth.
-  @visibleForTesting
-  static Set<String> mergeSeen(Set<String> seen, Set<String> currentIds) {
-    final merged = seen.union(currentIds);
-    return merged.length > _maxSeenIds ? currentIds : merged;
   }
 
   /// The `repoDisplay` of every monitored repository, derived from the persisted

--- a/test/notification_seen_store_test.dart
+++ b/test/notification_seen_store_test.dart
@@ -1,0 +1,100 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/database/app_database.dart';
+import 'package:kode_radar/notification_seen_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.forExecutor(NativeDatabase.memory());
+    NotificationSeenStore.debugUseDatabase(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('starts unseeded and empty', () async {
+    expect(await NotificationSeenStore.isSeeded(), isFalse);
+    expect(await NotificationSeenStore.seenIds(), isEmpty);
+    expect(await NotificationSeenStore.knownRepos(), isEmpty);
+  });
+
+  test('recordBaseline seeds and unions ids/repos additively', () async {
+    await NotificationSeenStore.recordBaseline({'a', 'b'}, {'owner/one'});
+    expect(await NotificationSeenStore.isSeeded(), isTrue);
+    expect(await NotificationSeenStore.seenIds(), {'a', 'b'});
+    expect(await NotificationSeenStore.knownRepos(), {'owner/one'});
+
+    // A second record unions rather than overwrites (simulating a concurrent
+    // isolate's snapshot).
+    await NotificationSeenStore.recordBaseline({'b', 'c'}, {'owner/two'});
+    expect(await NotificationSeenStore.seenIds(), {'a', 'b', 'c'});
+    expect(await NotificationSeenStore.knownRepos(), {
+      'owner/one',
+      'owner/two',
+    });
+  });
+
+  test('recordBaseline prunes the seen set to the newest maxSeenIds', () async {
+    final many = {
+      for (var i = 0; i < NotificationSeenStore.maxSeenIds + 50; i++) 'id$i',
+    };
+    await NotificationSeenStore.recordBaseline(many, const {});
+    final seen = await NotificationSeenStore.seenIds();
+    expect(seen.length, NotificationSeenStore.maxSeenIds);
+    // Newest ids kept; oldest evicted.
+    expect(seen.contains('id${NotificationSeenStore.maxSeenIds + 49}'), isTrue);
+    expect(seen.contains('id0'), isFalse);
+  });
+
+  test('imports a legacy SharedPreferences baseline once', () async {
+    SharedPreferences.setMockInitialValues({
+      'seen_attention': ['x', 'y'],
+      'known_attention_repos': ['owner/legacy'],
+    });
+    // Fresh db + store so the one-time import runs against it.
+    final freshDb = AppDatabase.forExecutor(NativeDatabase.memory());
+    NotificationSeenStore.debugUseDatabase(freshDb);
+
+    expect(await NotificationSeenStore.isSeeded(), isTrue);
+    expect(await NotificationSeenStore.seenIds(), {'x', 'y'});
+    expect(await NotificationSeenStore.knownRepos(), {'owner/legacy'});
+    // Legacy keys cleared after import.
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.containsKey('seen_attention'), isFalse);
+
+    await freshDb.close();
+  });
+
+  test('a fresh install (no legacy baseline) stays unseeded', () async {
+    // No legacy keys set; import runs but establishes no baseline.
+    expect(await NotificationSeenStore.isSeeded(), isFalse);
+    expect(await NotificationSeenStore.seenIds(), isEmpty);
+  });
+
+  test('v6 -> v7 upgrade creates the notification-seen tables', () async {
+    // Set user_version = 6 so opening AppDatabase runs onUpgrade(6 -> 7). Create
+    // app_meta (an original table the store reads; present in any real upgrade).
+    final native = sqlite3.openInMemory();
+    native.execute(
+      'CREATE TABLE app_meta (key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)',
+    );
+    native.execute('PRAGMA user_version = 6;');
+    final upgraded = AppDatabase.forExecutor(
+      NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+    );
+    NotificationSeenStore.debugUseDatabase(upgraded);
+
+    await NotificationSeenStore.recordBaseline({'a'}, {'owner/one'});
+    expect(await NotificationSeenStore.seenIds(), {'a'});
+
+    await upgraded.close();
+  });
+}

--- a/test/notification_seen_store_test.dart
+++ b/test/notification_seen_store_test.dart
@@ -54,6 +54,20 @@ void main() {
     expect(seen.contains('id0'), isFalse);
   });
 
+  test('a re-seen id is bumped so it survives pruning', () async {
+    await NotificationSeenStore.recordBaseline({'keep'}, const {});
+    // Fill past the cap while ALSO re-seeing 'keep', which bumps it to newest.
+    final fresh = {
+      for (var i = 0; i <= NotificationSeenStore.maxSeenIds; i++) 'n$i',
+    };
+    await NotificationSeenStore.recordBaseline({...fresh, 'keep'}, const {});
+
+    final seen = await NotificationSeenStore.seenIds();
+    expect(seen.length, NotificationSeenStore.maxSeenIds);
+    // 'keep' was re-seen this round, so it wasn't evicted as "oldest".
+    expect(seen.contains('keep'), isTrue);
+  });
+
   test('imports a legacy SharedPreferences baseline once', () async {
     SharedPreferences.setMockInitialValues({
       'seen_attention': ['x', 'y'],

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -130,27 +130,4 @@ void main() {
       expect(pending, isEmpty);
     });
   });
-
-  group('mergeSeen', () {
-    test('unions so a transiently-absent id is retained (no re-notify)', () {
-      // The repo behind 'b' failed this cycle so 'b' is missing from current,
-      // but it must stay in the baseline so recovery does not re-notify it.
-      expect(NotificationService.mergeSeen(const {'a', 'b'}, const {'a'}), {
-        'a',
-        'b',
-      });
-    });
-
-    test('adds newly seen ids', () {
-      expect(NotificationService.mergeSeen(const {'a'}, const {'a', 'b'}), {
-        'a',
-        'b',
-      });
-    });
-
-    test('resets to the current snapshot beyond the growth cap', () {
-      final huge = {for (var i = 0; i < 6000; i++) 'id$i'};
-      expect(NotificationService.mergeSeen(huge, const {'a', 'b'}), {'a', 'b'});
-    });
-  });
 }


### PR DESCRIPTION
## What

Local-database **Phase 4** — the attention-notification "seen" baseline moves from SharedPreferences to the DB, fixing the documented cross-isolate baseline-clobber race and retiring the `seen_attention`/`known_attention_repos` blobs.

`notifyNewAttention` runs in **both** the foreground and the workmanager background-sync isolate. It maintained a monotonic seen-id set + known-repos set in SharedPreferences via read-modify-write, so two isolates could clobber each other's baseline (last-writer-win); a `prefs.reload()` only narrowed the window.

## Changes

- **New drift tables**: `notification_seen` (autoincrement `id` + UNIQUE `seenId`) and `notification_known_repos` (`repoDisplay` PK). `schemaVersion` 6→7 idempotent `onUpgrade`.
- **`NotificationSeenStore.recordBaseline`** does additive upserts in one transaction — `INSERT OR REPLACE` for seen ids (so a re-seen id is bumped to newest and a still-current item is never pruned as "oldest") and `INSERT OR IGNORE` for known repos — so concurrent isolates *union* rather than overwrite. The seen set is pruned to the newest 5000 via a `NOT IN (SELECT ... LIMIT)` subquery. `_ensureImported()` brings the legacy blobs across once (setting a `notif_seeded` marker iff the legacy key existed, to preserve first-run semantics), then clears them.
- **`NotificationService`**: reads `firstRun`/`seen`/`known` from the store and calls `recordBaseline`; removed the `_seenKey`/`_knownReposKey`/`_maxSeenIds` constants and the now-unused `mergeSeen` helper. `prefs.reload()` is **kept** (repurposed) so a reused background isolate still picks up foreground config changes (repo lists / notification settings stay in SharedPreferences). The pure `pendingIds`/`shouldAdvanceBaseline`/`monitoredRepoDisplays` logic is unchanged.

## Notes

- The notification *decision* (read baseline → notify → record) is still per-isolate, so a truly-simultaneous foreground+background run could each notify the same item once — rare (the background task runs while the app is suspended), and the additive baseline prevents any re-notify on the next cycle. Folding the whole decision into one transaction is a possible follow-up.

## Testing

- `test/notification_seen_store_test.dart`: unseeded start, additive union, prune to `maxSeenIds`, re-seen id survives pruning, one-time legacy import + key clearing, fresh-install-stays-unseeded, and the **v6→v7 upgrade**.
- `flutter test` (307), `flutter analyze --fatal-infos`, `dart format` all clean.