### PR TITLE
Populate the feed + attention caches from background sync

### DIFF
--- a/lib/sync_service.dart
+++ b/lib/sync_service.dart
@@ -1,13 +1,21 @@
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
 
+import 'activity_event_store.dart';
+import 'activity_feed_service.dart';
 import 'activity_service.dart';
 import 'app_http.dart';
 import 'attention_service.dart';
+import 'attention_store.dart';
 import 'identity_store.dart';
 import 'metric_store.dart';
+import 'monitored_repos.dart';
 import 'notification_service.dart';
+import 'preferences_store.dart';
+import 'repo_store.dart';
 import 'snooze_store.dart';
+import 'sync_state_store.dart';
 
 /// Outcome of a sync. [activityOk] reflects whether the repo-activity + trend
 /// capture half succeeded (the part a manual "Sync now" reports on); attention
@@ -23,15 +31,17 @@ class SyncResult {
 /// poll attention on their own timers; this centralizes the on-demand and
 /// background paths.)
 ///
-/// It refreshes repo activity and records a trend snapshot, then recomputes the
-/// attention inbox and notifies for anything new. It never throws — each half
-/// is isolated so a failure in one doesn't skip the other.
+/// It refreshes repo activity and records a trend snapshot, refreshes the
+/// attention inbox (notifying for anything new and persisting its cache), and
+/// refreshes the activity-feed cache, so the offline caches and their "Updated"
+/// provenance are current even when the sync ran in the background. It never
+/// throws — each phase is isolated so a failure in one doesn't skip the others.
 class SyncService {
   SyncService._();
 
   /// Runs one full sync. Pass [force] to bypass the trend-capture interval (used
   /// by "Sync now" so it always records a data point). Pass [background] to run
-  /// the two halves concurrently under a deadline that fits iOS's tight
+  /// the phases concurrently under a deadline that fits iOS's tight
   /// `BGAppRefreshTask` budget.
   static Future<SyncResult> runOnce({
     http.Client? client,
@@ -41,12 +51,14 @@ class SyncService {
     final httpClient = client ?? AppHttp.client;
     final deadline = background ? const Duration(seconds: 25) : null;
 
+    Future<T> withDeadline<T>(Future<T> future) =>
+        deadline == null ? future : future.timeout(deadline);
+
     Future<SyncResult> activityPhase() async {
       try {
-        final future = ActivityService.computeAll(client: httpClient);
-        final activities = deadline == null
-            ? await future
-            : await future.timeout(deadline);
+        final activities = await withDeadline(
+          ActivityService.computeAll(client: httpClient),
+        );
         await MetricStore.capture(
           activities,
           restrictToMonitored: true,
@@ -64,18 +76,53 @@ class SyncService {
         final snoozed = await SnoozeStore.snoozedIds();
         final selfGithub = await IdentityStore.selfGithubLogins();
         final selfAdo = await IdentityStore.selfAdoNames();
-        final future = AttentionService.computeAll(
-          client: httpClient,
-          snoozedIds: snoozed,
-          selfGithubLogins: selfGithub,
-          selfAdoNames: selfAdo,
+        // Compute WITHOUT snooze filtering so the persisted cache sees each
+        // repo's true success/failure (matching the inbox page); snooze is
+        // applied only when notifying.
+        final items = await withDeadline(
+          AttentionService.computeAll(
+            client: httpClient,
+            selfGithubLogins: selfGithub,
+            selfAdoNames: selfAdo,
+          ),
         );
-        final items = deadline == null
-            ? await future
-            : await future.timeout(deadline);
-        await NotificationService.notifyNewAttention(items);
+        await AttentionStore.save(items);
+        // Provenance: a real sync unless every monitored repo errored.
+        final erroredRepos = items
+            .where((i) => i.category == AttentionStore.errorCategory)
+            .length;
+        final prefs = await SharedPreferences.getInstance();
+        final monitoredCount = parseMonitoredRepos(
+          prefs.getStringList(RepoStore.githubKey) ?? const <String>[],
+          prefs.getStringList(RepoStore.adoKey) ?? const <String>[],
+        ).length;
+        if (monitoredCount == 0 || erroredRepos < monitoredCount) {
+          await SyncStateStore.markSuccess(SyncStateStore.attentionScope);
+        }
+        await NotificationService.notifyNewAttention(
+          items.where((i) => !snoozed.contains(i.id)).toList(),
+        );
       } catch (e, st) {
         debugPrint('SyncService: attention failed: $e\n$st');
+      }
+    }
+
+    Future<void> feedPhase() async {
+      try {
+        final appPrefs = await PreferencesStore.load();
+        final lookback = Duration(days: appPrefs.feedLookbackDays);
+        final result = await withDeadline(
+          ActivityFeedService.computeAll(
+            client: httpClient,
+            lookback: lookback,
+          ),
+        );
+        await ActivityEventStore.save(result.events, restrictToMonitored: true);
+        if (result.failedSources == 0 || result.okSources > 0) {
+          await SyncStateStore.markSuccess(SyncStateStore.feedScope);
+        }
+      } catch (e, st) {
+        debugPrint('SyncService: feed cache failed: $e\n$st');
       }
     }
 
@@ -86,12 +133,14 @@ class SyncService {
       await Future.wait([
         activityPhase().then((r) => result = r),
         attentionPhase(),
+        feedPhase(),
       ]);
       return result;
     }
 
     final result = await activityPhase();
     await attentionPhase();
+    await feedPhase();
     return result;
   }
 }

--- a/lib/sync_service.dart
+++ b/lib/sync_service.dart
@@ -54,7 +54,12 @@ class SyncService {
     // Freshen the config cache from disk: a reused background isolate could hold
     // a stale monitored-repo list / preferences, which would skew the
     // `restrictToMonitored` cache prune and the provenance monitored-count.
-    await (await SharedPreferences.getInstance()).reload();
+    // Swallow failures so runOnce keeps its never-throw contract.
+    try {
+      await (await SharedPreferences.getInstance()).reload();
+    } catch (e, st) {
+      debugPrint('SyncService: prefs reload failed: $e\n$st');
+    }
 
     // NOTE: the per-repo cache writes below are serialized only within an
     // isolate (each store's static lock). A background run happens while the app
@@ -99,9 +104,13 @@ class SyncService {
           ),
         );
         await AttentionStore.save(items);
-        // Provenance: a real sync unless every monitored repo errored.
+        // Provenance: a real sync unless every monitored repo errored. Count
+        // errored repos by distinct repoDisplay to line up with monitoredCount
+        // (which parseMonitoredRepos de-dupes by repoKey).
         final erroredRepos = items
             .where((i) => i.category == AttentionStore.errorCategory)
+            .map((i) => i.repoDisplay)
+            .toSet()
             .length;
         final prefs = await SharedPreferences.getInstance();
         final monitoredCount = parseMonitoredRepos(

--- a/lib/sync_service.dart
+++ b/lib/sync_service.dart
@@ -51,6 +51,18 @@ class SyncService {
     final httpClient = client ?? AppHttp.client;
     final deadline = background ? const Duration(seconds: 25) : null;
 
+    // Freshen the config cache from disk: a reused background isolate could hold
+    // a stale monitored-repo list / preferences, which would skew the
+    // `restrictToMonitored` cache prune and the provenance monitored-count.
+    await (await SharedPreferences.getInstance()).reload();
+
+    // NOTE: the per-repo cache writes below are serialized only within an
+    // isolate (each store's static lock). A background run happens while the app
+    // is suspended, so it rarely overlaps a foreground write; if it did, the
+    // later snapshot could briefly overwrite a newer one — self-corrected on the
+    // next foreground load. A cross-isolate write-generation guard is a possible
+    // follow-up.
+
     Future<T> withDeadline<T>(Future<T> future) =>
         deadline == null ? future : future.timeout(deadline);
 
@@ -111,10 +123,16 @@ class SyncService {
       try {
         final appPrefs = await PreferencesStore.load();
         final lookback = Duration(days: appPrefs.feedLookbackDays);
+        final selfGithub = await IdentityStore.selfGithubLogins();
+        final selfAdo = await IdentityStore.selfAdoNames();
         final result = await withDeadline(
           ActivityFeedService.computeAll(
             client: httpClient,
             lookback: lookback,
+            // Pass identities so cached events keep their correct `isMine`
+            // instead of being overwritten as not-mine.
+            selfGithubLogins: selfGithub,
+            selfAdoNames: selfAdo,
           ),
         );
         await ActivityEventStore.save(result.events, restrictToMonitored: true);


### PR DESCRIPTION
## What

`SyncService.runOnce` (shared by manual **Sync now** and the workmanager background-sync isolate) now keeps the offline caches fresh — not just the MetricStore trend snapshot — so a **cold start / resume after a background run shows fresh cached data** with an honest "Updated Xh ago" label.

## Changes (lib/sync_service.dart)

- **`attentionPhase`** persists the snapshot to `AttentionStore` (computed **unfiltered** like the inbox page, so the cache sees each repo's true success/failure; notifications stay snooze-filtered) and marks `SyncStateStore` attention provenance when at least one monitored repo loaded.
- **New `feedPhase`** fetches the activity feed (**with identities**, so cached events keep their correct `isMine`) and `ActivityEventStore.save(..., restrictToMonitored: true)`, marking feed provenance when `failedSources == 0 || okSources > 0`.
- Reloads SharedPreferences up front so a reused background isolate doesn't use a stale monitored-repo list. Extracted a `withDeadline()` helper (the 25s iOS budget wraps only the network fetches, not the DB writes). Background runs all three phases concurrently; foreground sequentially.

## Notes / limitations

- **Reactivity is same-isolate.** Drift's table-change notifications don't cross DB connections, so a *background* isolate's write doesn't live-update an already-open page; because the background task runs while the app is suspended, the win is on the next cold start/resume read (and a foreground **Sync now** *does* live-update the reactive feed within the foreground isolate).
- Per-repo cache writes are serialized only within an isolate; a background run overlapping a foreground write is rare (app suspended) and self-corrects on the next foreground load (documented in code as a possible cross-isolate-guard follow-up).

## Testing

- `flutter test` (307), `flutter analyze --fatal-infos`, `dart format` all clean.