### PR TITLE
Make the Attention Inbox reactive (Phase 3c)

### DIFF
--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -216,11 +216,13 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         if (syncedOk) _lastSynced = DateTime.now();
         _refreshing = false;
       });
-      // Notify on the fresh, snooze-filtered set (error items are additionally
-      // excluded inside NotificationService).
+      // Notify on the fresh set, excluding both persisted and just-made local
+      // snoozes (an optimistic dismiss may not be reflected in SnoozeStore yet).
+      // Error items are additionally excluded inside NotificationService.
+      final effectiveSnoozed = {...freshSnoozed, ..._snoozedIds};
       unawaited(
         NotificationService.notifyNewAttention(
-          computed.where((i) => !freshSnoozed.contains(i.id)).toList(),
+          computed.where((i) => !effectiveSnoozed.contains(i.id)).toList(),
         ),
       );
     } catch (e) {

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -490,11 +490,14 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
           label: 'Undo',
           onPressed: () async {
             // Ensure the snooze write finished before undoing, but never let a
-            // persistence error prevent the undo.
+            // persistence error prevent the undo — both the wait and the
+            // unsnooze are best-effort so the UI undo always completes.
             try {
               await pending;
             } catch (_) {}
-            await SnoozeStore.unsnooze(item.id);
+            try {
+              await SnoozeStore.unsnooze(item.id);
+            } catch (_) {}
             if (!mounted) return;
             // Drop it from the local snooze set so it reappears from the cached
             // stream without a full network reload.

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -67,10 +67,34 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
 
   /// The rendered snapshot: the persisted stream items plus this round's error
   /// markers, minus locally snoozed/dismissed ids, ranked most-urgent first.
-  List<AttentionItem> get _items => [
-    ..._streamItems,
-    ..._errorItems,
-  ].where((i) => !_snoozedIds.contains(i.id)).toList()..sort(_compareItems);
+  ///
+  /// Memoized on the identity of its three inputs (each is always replaced, not
+  /// mutated in place, on change), so the multiple reads per build (via
+  /// [_showSpinner], [_mineFiltered], [_visibleItems], [_buildEmptyState]) reuse
+  /// one merged+sorted list instead of re-doing the O(n log n) work each time.
+  List<AttentionItem>? _itemsCache;
+  List<AttentionItem>? _itemsCacheFromStream;
+  List<AttentionItem>? _itemsCacheFromErrors;
+  Set<String>? _itemsCacheFromSnoozed;
+
+  List<AttentionItem> get _items {
+    final cached = _itemsCache;
+    if (cached != null &&
+        identical(_itemsCacheFromStream, _streamItems) &&
+        identical(_itemsCacheFromErrors, _errorItems) &&
+        identical(_itemsCacheFromSnoozed, _snoozedIds)) {
+      return cached;
+    }
+    final computed = [
+      ..._streamItems,
+      ..._errorItems,
+    ].where((i) => !_snoozedIds.contains(i.id)).toList()..sort(_compareItems);
+    _itemsCache = computed;
+    _itemsCacheFromStream = _streamItems;
+    _itemsCacheFromErrors = _errorItems;
+    _itemsCacheFromSnoozed = _snoozedIds;
+    return computed;
+  }
 
   /// Most-urgent-first ordering (severity desc, then repo, then id) matching
   /// [AttentionStore]'s persisted order so the error overlay slots in stably.

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -115,9 +115,11 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         if (!mounted) return;
         setState(() {
           _streamItems = items;
-          // A late cache emission should clear a stale error screen that a
-          // failed refresh set before the cache arrived.
-          if (items.isNotEmpty) _error = null;
+          // Any cache emission — even an empty one (a cleanly empty inbox) —
+          // is valid data, so clear a stale error screen a failed refresh set
+          // before the cache arrived. (The stream only emits [] on subscribe or
+          // after a successful save, never as the result of a failed refresh.)
+          _error = null;
         });
       },
       onError: (Object e) =>
@@ -229,8 +231,11 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       debugPrint('AttentionInbox failed to load: $e');
       if (!mounted || seq != _loadSeq) return;
       setState(() {
-        // Keep any cached items rendered by the stream rather than replacing
-        // them with an error state; only show the error when we have nothing.
+        // The refresh failed before producing fresh per-repo error markers, so
+        // drop any stale ones (they'd misrepresent the current state and inflate
+        // the category chip counts). The cached items from the stream stay
+        // rendered; only show the error banner when we have nothing at all.
+        _errorItems = const [];
         if (_items.isEmpty) {
           _error =
               'Something went wrong while loading your inbox. Pull down to try again.';

--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -27,7 +27,27 @@ class AttentionInboxPage extends StatefulWidget {
 }
 
 class _AttentionInboxPageState extends State<AttentionInboxPage> {
-  List<AttentionItem> _items = const [];
+  /// The persisted snapshot, driven by the reactive [AttentionStore.watch]
+  /// stream (instant cache on cold start; auto-updates when a refresh persists).
+  /// NOT snooze-filtered — snooze is applied at display time via [_snoozedIds].
+  List<AttentionItem> _streamItems = const [];
+  StreamSubscription<List<AttentionItem>>? _itemsSub;
+
+  /// This round's transient per-repo error markers. These are never persisted to
+  /// the store (so a failed repo doesn't look "clean" and wipe its cache), so
+  /// they're overlaid on the persisted snapshot here.
+  List<AttentionItem> _errorItems = const [];
+
+  /// Locally snoozed/dismissed ids applied at display time (mirrors
+  /// [SnoozeStore]), so a just-made dismiss is honored immediately and an undo
+  /// restores the item from the cache without a network reload.
+  Set<String> _snoozedIds = <String>{};
+
+  /// Bumped on every local snooze mutation (dismiss/undo). An in-flight [_load]
+  /// captures this before reading [SnoozeStore] and only applies the fetched set
+  /// if it hasn't changed since, so a concurrent dismiss/undo isn't clobbered by
+  /// a stale read.
+  int _snoozeGen = 0;
 
   /// A load (cache render + network refresh) is in flight. Gates the manual
   /// Refresh action so overlapping network fetches/DB writes can't stack on top
@@ -45,6 +65,23 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
   // Guards against a stale in-flight load applying after a newer one.
   int _loadSeq = 0;
 
+  /// The rendered snapshot: the persisted stream items plus this round's error
+  /// markers, minus locally snoozed/dismissed ids, ranked most-urgent first.
+  List<AttentionItem> get _items => [
+    ..._streamItems,
+    ..._errorItems,
+  ].where((i) => !_snoozedIds.contains(i.id)).toList()..sort(_compareItems);
+
+  /// Most-urgent-first ordering (severity desc, then repo, then id) matching
+  /// [AttentionStore]'s persisted order so the error overlay slots in stably.
+  static int _compareItems(AttentionItem a, AttentionItem b) {
+    final bySeverity = b.severity.compareTo(a.severity);
+    if (bySeverity != 0) return bySeverity;
+    final byRepo = a.repoDisplay.compareTo(b.repoDisplay);
+    if (byRepo != 0) return byRepo;
+    return a.id.compareTo(b.id);
+  }
+
   /// Show the full-screen spinner only when a load is in flight and there's
   /// nothing cached to render yet; once items are on screen, content stays
   /// visible while the network refresh continues underneath.
@@ -59,12 +96,33 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
 
   @override
   void dispose() {
+    _itemsSub?.cancel();
     configRevision.removeListener(_onConfigChanged);
     super.dispose();
   }
 
   void _onConfigChanged() {
     if (mounted) _load();
+  }
+
+  /// (Re)subscribes the reactive cache stream. The first emission renders the
+  /// cache instantly; later emissions (a refresh persisting, or a repo-delete
+  /// pruning) update the list automatically.
+  void _subscribe() {
+    _itemsSub?.cancel();
+    _itemsSub = AttentionStore.watch().listen(
+      (items) {
+        if (!mounted) return;
+        setState(() {
+          _streamItems = items;
+          // A late cache emission should clear a stale error screen that a
+          // failed refresh set before the cache arrived.
+          if (items.isNotEmpty) _error = null;
+        });
+      },
+      onError: (Object e) =>
+          debugPrint('AttentionInbox watch stream error: $e'),
+    );
   }
 
   /// Items after the "Mine" toggle only — drives the per-category chip counts.
@@ -84,36 +142,36 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       _error = null;
     });
     try {
+      final snoozeGen = _snoozeGen;
       final snoozed = await SnoozeStore.snoozedIds();
       final selfGithub = await IdentityStore.selfGithubLogins();
       final selfAdo = await IdentityStore.selfAdoNames();
+      if (!mounted || seq != _loadSeq) return;
 
-      // Phase A: render the cached snapshot immediately so a cold start isn't a
-      // blank spinner while the network fetch runs (or if it's offline). Only
-      // meaningful when we don't already have items on screen.
-      if (_items.isEmpty) {
-        final cachedItems = await AttentionStore.cached(snoozedIds: snoozed);
-        final lastSynced = await SyncStateStore.lastSuccess(
-          SyncStateStore.attentionScope,
-        );
-        if (!mounted || seq != _loadSeq) return;
-        // Set the provenance label even when the cache is empty (a clean inbox
-        // that synced successfully), so its "checked" time survives a
-        // restart/offline open.
-        if (cachedItems.isNotEmpty || lastSynced != null) {
-          setState(() {
-            if (cachedItems.isNotEmpty) _items = cachedItems;
-            _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
-            _lastSynced = lastSynced;
-          });
-        }
-      }
+      // Apply the current snoozes and (re)subscribe the reactive cache stream so
+      // the persisted snapshot renders instantly (cold start / offline). Reading
+      // snoozes before subscribing avoids a flash of snoozed items on the first
+      // emission. Skip the assignment if a local dismiss/undo raced this read
+      // (the local set is already authoritative in that case).
+      setState(() {
+        if (_snoozeGen == snoozeGen) _snoozedIds = snoozed;
+        _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
+      });
+      _subscribe();
 
-      // Phase B: refresh from the network and persist the snapshot. Compute
-      // WITHOUT snooze filtering so `save` sees each repo's true success/failure
-      // (a snoozed-away item or a dismissed error marker must not make a repo
-      // look "clean" and wipe its last-known-good cache); snooze is applied only
-      // when rendering/notifying below.
+      // Provenance label (survives restart/offline), set even for a clean inbox.
+      final lastSynced = await SyncStateStore.lastSuccess(
+        SyncStateStore.attentionScope,
+      );
+      if (!mounted || seq != _loadSeq) return;
+      setState(() => _lastSynced = lastSynced);
+
+      // Refresh from the network and persist the snapshot. Compute WITHOUT
+      // snooze filtering so `save` sees each repo's true success/failure (a
+      // snoozed-away item or a dismissed error marker must not make a repo look
+      // "clean" and wipe its last-known-good cache); snooze is applied only when
+      // rendering/notifying below. Persisting triggers the watch stream, which
+      // updates `_streamItems`.
       final computed = await AttentionService.computeAll(
         client: AppHttp.client,
         selfGithubLogins: selfGithub,
@@ -124,13 +182,8 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       if (!mounted || seq != _loadSeq) return;
       // Re-read snoozes now (a dismiss may have happened during the fetch) so a
       // just-dismissed item can't flicker back into the rendered snapshot.
+      final freshSnoozeGen = _snoozeGen;
       final freshSnoozed = await SnoozeStore.snoozedIds();
-      if (!mounted || seq != _loadSeq) return;
-      // Render the persisted snapshot (which keeps last-known-good items for any
-      // repo that failed this round) plus this round's fresh error items, so an
-      // offline/partial refresh never blanks the inbox yet still surfaces which
-      // repos couldn't load.
-      final cachedReal = await AttentionStore.cached(snoozedIds: freshSnoozed);
       if (!mounted || seq != _loadSeq) return;
       // A successful sync = at least one monitored repo was fetched without an
       // error (it had real items or was cleanly empty). Compare the number of
@@ -151,24 +204,14 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         await SyncStateStore.markSuccess(SyncStateStore.attentionScope);
         if (!mounted || seq != _loadSeq) return;
       }
+      // Overlay this round's error markers (never persisted) on the streamed
+      // snapshot; snooze filtering is applied by the `_items` getter.
       final errors = computed
-          .where(
-            (i) =>
-                i.category == AttentionStore.errorCategory &&
-                !freshSnoozed.contains(i.id),
-          )
+          .where((i) => i.category == AttentionStore.errorCategory)
           .toList();
-      final merged = [...cachedReal, ...errors]
-        ..sort((a, b) {
-          final bySeverity = b.severity.compareTo(a.severity);
-          if (bySeverity != 0) return bySeverity;
-          final byRepo = a.repoDisplay.compareTo(b.repoDisplay);
-          if (byRepo != 0) return byRepo;
-          // Stable final tie-breaker so ties don't reorder between renders.
-          return a.id.compareTo(b.id);
-        });
       setState(() {
-        _items = merged;
+        if (_snoozeGen == freshSnoozeGen) _snoozedIds = freshSnoozed;
+        _errorItems = errors;
         _identitySet = selfGithub.isNotEmpty || selfAdo.isNotEmpty;
         if (syncedOk) _lastSynced = DateTime.now();
         _refreshing = false;
@@ -184,8 +227,8 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
       debugPrint('AttentionInbox failed to load: $e');
       if (!mounted || seq != _loadSeq) return;
       setState(() {
-        // Keep any cached items rendered in Phase A rather than replacing them
-        // with an error state; only show the error when we have nothing.
+        // Keep any cached items rendered by the stream rather than replacing
+        // them with an error state; only show the error when we have nothing.
         if (_items.isEmpty) {
           _error =
               'Something went wrong while loading your inbox. Pull down to try again.';
@@ -430,10 +473,11 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
 
   void _onDismissed(AttentionItem item, DismissDirection direction) {
     final dismissForever = direction == DismissDirection.endToStart;
-    // Remove synchronously so the dismissed widget is gone before the next
-    // build, then persist the snooze in the background.
+    // Add to the local snooze set so the item disappears before the next build
+    // (the `_items` getter filters it out), then persist the snooze.
     setState(() {
-      _items = _items.where((i) => i.id != item.id).toList();
+      _snoozedIds = {..._snoozedIds, item.id};
+      _snoozeGen++;
     });
     final pending = dismissForever
         ? SnoozeStore.snooze(item.id)
@@ -446,13 +490,18 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
           label: 'Undo',
           onPressed: () async {
             // Ensure the snooze write finished before undoing, but never let a
-            // persistence error prevent the undo/reload.
+            // persistence error prevent the undo.
             try {
               await pending;
             } catch (_) {}
             await SnoozeStore.unsnooze(item.id);
             if (!mounted) return;
-            await _load();
+            // Drop it from the local snooze set so it reappears from the cached
+            // stream without a full network reload.
+            setState(() {
+              _snoozedIds = {..._snoozedIds}..remove(item.id);
+              _snoozeGen++;
+            });
           },
         ),
       ),

--- a/lib/attention_store.dart
+++ b/lib/attention_store.dart
@@ -43,24 +43,36 @@ class AttentionStore {
   }
 
   /// Returns the cached snapshot ranked most-urgent first (severity desc, then
-  /// repo), excluding any ids in [snoozedIds] so a just-made dismiss/snooze is
-  /// honored even before the next network refresh rewrites the cache.
-  static Future<List<AttentionItem>> cached({
-    Set<String> snoozedIds = const {},
-  }) async {
+  /// repo) — a one-shot read companion to [watch]. Snooze is applied by callers
+  /// at display time (see [AttentionInboxPage]), not here.
+  static Future<List<AttentionItem>> cached() async {
+    final rows = await _selectRanked().get();
+    return rows.map(_toItem).toList();
+  }
+
+  /// A reactive stream of the full ranked cached snapshot that re-emits whenever
+  /// the `attention_items` table changes — so a page bound to it renders the
+  /// cache instantly on cold start and updates automatically when a refresh (or
+  /// another in-isolate writer) persists new data.
+  ///
+  /// Unlike [cached] this does NOT apply a snooze filter: snooze is a display
+  /// concern the page layers on top (via [SnoozeStore]) while the cache stays
+  /// the source of truth for what each repo currently has.
+  static Stream<List<AttentionItem>> watch() {
+    return _selectRanked().watch().map((rows) => rows.map(_toItem).toList());
+  }
+
+  static SimpleSelectStatement<$AttentionItemsTable, AttentionItemRow>
+  _selectRanked() {
     final db = _database;
-    final rows =
-        await (db.select(db.attentionItems)..orderBy([
-              (t) =>
-                  OrderingTerm(expression: t.severity, mode: OrderingMode.desc),
-              (t) => OrderingTerm(expression: t.repoDisplay),
-              // Final tie-breaker so same-severity items in the same repo have a
-              // stable order (SQLite is otherwise free to reorder them, causing
-              // list jitter between cache and network renders).
-              (t) => OrderingTerm(expression: t.id),
-            ]))
-            .get();
-    return rows.where((r) => !snoozedIds.contains(r.id)).map(_toItem).toList();
+    return db.select(db.attentionItems)..orderBy([
+      (t) => OrderingTerm(expression: t.severity, mode: OrderingMode.desc),
+      (t) => OrderingTerm(expression: t.repoDisplay),
+      // Final tie-breaker so same-severity items in the same repo have a stable
+      // order (SQLite is otherwise free to reorder them, causing list jitter
+      // between cache and network renders).
+      (t) => OrderingTerm(expression: t.id),
+    ]);
   }
 
   /// Replaces the cached snapshot from a freshly-[computed] list (as returned by

--- a/lib/attention_store.dart
+++ b/lib/attention_store.dart
@@ -44,7 +44,7 @@ class AttentionStore {
 
   /// Returns the cached snapshot ranked most-urgent first (severity desc, then
   /// repo) — a one-shot read companion to [watch]. Snooze is applied by callers
-  /// at display time (see [AttentionInboxPage]), not here.
+  /// at display time (see `AttentionInboxPage`), not here.
   static Future<List<AttentionItem>> cached() async {
     final rows = await _selectRanked().get();
     return rows.map(_toItem).toList();
@@ -56,7 +56,7 @@ class AttentionStore {
   /// another in-isolate writer) persists new data.
   ///
   /// Unlike [cached] this does NOT apply a snooze filter: snooze is a display
-  /// concern the page layers on top (via [SnoozeStore]) while the cache stays
+  /// concern the page layers on top (via `SnoozeStore`) while the cache stays
   /// the source of truth for what each repo currently has.
   static Stream<List<AttentionItem>> watch() {
     return _selectRanked().watch().map((rows) => rows.map(_toItem).toList());
@@ -81,7 +81,7 @@ class AttentionStore {
   ///
   /// Callers should pass the FULL snapshot (do not pre-filter snoozed items):
   /// the cache is the source of truth for what each repo currently has, and
-  /// snooze is a display concern the page applies (see [AttentionInboxPage]).
+  /// snooze is a display concern the page applies (see `AttentionInboxPage`).
   /// Pre-filtering would make a snoozed-away or dismissed item look like the
   /// repo went clean and wrongly evict its cached data.
   ///

--- a/lib/attention_store.dart
+++ b/lib/attention_store.dart
@@ -13,8 +13,8 @@ import 'database/app_database.dart';
 /// [AttentionItem.id]. [save] merges intelligently: items for repos that
 /// returned an `error` this round (a transient/offline failure) are retained
 /// from the prior snapshot, while repos that were fetched successfully have
-/// their items replaced. Transient `error` items are never persisted; snoozed
-/// items are filtered on read.
+/// their items replaced. Transient `error` items are never persisted; snooze
+/// is applied by the page at display time (not here).
 class AttentionStore {
   AttentionStore._();
 
@@ -81,9 +81,9 @@ class AttentionStore {
   ///
   /// Callers should pass the FULL snapshot (do not pre-filter snoozed items):
   /// the cache is the source of truth for what each repo currently has, and
-  /// snooze is a display concern applied at read time by [cached]. Pre-filtering
-  /// would make a snoozed-away or dismissed item look like the repo went clean
-  /// and wrongly evict its cached data.
+  /// snooze is a display concern the page applies (see [AttentionInboxPage]).
+  /// Pre-filtering would make a snoozed-away or dismissed item look like the
+  /// repo went clean and wrongly evict its cached data.
   ///
   /// Repos that returned an `error` this round keep their previously-cached
   /// items (so a transient/offline failure doesn't drop their data); every other

--- a/test/attention_store_test.dart
+++ b/test/attention_store_test.dart
@@ -80,14 +80,32 @@ void main() {
     expect(cached.map((e) => e.id).toList(), ['a', 'm', 'z']);
   });
 
-  test('cached filters out snoozed ids on read', () async {
+  test('watch emits the ranked cache and re-emits after a save', () async {
+    final emissions = <List<String>>[];
+    final sub = AttentionStore.watch().listen((items) {
+      emissions.add(items.map((e) => e.id).toList());
+    });
+    // Initial emission (empty cache).
+    await pumpEventQueue();
+    await AttentionStore.save([
+      _item(id: 'a', repoDisplay: 'owner/one', severity: 3000),
+      _item(id: 'b', repoDisplay: 'owner/two', severity: 5000),
+    ]);
+    await pumpEventQueue();
+    await sub.cancel();
+
+    expect(emissions.first, isEmpty);
+    // Ranked most-urgent first (severity desc): b (5000) before a (3000).
+    expect(emissions.last, ['b', 'a']);
+  });
+
+  test('watch is not snooze-filtered (the page applies snooze)', () async {
     await AttentionStore.save([
       _item(id: 'a', repoDisplay: 'owner/one'),
       _item(id: 'b', repoDisplay: 'owner/two'),
     ]);
-
-    final cached = await AttentionStore.cached(snoozedIds: {'a'});
-    expect(cached.map((e) => e.id).toList(), ['b']);
+    final items = await AttentionStore.watch().first;
+    expect(items.map((e) => e.id).toSet(), {'a', 'b'});
   });
 
   test('a successful refresh replaces a repo\'s items', () async {


### PR DESCRIPTION
## What

Converts the **Attention Inbox** from an imperative cache-then-refresh model to a **reactive drift stream** — the last substantive piece of Phase 3c (mirrors the already-merged reactive Activity Feed). The inbox renders the persisted cache instantly on cold start and auto-updates whenever an in-isolate write changes the cache (its own refresh, a repo-delete prune), without imperative re-reads.

## How

- **`lib/attention_store.dart`** — extracted a shared `_selectRanked()` builder (ORDER BY severity desc, repoDisplay, id) used by both `cached()` and the new **`watch()`** (`Stream<List<AttentionItem>>` via drift `.watch()`). `watch()` is intentionally **not** snooze-filtered (snooze is now a page concern), and `cached()` drops its vestigial `snoozedIds` param, becoming a one-shot read companion to `watch()`.
- **`lib/attention_inbox_page.dart`** — the page holds:
  - `_streamItems` — the persisted ranked snapshot from the `watch()` stream.
  - `_errorItems` — this round's transient per-repo error markers (never persisted, so a failed repo doesn't wipe its cache), overlaid on the snapshot.
  - `_snoozedIds` — a local Set mirroring `SnoozeStore`, applied at display time.
  
  The rendered `_items` is a computed getter = `[..._streamItems, ..._errorItems].where(not snoozed)..sort`. `_subscribe()` cancels the prior sub and re-listens (called in `_load` after reading snoozes so the first emission isn't a flash of snoozed items). Dismiss/snooze adds the id to `_snoozedIds` (item vanishes immediately); undo removes it (item reappears from the cached stream — no network reload, unlike the old `_load()`-on-undo).
- **Snooze-mutation generation guard** — an in-flight `_load` captures `_snoozeGen` before reading `SnoozeStore` and only applies the fetched set if it hasn't changed, so a concurrent dismiss/undo isn't clobbered by a stale read.

## Notes

- **Cross-isolate:** drift table-change notifications don't cross isolates, so a background-sync isolate write updates an open page only on the next cold-start read (not live) — the same limitation as the merged reactive feed. Live updates apply to in-isolate writes (the page's own refresh, "Sync now", repo-delete).
- Provenance (`syncedOk`), notification filtering, and ordering are unchanged.

## Tests

`test/attention_store_test.dart`: new `watch()` tests (emits ranked cache, re-emits after save; not snooze-filtered). The removed store-level snooze test reflects snooze moving to the page. `dart format` clean, `flutter analyze --fatal-infos` clean, all 323 tests pass.

Follow-up (separate PR): the same reactive conversion for the Repo-detail page (3-table composite).
