### PR TITLE
Make the Repo-detail page reactive (Phase 3c)

### DIFF
--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -23,7 +25,19 @@ class RepoDetailPage extends StatefulWidget {
 }
 
 class _RepoDetailPageState extends State<RepoDetailPage> {
-  RepoDetailData _data = const RepoDetailData();
+  /// The persisted detail composite, driven by the reactive
+  /// [RepoDetailStore.watch] stream (instant cache on cold start; auto-updates
+  /// when a refresh or repo-delete changes the cache). Its own failure flags are
+  /// always false (last-known-good); the fresh flags are overlaid via [_data].
+  RepoDetailData _streamDetail = const RepoDetailData();
+  StreamSubscription<RepoDetailData>? _detailSub;
+
+  /// This round's fresh per-source failure flags from the network refresh,
+  /// overlaid on the streamed cache so each tab can still show "couldn't load".
+  bool _pullsFailed = false;
+  bool _ciFailed = false;
+  bool _releasesFailed = false;
+
   List<ActivityEvent> _events = const [];
   int _feedFailed = 0;
   bool _feedTruncated = false;
@@ -43,12 +57,24 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
 
   RepoActivity get _repo => widget.repo;
 
+  /// The rendered detail: the streamed persisted composite plus this round's
+  /// fresh per-source failure flags.
+  RepoDetailData get _data => RepoDetailData(
+    pulls: _streamDetail.pulls,
+    ci: _streamDetail.ci,
+    releases: _streamDetail.releases,
+    releasesSupported: _releasesSupported,
+    pullsFailed: _pullsFailed,
+    ciFailed: _ciFailed,
+    releasesFailed: _releasesFailed,
+  );
+
   /// True once anything (detail or timeline) is on screen.
   bool get _hasContent =>
       _events.isNotEmpty ||
-      _data.pulls.isNotEmpty ||
-      _data.ci.isNotEmpty ||
-      _data.releases.isNotEmpty;
+      _streamDetail.pulls.isNotEmpty ||
+      _streamDetail.ci.isNotEmpty ||
+      _streamDetail.releases.isNotEmpty;
 
   /// Full-screen spinner only while a load is in flight and nothing is cached
   /// to show yet.
@@ -57,7 +83,42 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
   @override
   void initState() {
     super.initState();
+    _subscribe();
     _load();
+  }
+
+  @override
+  void dispose() {
+    _detailSub?.cancel();
+    super.dispose();
+  }
+
+  /// Subscribes the reactive detail cache. The first emission renders the cache
+  /// instantly; later emissions (a refresh persisting, or a repo-delete pruning)
+  /// update the tabs automatically.
+  void _subscribe() {
+    _detailSub?.cancel();
+    _detailSub =
+        RepoDetailStore.watch(
+          _repo.repoKey,
+          releasesSupported: _releasesSupported,
+        ).listen(
+          (detail) {
+            if (!mounted) return;
+            setState(() {
+              _streamDetail = detail;
+              // A cache emission with content clears a stale error screen a
+              // failed refresh set before the cache arrived.
+              if (detail.pulls.isNotEmpty ||
+                  detail.ci.isNotEmpty ||
+                  detail.releases.isNotEmpty) {
+                _error = null;
+              }
+            });
+          },
+          onError: (Object e) =>
+              debugPrint('RepoDetail watch stream error: $e'),
+        );
   }
 
   Future<void> _load() async {
@@ -67,43 +128,30 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       _error = null;
     });
     try {
-      // Phase A: render cached detail + this repo's cached timeline events
-      // immediately so a cold start / offline open isn't a blank spinner.
-      if (!_hasContent) {
-        // Run the two cache reads concurrently to cut cold-start latency; the
-        // seq/mounted guards below still apply.
+      // Phase A: render this repo's cached timeline events + provenance
+      // immediately so a cold start / offline open isn't a blank spinner. (The
+      // detail composite renders via the reactive stream's first emission.)
+      if (_events.isEmpty) {
         final cachedResults = await Future.wait([
-          RepoDetailStore.cached(
-            _repo.repoKey,
-            releasesSupported: _releasesSupported,
-          ),
           ActivityEventStore.cached(repoKey: _repo.repoKey),
           SyncStateStore.lastSuccess(SyncStateStore.repoScope(_repo.repoKey)),
         ]);
         if (!mounted || seq != _loadSeq) return;
-        final cachedDetail = cachedResults[0] as RepoDetailData;
-        final repoEvents = cachedResults[1] as List<ActivityEvent>;
-        final lastSynced = cachedResults[2] as DateTime?;
-        final hasCache =
-            cachedDetail.pulls.isNotEmpty ||
-            cachedDetail.ci.isNotEmpty ||
-            cachedDetail.releases.isNotEmpty ||
-            repoEvents.isNotEmpty;
-        // Set the provenance label even when there's no cached content (a scope
+        final repoEvents = cachedResults[0] as List<ActivityEvent>;
+        final lastSynced = cachedResults[1] as DateTime?;
+        // Set the provenance label even when there's no cached timeline (a scope
         // that synced successfully but had nothing to show), so its "updated"
         // time survives a restart/offline open.
-        if (hasCache || lastSynced != null) {
+        if (repoEvents.isNotEmpty || lastSynced != null) {
           setState(() {
-            if (hasCache) {
-              _data = cachedDetail;
-              _events = repoEvents;
-            }
+            if (repoEvents.isNotEmpty) _events = repoEvents;
             _lastSynced = lastSynced;
           });
         }
       }
 
-      // Phase B: refresh from the network and persist the detail snapshot.
+      // Phase B: refresh from the network and persist the detail snapshot. The
+      // save triggers the watch stream, which updates the rendered composite.
       final detailFuture = RepoDetailService.load(
         repoKey: _repo.repoKey,
         provider: _repo.provider,
@@ -118,16 +166,6 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       final freshDetail = results[0] as RepoDetailData;
       final feed = results[1] as ActivityFeedResult;
       await RepoDetailStore.save(_repo.repoKey, freshDetail);
-      if (!mounted || seq != _loadSeq) return;
-      // Render the persisted detail (which keeps last-known-good rows for any
-      // source that failed this round) but carry the fresh per-source failure
-      // flags so each tab still shows "couldn't load". For the timeline, prefer
-      // the fresh scoped fetch and fall back to the cache when it's empty
-      // (offline), so it never blanks.
-      final mergedDetail = await RepoDetailStore.cached(
-        _repo.repoKey,
-        releasesSupported: _releasesSupported,
-      );
       if (!mounted || seq != _loadSeq) return;
       List<ActivityEvent> timeline = feed.events;
       // Fall back to the cached timeline only when the fresh fetch came back
@@ -153,16 +191,14 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
         );
         if (!mounted || seq != _loadSeq) return;
       }
+      // Overlay the fresh per-source failure flags on the streamed composite
+      // (which keeps last-known-good rows for any source that failed), and
+      // update the timeline. The persisted pulls/ci/releases come from the
+      // stream via the save above.
       setState(() {
-        _data = RepoDetailData(
-          pulls: mergedDetail.pulls,
-          ci: mergedDetail.ci,
-          releases: mergedDetail.releases,
-          releasesSupported: _releasesSupported,
-          pullsFailed: freshDetail.pullsFailed,
-          ciFailed: freshDetail.ciFailed,
-          releasesFailed: freshDetail.releasesFailed,
-        );
+        _pullsFailed = freshDetail.pullsFailed;
+        _ciFailed = freshDetail.ciFailed;
+        _releasesFailed = freshDetail.releasesFailed;
         _events = timeline;
         _feedFailed = feed.failedSources;
         _feedTruncated = feed.truncated;
@@ -173,8 +209,8 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
       debugPrint('RepoDetail failed to load: $e');
       if (!mounted || seq != _loadSeq) return;
       setState(() {
-        // Keep any cached content from Phase A; only show the error screen when
-        // there's nothing to show.
+        // Keep any cached content (timeline from Phase A, detail from the
+        // stream); only show the error screen when there's nothing to show.
         if (!_hasContent) {
           _error =
               'Something went wrong while loading this repository. '

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -116,8 +116,8 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
               }
             });
           },
-          onError: (Object e) =>
-              debugPrint('RepoDetail watch stream error: $e'),
+          onError: (Object e, StackTrace st) =>
+              debugPrint('RepoDetail watch stream error: $e\n$st'),
         );
   }
 

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -126,6 +126,14 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
     setState(() {
       _refreshing = true;
       _error = null;
+      // Clear the source-health indicators up front so a load that throws
+      // before producing fresh results can't leave stale "couldn't load"
+      // states (they're set fresh from this round's network result below).
+      _pullsFailed = false;
+      _ciFailed = false;
+      _releasesFailed = false;
+      _feedFailed = 0;
+      _feedTruncated = false;
     });
     try {
       // Phase A: render this repo's cached timeline events + provenance

--- a/lib/repo_detail_store.dart
+++ b/lib/repo_detail_store.dart
@@ -74,6 +74,12 @@ class RepoDetailStore {
     late StreamController<RepoDetailData> controller;
     StreamSubscription<Set<TableUpdate>>? updatesSub;
 
+    // Concurrent emit() calls stay ordered because [_read] runs through the
+    // store's static [_runLocked] chain: reads execute in invocation order and
+    // each completes before the next starts, so their `controller.add`s fire in
+    // order. The initial emit() below is invoked before the update listener, so
+    // it's always queued first — a later table-change read can't overtake it and
+    // revert the stream to stale data.
     Future<void> emit() async {
       try {
         final data = await _read(

--- a/lib/repo_detail_store.dart
+++ b/lib/repo_detail_store.dart
@@ -54,9 +54,10 @@ class RepoDetailStore {
   }
 
   /// A reactive stream of the cached composite for [repoKey] that re-emits
-  /// whenever any of the three detail tables (pulls / CI / releases) change — so
-  /// a page bound to it renders the cache instantly on cold start and updates
-  /// automatically when a refresh (or a repo-delete prune) persists new data.
+  /// whenever this repo's pull-request or CI rows change — plus release rows for
+  /// providers that support releases ([releasesSupported]) — so a page bound to
+  /// it renders the cache instantly on cold start and updates automatically when
+  /// a refresh (or a repo-delete prune) persists new data.
   ///
   /// Each emission recomputes PR ages against the current time *at the moment of
   /// that emission*; ages don't tick forward between DB changes (a page that
@@ -96,7 +97,8 @@ class RepoDetailStore {
     controller = StreamController<RepoDetailData>(
       onListen: () {
         // Initial snapshot, then re-read on any change to the composite's
-        // tables. `onAllTables` fires when any of the three is written.
+        // tables. `onAllTables` fires when repo_pulls or repo_runs — and
+        // repo_releases when releases are supported — is written.
         emit();
         updatesSub = db
             .tableUpdates(

--- a/lib/repo_detail_store.dart
+++ b/lib/repo_detail_store.dart
@@ -57,7 +57,15 @@ class RepoDetailStore {
   /// whenever any of the three detail tables (pulls / CI / releases) change — so
   /// a page bound to it renders the cache instantly on cold start and updates
   /// automatically when a refresh (or a repo-delete prune) persists new data.
-  /// Each emission recomputes PR ages against the current time.
+  ///
+  /// Each emission recomputes PR ages against the current time *at the moment of
+  /// that emission*; ages don't tick forward between DB changes (a page that
+  /// needs a fresher age re-reads on its own load / cold start).
+  ///
+  /// drift's change notifications are table-granular, so this fires on a write
+  /// to any repo's rows in those tables (like the feed/attention `watch`
+  /// streams); the `WHERE repoKey` in [_read] keeps the emitted data correctly
+  /// scoped, and such cross-repo triggers are rare and cheap.
   static Stream<RepoDetailData> watch(
     String repoKey, {
     required bool releasesSupported,
@@ -104,6 +112,9 @@ class RepoDetailStore {
       },
       onCancel: () async {
         await updatesSub?.cancel();
+        // Close the controller so any emit() still in flight (guarded by
+        // isClosed) is dropped rather than buffered on a listener-less stream.
+        if (!controller.isClosed) await controller.close();
       },
     );
     return controller.stream;

--- a/lib/repo_detail_store.dart
+++ b/lib/repo_detail_store.dart
@@ -97,7 +97,7 @@ class RepoDetailStore {
               TableUpdateQuery.onAllTables([
                 db.repoPulls,
                 db.repoRuns,
-                db.repoReleases,
+                if (releasesSupported) db.repoReleases,
               ]),
             )
             .listen(
@@ -141,11 +141,14 @@ class RepoDetailStore {
                 ..where((t) => t.repoKey.equals(repoKey))
                 ..orderBy([(t) => OrderingTerm(expression: t.id)]))
               .get();
-      final releases =
-          await (db.select(db.repoReleases)
-                ..where((t) => t.repoKey.equals(repoKey))
-                ..orderBy([(t) => OrderingTerm(expression: t.id)]))
-              .get();
+      // Skip the releases query for providers that don't support releases
+      // (e.g. Azure DevOps) — nothing is ever persisted there for such repos.
+      final releases = releasesSupported
+          ? await (db.select(db.repoReleases)
+                  ..where((t) => t.repoKey.equals(repoKey))
+                  ..orderBy([(t) => OrderingTerm(expression: t.id)]))
+                .get()
+          : const <RepoReleaseRow>[];
       return RepoDetailData(
         pulls: pulls.map((row) => _toPr(row, now)).toList(),
         ci: runs.map(_toRun).toList(),

--- a/lib/repo_detail_store.dart
+++ b/lib/repo_detail_store.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:drift/drift.dart';
 import 'package:flutter/foundation.dart';
 
@@ -44,11 +46,78 @@ class RepoDetailStore {
     required bool releasesSupported,
     DateTime? now,
   }) {
-    final at = now ?? DateTime.now();
-    // Read all three tables under the same lock the mutators use, so a
-    // concurrent save/removeRepo can't interleave between the SELECTs and yield
-    // an inconsistent composite (e.g. pulls from before a save, runs from
-    // after).
+    return _read(
+      repoKey,
+      releasesSupported: releasesSupported,
+      now: now ?? DateTime.now(),
+    );
+  }
+
+  /// A reactive stream of the cached composite for [repoKey] that re-emits
+  /// whenever any of the three detail tables (pulls / CI / releases) change — so
+  /// a page bound to it renders the cache instantly on cold start and updates
+  /// automatically when a refresh (or a repo-delete prune) persists new data.
+  /// Each emission recomputes PR ages against the current time.
+  static Stream<RepoDetailData> watch(
+    String repoKey, {
+    required bool releasesSupported,
+  }) {
+    final db = _database;
+    late StreamController<RepoDetailData> controller;
+    StreamSubscription<Set<TableUpdate>>? updatesSub;
+
+    Future<void> emit() async {
+      try {
+        final data = await _read(
+          repoKey,
+          releasesSupported: releasesSupported,
+          now: DateTime.now(),
+        );
+        if (!controller.isClosed) controller.add(data);
+      } catch (e, st) {
+        if (!controller.isClosed) controller.addError(e, st);
+      }
+    }
+
+    controller = StreamController<RepoDetailData>(
+      onListen: () {
+        // Initial snapshot, then re-read on any change to the composite's
+        // tables. `onAllTables` fires when any of the three is written.
+        emit();
+        updatesSub = db
+            .tableUpdates(
+              TableUpdateQuery.onAllTables([
+                db.repoPulls,
+                db.repoRuns,
+                db.repoReleases,
+              ]),
+            )
+            .listen(
+              (_) => emit(),
+              onError: (Object e, StackTrace st) {
+                if (!controller.isClosed) controller.addError(e, st);
+              },
+              onDone: () {
+                if (!controller.isClosed) controller.close();
+              },
+            );
+      },
+      onCancel: () async {
+        await updatesSub?.cancel();
+      },
+    );
+    return controller.stream;
+  }
+
+  /// Reads the cached composite for [repoKey] at [now]. All three tables are
+  /// read under the same lock the mutators use, so a concurrent save/removeRepo
+  /// can't interleave between the SELECTs and yield an inconsistent composite
+  /// (e.g. pulls from before a save, runs from after).
+  static Future<RepoDetailData> _read(
+    String repoKey, {
+    required bool releasesSupported,
+    required DateTime now,
+  }) {
     return _runLocked(() async {
       final db = _database;
       final pulls =
@@ -67,7 +136,7 @@ class RepoDetailStore {
                 ..orderBy([(t) => OrderingTerm(expression: t.id)]))
               .get();
       return RepoDetailData(
-        pulls: pulls.map((row) => _toPr(row, at)).toList(),
+        pulls: pulls.map((row) => _toPr(row, now)).toList(),
         ci: runs.map(_toRun).toList(),
         releases: releases.map(_toRelease).toList(),
         releasesSupported: releasesSupported,

--- a/test/repo_detail_store_test.dart
+++ b/test/repo_detail_store_test.dart
@@ -211,19 +211,26 @@ void main() {
   });
 
   test('watch re-emits when CI or releases change', () async {
-    final ciCounts = <int>[];
+    final emissions = <({int ci, int releases})>[];
     final sub = RepoDetailStore.watch(repo, releasesSupported: true).listen((
       data,
     ) {
-      ciCounts.add(data.ci.length);
+      emissions.add((ci: data.ci.length, releases: data.releases.length));
     });
     await pumpEventQueue();
     await RepoDetailStore.save(repo, RepoDetailData(ci: [_run('build')]));
     await pumpEventQueue();
+    await RepoDetailStore.save(
+      repo,
+      RepoDetailData(releases: [_release('v1')]),
+    );
+    await pumpEventQueue();
     await sub.cancel();
 
-    expect(ciCounts.first, 0);
-    expect(ciCounts.last, 1);
+    // Initial empty, then a CI change, then a releases change each re-emit.
+    expect(emissions.first, (ci: 0, releases: 0));
+    expect(emissions.any((e) => e.ci == 1), isTrue);
+    expect(emissions.last.releases, 1);
   });
 
   test('v3 -> v4 upgrade creates working repo-detail tables', () async {

--- a/test/repo_detail_store_test.dart
+++ b/test/repo_detail_store_test.dart
@@ -190,6 +190,42 @@ void main() {
     expect(cached.pulls.single.ageDays, 3);
   });
 
+  test('watch emits the composite and re-emits after a save', () async {
+    final emissions = <List<String>>[];
+    final sub = RepoDetailStore.watch(repo, releasesSupported: true).listen((
+      data,
+    ) {
+      emissions.add(data.pulls.map((p) => p.label).toList());
+    });
+    // Initial emission (empty cache).
+    await pumpEventQueue();
+    await RepoDetailStore.save(
+      repo,
+      RepoDetailData(pulls: [_pr('PR #1'), _pr('PR #2')]),
+    );
+    await pumpEventQueue();
+    await sub.cancel();
+
+    expect(emissions.first, isEmpty);
+    expect(emissions.last, ['PR #1', 'PR #2']);
+  });
+
+  test('watch re-emits when CI or releases change', () async {
+    final ciCounts = <int>[];
+    final sub = RepoDetailStore.watch(repo, releasesSupported: true).listen((
+      data,
+    ) {
+      ciCounts.add(data.ci.length);
+    });
+    await pumpEventQueue();
+    await RepoDetailStore.save(repo, RepoDetailData(ci: [_run('build')]));
+    await pumpEventQueue();
+    await sub.cancel();
+
+    expect(ciCounts.first, 0);
+    expect(ciCounts.last, 1);
+  });
+
   test('v3 -> v4 upgrade creates working repo-detail tables', () async {
     // Set user_version = 3 so opening AppDatabase runs onUpgrade(3 -> 4) rather
     // than onCreate; the other tables aren't materialized because the v4 step


### PR DESCRIPTION
## What

Converts the **Repo-detail page**'s detail composite (open PRs / CI runs / releases) from imperative cache-then-refresh to a **reactive drift stream** — the final piece of Phase 3c, mirroring the merged reactive [Activity Feed](https://github.com/kamilon/kode_radar/pull/31) and [Attention Inbox](https://github.com/kamilon/kode_radar/pull/36). The drill-down renders the persisted cache instantly on cold start and auto-updates when an in-isolate write changes the cache (its own refresh, a repo-delete prune).

The per-repo **timeline** tab is intentionally left on its existing imperative path: its network fetch (`ActivityFeedService.computeAll(onlyRepoKeys:)`) is **not persisted** to a cache, so a reactive `ActivityEventStore.watch()` would show the shared feed cache instead of this page's scoped fetch — a behavior change we don't want.

## How

- **`lib/repo_detail_store.dart`** — extracted a private `_read(repoKey, {releasesSupported, now})` (the existing locked 3-table read) shared by `cached()` and the new **`watch(repoKey, {releasesSupported})`**. Because the composite spans three tables (not one drift query), `watch()` uses a `StreamController` whose `onListen` emits an initial `_read()` snapshot then subscribes to `db.tableUpdates(TableUpdateQuery.onAllTables([repoPulls, repoRuns, repoReleases]))`, re-emitting on any change; it forwards errors/completion and `onCancel` cancels the update subscription. (An initial `async*` + `await for` version hung on cancel — the StreamController version is deliberate.)
- **`lib/repo_detail_page.dart`** — the page holds `_streamDetail` (from `watch()`, failure flags always false) plus separate `_pullsFailed`/`_ciFailed`/`_releasesFailed` overlaid from the last network refresh; `_data` is a getter combining them. `_subscribe()` runs once in `initState` (cancelled in `dispose`) and clears a stale `_error` on a non-empty emission. `_load` no longer re-reads the cache after `save()` — the stream supplies the persisted rows; it sets the failure flags, the (still-imperative) timeline with its offline fallback, and provenance (`syncedOk` unchanged).

## Notes

- **Cross-isolate:** like the feed/attention streams, drift change notifications don't cross isolates, so a background-isolate write updates an open page only on the next cold-start read. In-isolate writes (this page's own refresh, a repo-delete prune) update live.
- Reviewed by code-review + rubber-duck; addressed the stream-lifecycle `onError`/`onDone` forwarding.

## Tests

`test/repo_detail_store_test.dart`: `watch()` emits the composite and re-emits after a save; re-emits when CI/releases change. `dart format` clean, `flutter analyze --fatal-infos` clean, all 329 tests pass.
