### PR TITLE
Show per-token API rate-limit budget in Manage Tokens

### DIFF
--- a/lib/manage_tokens_page.dart
+++ b/lib/manage_tokens_page.dart
@@ -155,6 +155,8 @@ class _ManageTokensPageState extends State<ManageTokensPage> {
         checkedAt: now,
         account: result.account,
         message: result.message,
+        rateLimitRemaining: result.rateLimit?.remaining,
+        rateLimitResetAt: result.rateLimit?.resetAt,
       );
     });
   }
@@ -328,16 +330,53 @@ class _ManageTokensPageState extends State<ManageTokensPage> {
     final suffix = stale
         ? ' · checked ${_relativeTime(check.checkedAt)} (may be out of date)'
         : ' · checked ${_relativeTime(check.checkedAt)}';
-    return Row(
+    return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Icon(icon, size: 16, color: color),
-        const SizedBox(width: 6),
-        Expanded(
-          child: Text('$text$suffix', style: TextStyle(color: color)),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, size: 16, color: color),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Text('$text$suffix', style: TextStyle(color: color)),
+            ),
+          ],
         ),
+        if (check.rateLimitRemaining != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 2, left: 22),
+            child: Text(
+              _rateLimitText(check),
+              style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+            ),
+          ),
       ],
     );
