### PR TITLE
Surface last background-sync run in Settings

### DIFF
--- a/lib/background_sync.dart
+++ b/lib/background_sync.dart
@@ -41,6 +41,17 @@ void backgroundSyncCallbackDispatcher() {
       return result.activityOk;
     } catch (e, st) {
       debugPrint('Background sync task failed: $e\n$st');
+      // The task ran but threw (e.g. init failed). Record a finished-failure so
+      // this is distinguishable from an OS kill/expiry, which leaves only the
+      // "started" marker. Best-effort.
+      try {
+        await BackgroundSyncStatusStore.recordFinished(
+          activityOk: false,
+          repoCount: 0,
+        );
+      } catch (e2, st2) {
+        debugPrint('Background sync: recordFinished (error) failed: $e2\n$st2');
+      }
       return false;
     }
   });

--- a/lib/background_sync.dart
+++ b/lib/background_sync.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:workmanager/workmanager.dart';
 
+import 'background_sync_status_store.dart';
 import 'notification_service.dart';
 import 'sync_service.dart';
 
@@ -17,9 +18,25 @@ const String backgroundSyncTask = 'com.kamilon.koderadar.sync';
 void backgroundSyncCallbackDispatcher() {
   Workmanager().executeTask((task, inputData) async {
     WidgetsFlutterBinding.ensureInitialized();
+    // Record that the OS launched the task before doing any work, so a run that
+    // is later killed/expires still shows it started (the key iOS failure mode).
+    // Best-effort — never let status recording affect the task result.
+    try {
+      await BackgroundSyncStatusStore.recordStarted();
+    } catch (e, st) {
+      debugPrint('Background sync: recordStarted failed: $e\n$st');
+    }
     try {
       await NotificationService.init();
       final result = await SyncService.runOnce(background: true);
+      try {
+        await BackgroundSyncStatusStore.recordFinished(
+          activityOk: result.activityOk,
+          repoCount: result.repoCount,
+        );
+      } catch (e, st) {
+        debugPrint('Background sync: recordFinished failed: $e\n$st');
+      }
       // Report failure so the OS can retry/reschedule when nothing useful ran.
       return result.activityOk;
     } catch (e, st) {

--- a/lib/background_sync_status_store.dart
+++ b/lib/background_sync_status_store.dart
@@ -1,0 +1,147 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The recorded state of the most recent *background* sync run.
+///
+/// Only background runs are recorded (a foreground "Sync now" is user-initiated
+/// and self-evident), so this is an honest signal for "did the OS actually run
+/// my background task, and did it finish?".
+///
+/// A run is recorded in two steps: [BackgroundSyncStatusStore.recordStarted]
+/// when the OS launches the task (so a task that is later killed or expires
+/// still shows it started), then [BackgroundSyncStatusStore.recordFinished]
+/// with the outcome once the work completes.
+@immutable
+class BackgroundSyncStatus {
+  const BackgroundSyncStatus({
+    required this.at,
+    required this.finished,
+    required this.activityOk,
+    required this.repoCount,
+  });
+
+  /// When this state was recorded (task launch, or completion).
+  final DateTime at;
+
+  /// Whether the run completed. False means the task started but was killed /
+  /// expired / failed before finishing (a common iOS background outcome).
+  final bool finished;
+
+  /// Whether the repo-activity/trend half of the sync succeeded (only
+  /// meaningful when [finished]). This mirrors what "Sync now" reports and what
+  /// the OS uses to decide whether to reschedule.
+  final bool activityOk;
+
+  /// How many repositories the run processed (only meaningful when [finished]).
+  final int repoCount;
+
+  Map<String, dynamic> toJson() => {
+    'at': at.toUtc().millisecondsSinceEpoch,
+    'finished': finished,
+    'activityOk': activityOk,
+    'repoCount': repoCount,
+  };
+
+  /// Parses a stored entry, or null if it is malformed (missing/invalid
+  /// timestamp, or not a map).
+  static BackgroundSyncStatus? fromJson(Object? json) {
+    if (json is! Map) return null;
+    final atMillis = json['at'];
+    if (atMillis is! int) return null;
+    final DateTime at;
+    try {
+      at = DateTime.fromMillisecondsSinceEpoch(atMillis, isUtc: true);
+    } catch (_) {
+      return null;
+    }
+    final finished = json['finished'];
+    final activityOk = json['activityOk'];
+    final repoCount = json['repoCount'];
+    return BackgroundSyncStatus(
+      at: at,
+      // Default to finished for a partial/legacy record so it never sticks on
+      // "didn't finish".
+      finished: finished is bool ? finished : true,
+      activityOk: activityOk is bool ? activityOk : false,
+      repoCount: repoCount is int ? repoCount : 0,
+    );
+  }
+}
+
+/// Persists [BackgroundSyncStatus] in SharedPreferences so the foreground UI can
+/// show when the background sync last ran (and whether it finished). The value
+/// is written from the background isolate and read from the foreground, so
+/// [read] reloads from disk first to cross the isolate boundary.
+class BackgroundSyncStatusStore {
+  BackgroundSyncStatusStore._();
+
+  static const String _key = 'background_sync_status';
+
+  static Future<void> _lock = Future<void>.value();
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  static Future<void> _write(BackgroundSyncStatus status) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_key, jsonEncode(status.toJson()));
+    });
+  }
+
+  /// Records that the OS just launched the background task (defaults [at] to
+  /// now). If the task is later killed/expires this leaves an honest
+  /// "started but didn't finish" marker.
+  static Future<void> recordStarted({DateTime? at}) {
+    return _write(
+      BackgroundSyncStatus(
+        at: at ?? DateTime.now(),
+        finished: false,
+        activityOk: false,
+        repoCount: 0,
+      ),
+    );
+  }
+
+  /// Records that the background run finished with [activityOk]/[repoCount]
+  /// (defaults [at] to now).
+  static Future<void> recordFinished({
+    required bool activityOk,
+    required int repoCount,
+    DateTime? at,
+  }) {
+    return _write(
+      BackgroundSyncStatus(
+        at: at ?? DateTime.now(),
+        finished: true,
+        activityOk: activityOk,
+        repoCount: repoCount,
+      ),
+    );
+  }
+
+  /// The most recent recorded background state, or null if it has never run (or
+  /// the stored value is malformed).
+  static Future<BackgroundSyncStatus?> read() async {
+    final prefs = await SharedPreferences.getInstance();
+    // The record is written on a background isolate, so refresh this isolate's
+    // cached view from disk before reading. Swallow failures (best-effort).
+    try {
+      await prefs.reload();
+    } catch (e) {
+      debugPrint('BackgroundSyncStatusStore: reload failed: $e');
+    }
+    final raw = prefs.getString(_key);
+    if (raw == null) return null;
+    try {
+      return BackgroundSyncStatus.fromJson(jsonDecode(raw));
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/preferences_page.dart
+++ b/lib/preferences_page.dart
@@ -247,9 +247,9 @@ class _PreferencesPageState extends State<PreferencesPage>
   /// Describes the most recent background run for the read-only status tile.
   String _backgroundRunSubtitle() {
     final status = _bgStatus;
-    if (status == null) return 'Hasn’t run yet';
+    if (status == null) return 'Hasn\'t run yet';
     final when = _relativeTime(status.at);
-    if (!status.finished) return 'Started $when · didn’t finish';
+    if (!status.finished) return 'Started $when · didn\'t finish';
     if (!status.activityOk) return 'Ran $when · activity refresh failed';
     final repos = status.repoCount == 1
         ? '1 repo'

--- a/lib/preferences_page.dart
+++ b/lib/preferences_page.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'background_sync.dart';
+import 'background_sync_status_store.dart';
 import 'preferences_store.dart';
 
 /// Settings screen: notification enablement, quiet hours, the Activity Feed
@@ -12,23 +15,52 @@ class PreferencesPage extends StatefulWidget {
   State<PreferencesPage> createState() => _PreferencesPageState();
 }
 
-class _PreferencesPageState extends State<PreferencesPage> {
+class _PreferencesPageState extends State<PreferencesPage>
+    with WidgetsBindingObserver {
   AppPreferences _prefs = const AppPreferences();
+  BackgroundSyncStatus? _bgStatus;
   bool _loading = true;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _load();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // A background run may have recorded a new status while we were backgrounded
+    // with Settings open; refresh it on resume so the tile isn't stale.
+    if (state == AppLifecycleState.resumed) {
+      unawaited(_refreshBackgroundStatus());
+    }
   }
 
   Future<void> _load() async {
     final prefs = await PreferencesStore.load();
+    final bgStatus = BackgroundSync.isSupported
+        ? await BackgroundSyncStatusStore.read()
+        : null;
     if (!mounted) return;
     setState(() {
       _prefs = prefs;
+      _bgStatus = bgStatus;
       _loading = false;
     });
+  }
+
+  Future<void> _refreshBackgroundStatus() async {
+    if (!BackgroundSync.isSupported) return;
+    final bgStatus = await BackgroundSyncStatusStore.read();
+    if (!mounted) return;
+    setState(() => _bgStatus = bgStatus);
   }
 
   @override
@@ -163,6 +195,13 @@ class _PreferencesPageState extends State<PreferencesPage> {
                         }
                       : null,
                 ),
+                if (BackgroundSync.isSupported)
+                  ListTile(
+                    dense: true,
+                    leading: const Icon(Icons.history, size: 20),
+                    title: const Text('Last background run'),
+                    subtitle: Text(_backgroundRunSubtitle()),
+                  ),
               ],
             ),
     );
@@ -203,6 +242,34 @@ class _PreferencesPageState extends State<PreferencesPage> {
     if (!_prefs.quietHoursEnabled) return 'Notifications are never silenced';
     return 'Silence ${_formatHour(_prefs.quietStartHour)} – '
         '${_formatHour(_prefs.quietEndHour)}';
+  }
+
+  /// Describes the most recent background run for the read-only status tile.
+  String _backgroundRunSubtitle() {
+    final status = _bgStatus;
+    if (status == null) return 'Hasn’t run yet';
+    final when = _relativeTime(status.at);
+    if (!status.finished) return 'Started $when · didn’t finish';
+    if (!status.activityOk) return 'Ran $when · activity refresh failed';
+    final repos = status.repoCount == 1
+        ? '1 repo'
+        : '${status.repoCount} repos';
+    return 'Ran $when · $repos';
+  }
+
+  static String _relativeTime(DateTime time) {
+    final diff = DateTime.now().difference(time);
+    if (diff.isNegative || diff.inSeconds < 60) return 'just now';
+    if (diff.inMinutes < 60) {
+      final m = diff.inMinutes;
+      return '$m minute${m == 1 ? '' : 's'} ago';
+    }
+    if (diff.inHours < 24) {
+      final h = diff.inHours;
+      return '$h hour${h == 1 ? '' : 's'} ago';
+    }
+    final d = diff.inDays;
+    return '$d day${d == 1 ? '' : 's'} ago';
   }
 
   String _formatHour(int hour) {

--- a/test/background_sync_status_store_test.dart
+++ b/test/background_sync_status_store_test.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:kode_radar/background_sync_status_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('read() returns null before any background run', () async {
+    expect(await BackgroundSyncStatusStore.read(), isNull);
+  });
+
+  test('recordStarted leaves an unfinished marker', () async {
+    final at = DateTime.utc(2026, 7, 15, 12);
+    await BackgroundSyncStatusStore.recordStarted(at: at);
+
+    final status = await BackgroundSyncStatusStore.read();
+    expect(status, isNotNull);
+    expect(status!.at, at);
+    expect(status.finished, isFalse);
+  });
+
+  test('recordFinished records a successful run', () async {
+    final at = DateTime.utc(2026, 7, 15, 12);
+    await BackgroundSyncStatusStore.recordFinished(
+      activityOk: true,
+      repoCount: 7,
+      at: at,
+    );
+
+    final status = await BackgroundSyncStatusStore.read();
+    expect(status!.finished, isTrue);
+    expect(status.activityOk, isTrue);
+    expect(status.repoCount, 7);
+    expect(status.at, at);
+  });
+
+  test('recordFinished records a failed run', () async {
+    await BackgroundSyncStatusStore.recordFinished(
+      activityOk: false,
+      repoCount: 0,
+    );
+    final status = await BackgroundSyncStatusStore.read();
+    expect(status!.finished, isTrue);
+    expect(status.activityOk, isFalse);
+  });
+
+  test('recordFinished overwrites a prior started marker', () async {
+    await BackgroundSyncStatusStore.recordStarted(at: DateTime.utc(2026, 1, 1));
+    await BackgroundSyncStatusStore.recordFinished(
+      activityOk: true,
+      repoCount: 3,
+      at: DateTime.utc(2026, 1, 1, 0, 0, 20),
+    );
+    final status = await BackgroundSyncStatusStore.read();
+    expect(status!.finished, isTrue);
+    expect(status.repoCount, 3);
+  });
+
+  test('BackgroundSyncStatus JSON round-trips', () {
+    final original = BackgroundSyncStatus(
+      at: DateTime.utc(2026, 7, 15, 12),
+      finished: true,
+      activityOk: true,
+      repoCount: 12,
+    );
+    final restored = BackgroundSyncStatus.fromJson(
+      jsonDecode(jsonEncode(original.toJson())),
+    );
+    expect(restored, isNotNull);
+    expect(restored!.at, original.at);
+    expect(restored.finished, isTrue);
+    expect(restored.activityOk, isTrue);
+    expect(restored.repoCount, 12);
+  });
+
+  test('fromJson rejects malformed entries', () {
+    expect(BackgroundSyncStatus.fromJson('not-a-map'), isNull);
+    expect(BackgroundSyncStatus.fromJson({'finished': true}), isNull);
+    expect(BackgroundSyncStatus.fromJson({'at': 'nope'}), isNull);
+    // Out-of-range epoch must not throw.
+    expect(BackgroundSyncStatus.fromJson({'at': 9999999999999999}), isNull);
+  });
+
+  test('fromJson defaults missing/invalid optional fields', () {
+    final status = BackgroundSyncStatus.fromJson({
+      'at': DateTime.utc(2026, 7, 15).millisecondsSinceEpoch,
+    });
+    expect(status, isNotNull);
+    // A record with a valid timestamp but no `finished` flag is treated as
+    // finished so it never sticks on "didn't finish".
+    expect(status!.finished, isTrue);
+    expect(status.activityOk, isFalse);
+    expect(status.repoCount, 0);
+  });
+}


### PR DESCRIPTION
## What

Surfaces the **last background-sync run** in Settings, under the Background sync toggle. Background sync is best-effort (especially iOS `BGAppRefreshTask`, which is opaque and OS-scheduled), and there was previously no way to tell whether the OS actually ran the task.

The status tile shows one of:
- `Ran 12 minutes ago · 7 repos` — completed, activity/trend refresh succeeded
- `Ran 2 hours ago · activity refresh failed` — completed, but the activity phase failed/timed out
- `Started 2 hours ago · didn’t finish` — the OS launched the task but it was killed/expired before finishing (the key iOS failure mode)
- `Hasn’t run yet` — never recorded

## How

- **New `lib/background_sync_status_store.dart`** — an immutable `BackgroundSyncStatus {at, finished, activityOk, repoCount}` with defensive `toJson`/`fromJson` (rejects non-maps / missing / out-of-range timestamps; a record missing `finished` defaults to *finished* so it never sticks on "didn’t finish"). `BackgroundSyncStatusStore` persists it to SharedPreferences via `recordStarted()` / `recordFinished(...)` (serialized through a lock chain). `read()` calls `prefs.reload()` first because the value is written on the **background isolate** and read on the **foreground**.
- **`lib/background_sync.dart`** — the background callback records `recordStarted()` before doing any work (so a killed/expired run still shows it started), then `recordFinished(...)` with the outcome. Recording lives in the callback (not the shared `SyncService.runOnce`) so a foreground "Sync now" stays neutral — this is purely a *background* diagnostic. Both calls are best-effort (try/catch) and never affect the task result.
- **`lib/preferences_page.dart`** — loads the status when `BackgroundSync.isSupported`, shows a read-only status tile, and refreshes it on `AppLifecycleState.resumed` (so leaving Settings open, backgrounding, and resuming picks up a fresh run).

## Notes

`activityOk` reflects the activity/trend phase (matching what "Sync now" reports and what the OS uses to reschedule); attention/feed are best-effort and don't gate it. The repo count is labeled neutrally ("N repos" = processed).

## Tests

`test/background_sync_status_store_test.dart`: started/finished round-trips, failed run, started→finished overwrite, JSON round-trip, malformed/out-of-range rejection, missing-optional defaults.

`dart format` clean, `flutter analyze --fatal-infos` clean, all 322 tests pass.
