### PR TITLE
Page GitHub repo discovery via the Link header (>1000 repos)

### DIFF
--- a/lib/repo_discovery_page.dart
+++ b/lib/repo_discovery_page.dart
@@ -366,8 +366,9 @@ class _RepoDiscoveryPageState extends State<RepoDiscoveryPage> {
           if (_truncated) ...[
             const SizedBox(height: 12),
             Text(
-              'Showing the first 1000 repositories. Narrow the results by '
-              'organization to see the rest.',
+              'Some repositories were omitted because the account has a very '
+              'large number of them. Narrow the results by organization to see '
+              'the rest.',
               style: TextStyle(color: Colors.orange[800], fontSize: 12),
             ),
           ],

--- a/lib/repo_discovery_page.dart
+++ b/lib/repo_discovery_page.dart
@@ -366,9 +366,9 @@ class _RepoDiscoveryPageState extends State<RepoDiscoveryPage> {
           if (_truncated) ...[
             const SizedBox(height: 12),
             Text(
-              'Some repositories were omitted because the account has a very '
-              'large number of them. Narrow the results by organization to see '
-              'the rest.',
+              'Some repositories were omitted (the account has too many to '
+              'list, or its pagination could not be followed). Narrow the '
+              'results by organization to see the rest.',
               style: TextStyle(color: Colors.orange[800], fontSize: 12),
             ),
           ],

--- a/lib/repo_discovery_service.dart
+++ b/lib/repo_discovery_service.dart
@@ -40,6 +40,10 @@ class RepoDiscoveryService {
 
   static const Duration _requestTimeout = Duration(seconds: 20);
 
+  /// Safety cap on paged GitHub requests (100 repos/page, so up to ~5000 repos)
+  /// so a pathologically large account can't spin forever.
+  static const int _maxRepoPages = 50;
+
   static String githubKey(String owner, String name) =>
       'github:${owner.toLowerCase()}/${name.toLowerCase()}';
 
@@ -169,9 +173,21 @@ class RepoDiscoveryService {
   }) async {
     final all = <DiscoveredRepo>[];
     var truncated = false;
-    // Cap pagination to avoid runaway requests.
-    for (var page = 1; page <= 10; page++) {
-      final uri = Uri.parse('$base?per_page=100&page=$page');
+    // Page by following GitHub's `Link` header (rel="next"), starting from the
+    // first page, with a generous safety cap. This fully pages accounts that
+    // have more repos than the old fixed 10-page (1000-repo) limit.
+    String? next = '$base?per_page=100';
+    final visited = <String>{};
+    var pages = 0;
+    while (next != null) {
+      // Stop (as truncated) at the safety cap or if a link repeats — the latter
+      // guards against a server returning a self-referential `next`.
+      if (pages >= _maxRepoPages || !visited.add(next)) {
+        truncated = true;
+        break;
+      }
+      pages++;
+      final uri = Uri.parse(next);
       final response = await client
           .get(
             uri,
@@ -181,7 +197,7 @@ class RepoDiscoveryService {
             },
           )
           .timeout(_requestTimeout);
-      if (response.statusCode == 404 && allow404 && page == 1) {
+      if (response.statusCode == 404 && allow404 && pages == 1) {
         return null;
       }
       if (response.statusCode != 200) {
@@ -190,11 +206,38 @@ class RepoDiscoveryService {
       final body = jsonDecode(response.body);
       if (body is! List || body.isEmpty) break;
       all.addAll(parseGithubRepos(body));
-      if (body.length < 100) break;
-      // A full final page means there may be more we did not fetch.
-      if (page == 10) truncated = true;
+      // Follow the server's rel="next" link; its absence means the last page.
+      next = _nextLink(response.headers['link']);
     }
     return RepoFetchResult(repos: all, truncated: truncated);
+  }
+
+  /// Extracts the `rel="next"` URL from a GitHub `Link` response header, or null
+  /// when there is no next page (or no/blank header). The header looks like:
+  /// `<https://api.github.com/...&page=2>; rel="next", <...>; rel="last"`.
+  ///
+  /// Only same-origin `https://api.github.com` URLs are returned; a next link to
+  /// any other host/scheme is rejected (returns null) so a hostile or proxying
+  /// response can't redirect the token-bearing request to another host.
+  static String? _nextLink(String? linkHeader) {
+    if (linkHeader == null || linkHeader.isEmpty) return null;
+    for (final part in linkHeader.split(',')) {
+      final segments = part.split(';');
+      if (segments.length < 2) continue;
+      final urlMatch = RegExp(r'<([^>]+)>').firstMatch(segments[0]);
+      if (urlMatch == null) continue;
+      final isNext = segments.skip(1).any((s) => s.contains('rel="next"'));
+      if (!isNext) continue;
+      final url = urlMatch.group(1)!;
+      final uri = Uri.tryParse(url);
+      if (uri == null ||
+          uri.scheme != 'https' ||
+          uri.host != 'api.github.com') {
+        return null;
+      }
+      return url;
+    }
+    return null;
   }
 
   static Future<RepoFetchResult> _fetchAdo(

--- a/lib/repo_discovery_service.dart
+++ b/lib/repo_discovery_service.dart
@@ -207,20 +207,28 @@ class RepoDiscoveryService {
       if (body is! List || body.isEmpty) break;
       all.addAll(parseGithubRepos(body));
       // Follow the server's rel="next" link; its absence means the last page.
-      next = _nextLink(response.headers['link']);
+      // A present-but-rejected next (untrusted host / unparseable) marks the
+      // result truncated so the UI warns that repos were omitted.
+      final link = _nextLink(response.headers['link']);
+      if (link.rejected) truncated = true;
+      next = link.url;
     }
     return RepoFetchResult(repos: all, truncated: truncated);
   }
 
-  /// Extracts the `rel="next"` URL from a GitHub `Link` response header, or null
-  /// when there is no next page (or no/blank header). The header looks like:
-  /// `<https://api.github.com/...&page=2>; rel="next", <...>; rel="last"`.
+  /// Extracts the `rel="next"` URL from a GitHub `Link` response header. Returns
+  /// `url == null` when there is no next page (or no/blank header). The header
+  /// looks like `<https://api.github.com/...&page=2>; rel="next", <...>`.
   ///
-  /// Only same-origin `https://api.github.com` URLs are returned; a next link to
-  /// any other host/scheme is rejected (returns null) so a hostile or proxying
-  /// response can't redirect the token-bearing request to another host.
-  static String? _nextLink(String? linkHeader) {
-    if (linkHeader == null || linkHeader.isEmpty) return null;
+  /// Only same-origin `https://api.github.com` URLs are followed; a next link to
+  /// any other host/scheme (or one that won't parse) is rejected — `url` is null
+  /// and `rejected` is true — so a hostile or proxying response can't redirect
+  /// the token-bearing request to another host, and the caller can surface that
+  /// pages were omitted.
+  static ({String? url, bool rejected}) _nextLink(String? linkHeader) {
+    if (linkHeader == null || linkHeader.isEmpty) {
+      return (url: null, rejected: false);
+    }
     for (final part in linkHeader.split(',')) {
       final segments = part.split(';');
       if (segments.length < 2) continue;
@@ -233,11 +241,11 @@ class RepoDiscoveryService {
       if (uri == null ||
           uri.scheme != 'https' ||
           uri.host != 'api.github.com') {
-        return null;
+        return (url: null, rejected: true);
       }
-      return url;
+      return (url: url, rejected: false);
     }
-    return null;
+    return (url: null, rejected: false);
   }
 
   static Future<RepoFetchResult> _fetchAdo(

--- a/test/auto_add_service_test.dart
+++ b/test/auto_add_service_test.dart
@@ -32,7 +32,7 @@ void main() {
 
       final client = MockClient((request) async {
         if (request.url.path == '/orgs/acme/repos' &&
-            request.url.queryParameters['page'] == '1') {
+            request.url.queryParameters['page'] == null) {
           return http.Response(
             jsonEncode([
               {
@@ -150,7 +150,7 @@ void main() {
 
     final client = MockClient((request) async {
       if (request.url.path == '/orgs/acme/repos' &&
-          request.url.queryParameters['page'] == '1') {
+          request.url.queryParameters['page'] == null) {
         return http.Response(
           jsonEncode([
             {

--- a/test/repo_discovery_test.dart
+++ b/test/repo_discovery_test.dart
@@ -193,8 +193,10 @@ void main() {
       client: client,
     );
 
-    // The cross-host next link is rejected, so only api.github.com is hit.
+    // The cross-host next link is rejected, so only api.github.com is hit, and
+    // the result is marked truncated (more pages existed but weren't followed).
     expect(hosts, ['api.github.com']);
     expect(result.repos.length, 1);
+    expect(result.truncated, isTrue);
   });
 }

--- a/test/repo_discovery_test.dart
+++ b/test/repo_discovery_test.dart
@@ -91,4 +91,110 @@ void main() {
       expect(result.repos.single.display, 'octocat/hello');
     },
   );
+
+  test(
+    'follows the Link header to page GitHub repos beyond one page',
+    () async {
+      List<Map<String, dynamic>> reposPage(String prefix, int count) => [
+        for (var i = 0; i < count; i++)
+          {
+            'name': '$prefix$i',
+            'owner': {'login': 'acme'},
+          },
+      ];
+      final client = MockClient((request) async {
+        if (request.url.path != '/user/repos') {
+          return http.Response('[]', 200);
+        }
+        final page = request.url.queryParameters['page'];
+        if (page == null) {
+          // First page: a full page plus a Link header pointing to page 2.
+          return http.Response(
+            jsonEncode(reposPage('p1_', 100)),
+            200,
+            headers: {
+              'link':
+                  '<https://api.github.com/user/repos?per_page=100&page=2>; '
+                  'rel="next", '
+                  '<https://api.github.com/user/repos?per_page=100&page=2>; '
+                  'rel="last"',
+            },
+          );
+        }
+        if (page == '2') {
+          // Last page: no Link header, so paging stops here.
+          return http.Response(jsonEncode(reposPage('p2_', 5)), 200);
+        }
+        return http.Response('[]', 200);
+      });
+
+      final result = await RepoDiscoveryService.fetch(
+        provider: TokenStore.providerGithub,
+        secret: 'ghp_secret',
+        org: '',
+        client: client,
+      );
+
+      // Both pages collected (100 + 5), and not marked truncated.
+      expect(result.repos.length, 105);
+      expect(result.truncated, isFalse);
+    },
+  );
+
+  test('stops after one page when there is no Link header', () async {
+    var requests = 0;
+    final client = MockClient((request) async {
+      requests++;
+      return http.Response(
+        jsonEncode([
+          {
+            'name': 'solo',
+            'owner': {'login': 'acme'},
+          },
+        ]),
+        200,
+      );
+    });
+
+    final result = await RepoDiscoveryService.fetch(
+      provider: TokenStore.providerGithub,
+      secret: 'ghp_secret',
+      org: '',
+      client: client,
+    );
+
+    expect(result.repos.length, 1);
+    expect(requests, 1);
+  });
+
+  test('does not follow a cross-host Link (no token leak)', () async {
+    final hosts = <String>[];
+    final client = MockClient((request) async {
+      hosts.add(request.url.host);
+      return http.Response(
+        jsonEncode([
+          {
+            'name': 'solo',
+            'owner': {'login': 'acme'},
+          },
+        ]),
+        200,
+        headers: {
+          // A hostile/proxying response pointing the next page at another host.
+          'link': '<https://evil.example.com/user/repos?page=2>; rel="next"',
+        },
+      );
+    });
+
+    final result = await RepoDiscoveryService.fetch(
+      provider: TokenStore.providerGithub,
+      secret: 'ghp_secret',
+      org: '',
+      client: client,
+    );
+
+    // The cross-host next link is rejected, so only api.github.com is hit.
+    expect(hosts, ['api.github.com']);
+    expect(result.repos.length, 1);
+  });
 }

--- a/test/repo_discovery_test.dart
+++ b/test/repo_discovery_test.dart
@@ -103,29 +103,30 @@ void main() {
           },
       ];
       final client = MockClient((request) async {
-        if (request.url.path != '/user/repos') {
-          return http.Response('[]', 200);
+        if (request.url.path == '/user/repos') {
+          final page = request.url.queryParameters['page'];
+          if (page == null) {
+            // First page: a full page plus a Link header pointing to page 2.
+            return http.Response(
+              jsonEncode(reposPage('p1_', 100)),
+              200,
+              headers: {
+                'link':
+                    '<https://api.github.com/user/repos?per_page=100&page=2>; '
+                    'rel="next", '
+                    '<https://api.github.com/user/repos?per_page=100&page=2>; '
+                    'rel="last"',
+              },
+            );
+          }
+          if (page == '2') {
+            // Last page: no Link header, so paging stops here.
+            return http.Response(jsonEncode(reposPage('p2_', 5)), 200);
+          }
         }
-        final page = request.url.queryParameters['page'];
-        if (page == null) {
-          // First page: a full page plus a Link header pointing to page 2.
-          return http.Response(
-            jsonEncode(reposPage('p1_', 100)),
-            200,
-            headers: {
-              'link':
-                  '<https://api.github.com/user/repos?per_page=100&page=2>; '
-                  'rel="next", '
-                  '<https://api.github.com/user/repos?per_page=100&page=2>; '
-                  'rel="last"',
-            },
-          );
-        }
-        if (page == '2') {
-          // Last page: no Link header, so paging stops here.
-          return http.Response(jsonEncode(reposPage('p2_', 5)), 200);
-        }
-        return http.Response('[]', 200);
+        // Any other request means the pager hit the wrong endpoint or made an
+        // extra call — fail loudly rather than masking it with an empty page.
+        return fail('unexpected request: ${request.url}');
       });
 
       final result = await RepoDiscoveryService.fetch(


### PR DESCRIPTION
## What

Makes GitHub repository discovery (used by both **manual import** and the **background auto-add** pass) page through **all** of an account's repos instead of stopping at a hard 10-page (1000-repo) cap. It now follows GitHub's `Link` response header (`rel="next"`) with a 50-page (~5000-repo) safety cap.

## How

- **`lib/repo_discovery_service.dart`** — `_fetchGithubPaged` starts at `?per_page=100` and loops on the `rel="next"` URL from the `Link` header (parsed by the new `_nextLink`) rather than incrementing a page counter. `truncated` is set only when the safety cap (or the cycle guard) trips while more pages remain.
  - **Security:** `_nextLink` only returns **same-origin `https://api.github.com`** URLs — a next link to any other host/scheme is rejected — so a hostile or proxying response can't redirect the token-bearing request (and its `Authorization` header) to another host.
  - **Cycle guard:** visited next-URLs are tracked, so a self-referential `next` stops immediately (as truncated) rather than looping to the cap.
- **`lib/repo_discovery_page.dart`** — the import UI's truncation notice no longer hard-codes "first 1000 repositories".
- **ADO** listing is unchanged — its `/git/repositories` endpoint returns all repos in one response (no pagination).

## Review gate

Pre-open review by code-review + rubber-duck. Rubber-duck flagged a **cross-host token-leak/SSRF** risk in following `Link` URLs unconditionally — addressed by the same-origin `https://api.github.com` validation above (with a regression test).

## Tests

`test/repo_discovery_test.dart`: multi-page Link following (100 + 5 → 105 repos, not truncated), single-page stop (exactly one request when no Link header), and **cross-host next-link rejection** (only `api.github.com` is contacted). Two `auto_add_service_test` mocks updated for the new initial request (no `page=1`).

`dart format` clean, `flutter analyze --fatal-infos` clean, all 332 tests pass.