+  }
+
+  /// A one-line API rate-limit budget summary for a stored check, e.g.
+  /// "GitHub REST API: 4823 left · resets in 41m". Only GitHub reports this
+  /// budget; the count reflects the moment of the last check (see the
+  /// "checked …" note on the status line above it).
+  static String _rateLimitText(StoredTokenCheck check) {
+    final buffer = StringBuffer(
+      'GitHub REST API: ${check.rateLimitRemaining} left',
+    );
+    final reset = check.rateLimitResetAt;
+    if (reset != null) {
+      final until = reset.difference(DateTime.now());
+      if (until.inSeconds > 0) {
+        if (until.inMinutes < 1) {
+          buffer.write(' · resets in ${until.inSeconds}s');
+        } else if (until.inMinutes < 60) {
+          buffer.write(' · resets in ${until.inMinutes}m');
+        } else {
+          buffer.write(' · resets in ${until.inHours}h');
+        }
+      }
+    }
+    return buffer.toString();
   }
 
   static String _relativeTime(DateTime time) {

--- a/lib/manage_tokens_page.dart
+++ b/lib/manage_tokens_page.dart
@@ -302,6 +302,10 @@ class _ManageTokensPageState extends State<ManageTokensPage> {
   }
 
   Widget _buildCheckStatus(StoredTokenCheck check) {
+    // The status icon and the gap to its text; the secondary budget line is
+    // indented by their sum so it aligns under the status text.
+    const iconSize = 16.0;
+    const iconGap = 6.0;
     // A stored "authenticated" result only reflects the moment it was checked;
     // after a while the token may have been revoked, so de-emphasize old
     // successes rather than implying current validity.
@@ -336,8 +340,8 @@ class _ManageTokensPageState extends State<ManageTokensPage> {
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Icon(icon, size: 16, color: color),
-            const SizedBox(width: 6),
+            Icon(icon, size: iconSize, color: color),
+            const SizedBox(width: iconGap),
             Expanded(
               child: Text('$text$suffix', style: TextStyle(color: color)),
             ),
@@ -345,7 +349,7 @@ class _ManageTokensPageState extends State<ManageTokensPage> {
         ),
         if (check.rateLimitRemaining != null)
           Padding(
-            padding: const EdgeInsets.only(top: 2, left: 22),
+            padding: const EdgeInsets.only(top: 2, left: iconSize + iconGap),
             child: Text(
               _rateLimitText(check),
               style: TextStyle(fontSize: 12, color: Colors.grey[600]),

--- a/lib/token_health_service.dart
+++ b/lib/token_health_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import 'identity_service.dart';
+import 'api_cache.dart';
 import 'token_store.dart';
 
 /// The outcome of a token health check.
@@ -21,7 +22,7 @@ enum TokenHealth {
 
 /// The result of verifying a single token against its provider.
 class TokenCheck {
-  const TokenCheck(this.health, {this.account, this.message});
+  const TokenCheck(this.health, {this.account, this.message, this.rateLimit});
 
   final TokenHealth health;
 
@@ -32,7 +33,19 @@ class TokenCheck {
   /// A human-readable explanation when the token is not valid.
   final String? message;
 
+  /// The API rate-limit budget the provider reported for this token on the
+  /// check request (GitHub returns `X-RateLimit-*`), or null if none was seen.
+  final RateLimitStatus? rateLimit;
+
   bool get isValid => health == TokenHealth.valid;
+
+  /// Returns a copy carrying [rateLimit].
+  TokenCheck withRateLimit(RateLimitStatus? rateLimit) => TokenCheck(
+    health,
+    account: account,
+    message: message,
+    rateLimit: rateLimit,
+  );
 }
 
 /// Actively verifies whether a stored token still authenticates, reusing the
@@ -143,7 +156,10 @@ class TokenHealthService {
           ),
           {'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}'},
         );
-        return adoResult(response.statusCode, _tryDecode(response.body));
+        return adoResult(
+          response.statusCode,
+          _tryDecode(response.body),
+        ).withRateLimit(_rateLimitOf(response));
       }
       final response = await _send(
         httpClient,
@@ -153,7 +169,10 @@ class TokenHealthService {
           'Accept': 'application/vnd.github+json',
         },
       );
-      return githubResult(response.statusCode, _tryDecode(response.body));
+      return githubResult(
+        response.statusCode,
+        _tryDecode(response.body),
+      ).withRateLimit(_rateLimitOf(response));
     } on TimeoutException {
       return const TokenCheck(
         TokenHealth.error,
@@ -199,5 +218,13 @@ class TokenHealthService {
     } catch (_) {
       return null;
     }
+  }
+
+  /// The rate-limit budget from a response's headers, or null when the provider
+  /// reported no budget (e.g. Azure DevOps, which doesn't send `X-RateLimit-*`,
+  /// or a response carrying only `Retry-After`).
+  static RateLimitStatus? _rateLimitOf(http.Response response) {
+    final status = parseRateLimit(response.headers);
+    return (status.remaining != null || status.resetAt != null) ? status : null;
   }
 }

--- a/lib/token_health_service.dart
+++ b/lib/token_health_service.dart
@@ -221,8 +221,12 @@ class TokenHealthService {
   }
 
   /// The rate-limit budget from a response's headers, or null when the provider
-  /// reported no budget (e.g. Azure DevOps, which doesn't send `X-RateLimit-*`,
-  /// or a response carrying only `Retry-After`).
+  /// reported no usable budget — Azure DevOps (no `X-RateLimit-*`), a
+  /// `Retry-After`-only response, or a reset without a remaining count.
+  ///
+  /// Requires `remaining` because both storage and the UI are keyed off it
+  /// (GitHub always sends `X-RateLimit-Remaining` alongside `-Reset`), so a
+  /// reset-only status would persist a budget that could never be rendered.
   ///
   /// Best-effort: a malformed header (e.g. an out-of-range reset epoch that
   /// makes `parseRateLimit` throw) is swallowed so the budget is simply
@@ -230,9 +234,7 @@ class TokenHealthService {
   static RateLimitStatus? _rateLimitOf(http.Response response) {
     try {
       final status = parseRateLimit(response.headers);
-      return (status.remaining != null || status.resetAt != null)
-          ? status
-          : null;
+      return status.remaining != null ? status : null;
     } catch (_) {
       return null;
     }

--- a/lib/token_health_service.dart
+++ b/lib/token_health_service.dart
@@ -223,8 +223,18 @@ class TokenHealthService {
   /// The rate-limit budget from a response's headers, or null when the provider
   /// reported no budget (e.g. Azure DevOps, which doesn't send `X-RateLimit-*`,
   /// or a response carrying only `Retry-After`).
+  ///
+  /// Best-effort: a malformed header (e.g. an out-of-range reset epoch that
+  /// makes `parseRateLimit` throw) is swallowed so the budget is simply
+  /// omitted rather than corrupting the check's health/message.
   static RateLimitStatus? _rateLimitOf(http.Response response) {
-    final status = parseRateLimit(response.headers);
-    return (status.remaining != null || status.resetAt != null) ? status : null;
+    try {
+      final status = parseRateLimit(response.headers);
+      return (status.remaining != null || status.resetAt != null)
+          ? status
+          : null;
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/lib/token_health_store.dart
+++ b/lib/token_health_store.dart
@@ -12,6 +12,8 @@ class StoredTokenCheck {
     required this.checkedAt,
     this.account,
     this.message,
+    this.rateLimitRemaining,
+    this.rateLimitResetAt,
   });
 
   final TokenHealth health;
@@ -19,11 +21,19 @@ class StoredTokenCheck {
   final String? account;
   final String? message;
 
+  /// The API rate-limit budget reported for this token on the last check
+  /// (GitHub `X-RateLimit-Remaining` / reset), or null if none was reported.
+  final int? rateLimitRemaining;
+  final DateTime? rateLimitResetAt;
+
   Map<String, dynamic> toJson() => {
     'health': health.name,
     'checkedAt': checkedAt.toUtc().millisecondsSinceEpoch,
     if (account != null) 'account': account,
     if (message != null) 'message': message,
+    if (rateLimitRemaining != null) 'rlRemaining': rateLimitRemaining,
+    if (rateLimitResetAt != null)
+      'rlResetAt': rateLimitResetAt!.toUtc().millisecondsSinceEpoch,
   };
 
   /// Parses a stored entry, or null if it is malformed (unknown health or a
@@ -50,11 +60,26 @@ class StoredTokenCheck {
     }
     final account = json['account'];
     final message = json['message'];
+    final rlRemaining = json['rlRemaining'];
+    final rlResetMillis = json['rlResetAt'];
+    DateTime? rlResetAt;
+    if (rlResetMillis is int) {
+      try {
+        rlResetAt = DateTime.fromMillisecondsSinceEpoch(
+          rlResetMillis,
+          isUtc: true,
+        );
+      } catch (_) {
+        rlResetAt = null;
+      }
+    }
     return StoredTokenCheck(
       health: health,
       checkedAt: checkedAt,
       account: account is String ? account : null,
       message: message is String ? message : null,
+      rateLimitRemaining: rlRemaining is int ? rlRemaining : null,
+      rateLimitResetAt: rlResetAt,
     );
   }
 }
@@ -90,6 +115,8 @@ class TokenHealthStore {
         checkedAt: now ?? DateTime.now(),
         account: check.account,
         message: check.message,
+        rateLimitRemaining: check.rateLimit?.remaining,
+        rateLimitResetAt: check.rateLimit?.resetAt,
       );
       await _writeTo(prefs, raw);
     });

--- a/test/token_health_service_test.dart
+++ b/test/token_health_service_test.dart
@@ -210,6 +210,27 @@ void main() {
     });
 
     test(
+      'a reset without a remaining count is not treated as a budget',
+      () async {
+        final token = await TokenStore.addToken(
+          provider: TokenStore.providerGithub,
+          label: 'GH',
+          scope: 'acme',
+          secret: 'ghp_secret',
+        );
+        final client = MockClient(
+          (_) async => http.Response(
+            jsonEncode({'login': 'alice'}),
+            200,
+            headers: {'x-ratelimit-reset': '1800000000'},
+          ),
+        );
+        final check = await TokenHealthService.check(token, client: client);
+        expect(check.rateLimit, isNull);
+      },
+    );
+
+    test(
       'a malformed rate-limit reset does not corrupt an otherwise valid check',
       () async {
         final token = await TokenStore.addToken(

--- a/test/token_health_service_test.dart
+++ b/test/token_health_service_test.dart
@@ -170,5 +170,43 @@ void main() {
       final check = await TokenHealthService.check(token, client: client);
       expect(check.health, TokenHealth.error);
     });
+
+    test('captures the rate-limit budget from response headers', () async {
+      final token = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'GH',
+        scope: 'acme',
+        secret: 'ghp_secret',
+      );
+      final reset = DateTime.utc(2026, 7, 15, 12, 41);
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'login': 'alice'}),
+          200,
+          headers: {
+            'x-ratelimit-remaining': '4823',
+            'x-ratelimit-reset': '${reset.millisecondsSinceEpoch ~/ 1000}',
+          },
+        ),
+      );
+
+      final check = await TokenHealthService.check(token, client: client);
+      expect(check.rateLimit?.remaining, 4823);
+      expect(check.rateLimit?.resetAt, reset);
+    });
+
+    test('a response without rate-limit headers leaves it null', () async {
+      final token = await TokenStore.addToken(
+        provider: TokenStore.providerGithub,
+        label: 'GH',
+        scope: 'acme',
+        secret: 'ghp_secret',
+      );
+      final client = MockClient(
+        (_) async => http.Response(jsonEncode({'login': 'alice'}), 200),
+      );
+      final check = await TokenHealthService.check(token, client: client);
+      expect(check.rateLimit, isNull);
+    });
   });
 }

--- a/test/token_health_service_test.dart
+++ b/test/token_health_service_test.dart
@@ -208,5 +208,36 @@ void main() {
       final check = await TokenHealthService.check(token, client: client);
       expect(check.rateLimit, isNull);
     });
+
+    test(
+      'a malformed rate-limit reset does not corrupt an otherwise valid check',
+      () async {
+        final token = await TokenStore.addToken(
+          provider: TokenStore.providerGithub,
+          label: 'GH',
+          scope: 'acme',
+          secret: 'ghp_secret',
+        );
+        // A reset epoch far past DateTime's supported range makes
+        // parseRateLimit throw; the check must still report the successful
+        // auth, sans budget. (9999999999999 s * 1000 ≈ 1e16 ms, beyond
+        // DateTime's ~8.64e15 ms limit, but within int64 so it doesn't wrap.)
+        final client = MockClient(
+          (_) async => http.Response(
+            jsonEncode({'login': 'alice'}),
+            200,
+            headers: {
+              'x-ratelimit-remaining': '10',
+              'x-ratelimit-reset': '9999999999999',
+            },
+          ),
+        );
+
+        final check = await TokenHealthService.check(token, client: client);
+        expect(check.health, TokenHealth.valid);
+        expect(check.account, 'alice');
+        expect(check.rateLimit, isNull);
+      },
+    );
   });
 }

--- a/test/token_health_store_test.dart
+++ b/test/token_health_store_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:kode_radar/api_cache.dart';
 import 'package:kode_radar/token_health_service.dart';
 import 'package:kode_radar/token_health_store.dart';
 
@@ -110,5 +111,50 @@ void main() {
 
   test('all() returns empty on a fresh store', () async {
     expect(await TokenHealthStore.all(), isEmpty);
+  });
+
+  test('persists and reads back the rate-limit budget', () async {
+    final now = DateTime.utc(2026, 7, 15, 12);
+    final reset = DateTime.utc(2026, 7, 15, 12, 41);
+    await TokenHealthStore.record(
+      'tok-1',
+      const TokenCheck(
+        TokenHealth.valid,
+        account: 'octocat',
+      ).withRateLimit(RateLimitStatus(remaining: 4823, resetAt: reset)),
+      now: now,
+    );
+
+    final all = await TokenHealthStore.all();
+    expect(all['tok-1']!.rateLimitRemaining, 4823);
+    expect(all['tok-1']!.rateLimitResetAt, reset);
+  });
+
+  test('StoredTokenCheck JSON round-trips the rate-limit fields', () {
+    final reset = DateTime.utc(2026, 7, 15, 12, 41);
+    final original = StoredTokenCheck(
+      health: TokenHealth.valid,
+      checkedAt: DateTime.utc(2026, 7, 15, 12),
+      account: 'octocat',
+      rateLimitRemaining: 12,
+      rateLimitResetAt: reset,
+    );
+
+    final restored = StoredTokenCheck.fromJson(
+      jsonDecode(jsonEncode(original.toJson())),
+    );
+    expect(restored, isNotNull);
+    expect(restored!.rateLimitRemaining, 12);
+    expect(restored.rateLimitResetAt, reset);
+  });
+
+  test('a check without a rate-limit stores null budget fields', () async {
+    await TokenHealthStore.record(
+      'tok-1',
+      const TokenCheck(TokenHealth.valid, account: 'octocat'),
+    );
+    final all = await TokenHealthStore.all();
+    expect(all['tok-1']!.rateLimitRemaining, isNull);
+    expect(all['tok-1']!.rateLimitResetAt, isNull);
   });
 }


### PR DESCRIPTION
## What

Surfaces the GitHub REST API rate-limit budget for each token in **Manage Tokens**, captured during the existing token health check.

When you run a token check, the health service already hits GitHub `/user` (or the ADO profile). This change reads the `X-RateLimit-Remaining` / `X-RateLimit-Reset` headers from that same response and shows a secondary line under the check status:

> GitHub REST API: 4823 left · resets in 41m

## How

- **`TokenCheck`** (`token_health_service.dart`) gains a nullable `RateLimitStatus? rateLimit`, attached on both the GitHub and ADO return paths via `_rateLimitOf(response)`. Returns null when the provider sends no `X-RateLimit-*` budget (Azure DevOps, or a `Retry-After`-only response).
- **`StoredTokenCheck`** (`token_health_store.dart`) persists `rateLimitRemaining` + `rateLimitResetAt` alongside the existing record in SharedPreferences, with a defensive JSON round-trip (guards non-int values; wraps `DateTime.fromMillisecondsSinceEpoch`).
- **`manage_tokens_page.dart`** renders the budget line under the check status; the "resets in Xm" countdown is omitted once the reset time has passed so a stale count is not presented as current.

Only GitHub reports this budget; the count reflects the moment of the last check (contextualized by the existing "checked ..." note on the status line).

## Tests

- `token_health_service_test.dart`: rate-limit captured from response headers; null when headers absent.
- `token_health_store_test.dart`: `record()` round-trips the budget; `StoredTokenCheck` JSON round-trip; null budget fields when no rate-limit.

`dart format` clean, `flutter analyze --fatal-infos` clean, all 312 tests pass.
