### PR TITLE
Make notification taps actionable (open inbox / deep-link PR)

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import UserNotifications
 import workmanager_apple
 
 @main
@@ -8,6 +9,13 @@ import workmanager_apple
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // Receive notification taps so flutter_local_notifications can forward the
+    // tapped payload (and launch details) to Dart. The iOS plugin registers as
+    // an application delegate but does not set the UNUserNotificationCenter
+    // delegate itself, so we must — otherwise taps are never delivered.
+    if #available(iOS 10.0, *) {
+      UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
+    }
     // Make plugins available to the background isolate that workmanager spins up
     // for BGTaskScheduler work.
     WorkmanagerPlugin.setPluginRegistrantCallback { registry in

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -14,7 +14,7 @@ import workmanager_apple
     // an application delegate but does not set the UNUserNotificationCenter
     // delegate itself, so we must — otherwise taps are never delivered.
     if #available(iOS 10.0, *) {
-      UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
+      UNUserNotificationCenter.current().delegate = self
     }
     // Make plugins available to the background isolate that workmanager spins up
     // for BGTaskScheduler work.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:tray_manager/tray_manager.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'radar_page.dart';
@@ -187,6 +188,10 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this); // Observe app lifecycle.
+    // Route notification taps: a live tap updates tappedPayload, and a cold
+    // start (app launched by tapping a notification) is read once here.
+    NotificationService.tappedPayload.addListener(_onNotificationTap);
+    unawaited(_handleLaunchNotification());
     final initialState = WidgetsBinding.instance.lifecycleState;
     if (initialState != null && _lifecyclePolicy.isBackground(initialState)) {
       // Launched directly into the background. Record the state; on desktop keep
@@ -208,8 +213,44 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    NotificationService.tappedPayload.removeListener(_onNotificationTap);
     _cancelPollingTimers(); // Stop all polling when the widget is disposed.
     super.dispose();
+  }
+
+  /// Handles a live notification tap (while the app is running): consume the
+  /// payload and route it.
+  void _onNotificationTap() {
+    final payload = NotificationService.tappedPayload.value;
+    if (payload == null) return;
+    NotificationService.tappedPayload.value = null; // consume once
+    _routeNotificationPayload(payload);
+  }
+
+  /// Handles the cold-start case: if a notification launched the app, route its
+  /// payload once.
+  Future<void> _handleLaunchNotification() async {
+    final payload = await NotificationService.takeLaunchPayload();
+    if (!mounted || payload == null) return;
+    _routeNotificationPayload(payload);
+  }
+
+  void _routeNotificationPayload(String payload) {
+    // Always land on the Attention Inbox for in-app context; if the payload is
+    // a trusted PR URL, also open that PR directly.
+    _onSelectTab(0);
+    if (payload == NotificationService.attentionPayload) return;
+    if (NotificationService.isTrustedPrUrl(payload)) {
+      unawaited(_openNotificationUrl(payload));
+    }
+  }
+
+  Future<void> _openNotificationUrl(String url) async {
+    try {
+      await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    } catch (e) {
+      debugPrint('Failed to open notification URL: $e');
+    }
   }
 
   void _cancelPollingTimers() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -246,8 +246,17 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   }
 
   Future<void> _openNotificationUrl(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      debugPrint('Notification URL not parseable: $url');
+      return;
+    }
     try {
-      await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+      final launched = await launchUrl(
+        uri,
+        mode: LaunchMode.externalApplication,
+      );
+      if (!launched) debugPrint('launchUrl returned false for: $url');
     } catch (e) {
       debugPrint('Failed to open notification URL: $e');
     }

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -18,6 +18,17 @@ class NotificationService {
   static const String _channelDescription =
       'Notifications for new Attention Inbox items';
 
+  /// Payload marking a summary notification whose tap should open the Attention
+  /// Inbox (used when there isn't a single obvious item to deep-link to).
+  static const String attentionPayload = 'attention';
+
+  /// The payload of the most recently tapped notification, for the app shell to
+  /// route (open the inbox, or launch a single item's URL). The shell resets it
+  /// to null once consumed.
+  static final ValueNotifier<String?> tappedPayload = ValueNotifier<String?>(
+    null,
+  );
+
   static final FlutterLocalNotificationsPlugin _plugin =
       FlutterLocalNotificationsPlugin();
 
@@ -138,6 +149,53 @@ class NotificationService {
   static Set<String> diffNew(Set<String> seen, Iterable<String> current) =>
       current.toSet().difference(seen);
 
+  /// The payload for a summary notification. When exactly one new item is being
+  /// notified and it has a trusted PR URL, the payload is that URL so a tap can
+  /// open that PR directly; otherwise it is [attentionPayload], so a tap opens
+  /// the Attention Inbox (the right target for a multi-item summary).
+  @visibleForTesting
+  static String payloadFor(List<AttentionItem> newItems) {
+    if (newItems.length == 1 && isTrustedPrUrl(newItems.single.url)) {
+      return newItems.single.url!;
+    }
+    return attentionPayload;
+  }
+
+  /// Whether [url] is a PR URL we're willing to open from a notification tap:
+  /// `https` on a known provider host. This rejects a forged payload (e.g. an
+  /// Android intent crafted with an arbitrary URL) even though our own payloads
+  /// are always provider URLs.
+  static bool isTrustedPrUrl(String? url) {
+    if (url == null) return false;
+    final uri = Uri.tryParse(url);
+    if (uri == null || uri.scheme != 'https') return false;
+    return uri.host == 'github.com' || uri.host == 'dev.azure.com';
+  }
+
+  static void _onNotificationResponse(NotificationResponse response) {
+    tappedPayload.value = response.payload;
+  }
+
+  static bool _launchPayloadTaken = false;
+
+  /// The payload of the notification that launched the app from a terminated
+  /// state (cold start), or null. Returns it at most once per process, so a
+  /// shell rebuild can't re-open the same launch URL; live taps arrive via
+  /// [tappedPayload].
+  static Future<String?> takeLaunchPayload() async {
+    if (_launchPayloadTaken || !_isSupportedPlatform) return null;
+    _launchPayloadTaken = true;
+    try {
+      final details = await _plugin.getNotificationAppLaunchDetails();
+      if (details?.didNotificationLaunchApp ?? false) {
+        return details!.notificationResponse?.payload;
+      }
+    } catch (e) {
+      debugPrint('Failed to read notification launch details: $e');
+    }
+    return null;
+  }
+
   /// The ids to notify about: ids new since [seen], minus ids that belong to a
   /// repo appearing for the first time (a newly added repo's existing backlog
   /// is seeded silently rather than replayed). Returns nothing on the first run.
@@ -214,7 +272,10 @@ class NotificationService {
         iOS: DarwinInitializationSettings(),
         macOS: DarwinInitializationSettings(),
       );
-      await _plugin.initialize(settings: settings);
+      await _plugin.initialize(
+        settings: settings,
+        onDidReceiveNotificationResponse: _onNotificationResponse,
+      );
       // Android 13+ (API 33+) requires the runtime POST_NOTIFICATIONS grant.
       await _plugin
           .resolvePlatformSpecificImplementation<
@@ -246,6 +307,7 @@ class NotificationService {
         title: _summaryTitle(newItems.length),
         body: _summaryBody(newItems),
         notificationDetails: details,
+        payload: payloadFor(newItems),
       );
     } catch (e) {
       debugPrint('Failed to show attention notification: $e');

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -176,7 +176,9 @@ class NotificationService {
     }
     // Azure DevOps: /{org}/{project}/_git/{repo}/pullrequest/{id}
     if (uri.host == 'dev.azure.com') {
-      return RegExp(r'/_git/[^/]+/pullrequest/\d+/?$').hasMatch(path);
+      return RegExp(
+        r'^/[^/]+/[^/]+/_git/[^/]+/pullrequest/\d+/?$',
+      ).hasMatch(path);
     }
     return false;
   }

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -162,14 +162,23 @@ class NotificationService {
   }
 
   /// Whether [url] is a PR URL we're willing to open from a notification tap:
-  /// `https` on a known provider host. This rejects a forged payload (e.g. an
-  /// Android intent crafted with an arbitrary URL) even though our own payloads
-  /// are always provider URLs.
+  /// `https` on a known provider host **and** matching that provider's PR path
+  /// shape. This rejects a forged payload (e.g. an Android intent crafted with
+  /// an arbitrary URL) from opening some other page on a trusted host.
   static bool isTrustedPrUrl(String? url) {
     if (url == null) return false;
     final uri = Uri.tryParse(url);
     if (uri == null || uri.scheme != 'https') return false;
-    return uri.host == 'github.com' || uri.host == 'dev.azure.com';
+    final path = uri.path;
+    // GitHub: /{owner}/{repo}/pull/{number}
+    if (uri.host == 'github.com') {
+      return RegExp(r'^/[^/]+/[^/]+/pull/\d+/?$').hasMatch(path);
+    }
+    // Azure DevOps: /{org}/{project}/_git/{repo}/pullrequest/{id}
+    if (uri.host == 'dev.azure.com') {
+      return RegExp(r'/_git/[^/]+/pullrequest/\d+/?$').hasMatch(path);
+    }
+    return false;
   }
 
   static void _onNotificationResponse(NotificationResponse response) {

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -239,6 +239,13 @@ void main() {
         NotificationService.isTrustedPrUrl('https://dev.azure.com/org/proj'),
         isFalse,
       );
+      // Missing the leading /{org}/{project} segments (regex fully anchored).
+      expect(
+        NotificationService.isTrustedPrUrl(
+          'https://dev.azure.com/_git/repo/pullrequest/1',
+        ),
+        isFalse,
+      );
     });
   });
 }

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -195,7 +195,7 @@ void main() {
   });
 
   group('isTrustedPrUrl', () {
-    test('accepts https github.com and dev.azure.com', () {
+    test('accepts well-formed github.com and dev.azure.com PR URLs', () {
       expect(
         NotificationService.isTrustedPrUrl(
           'https://github.com/owner/repo/pull/1',
@@ -213,7 +213,7 @@ void main() {
     test('rejects null, non-https, and other hosts', () {
       expect(NotificationService.isTrustedPrUrl(null), isFalse);
       expect(
-        NotificationService.isTrustedPrUrl('http://github.com/x'),
+        NotificationService.isTrustedPrUrl('http://github.com/o/r/pull/1'),
         isFalse,
       );
       expect(
@@ -221,6 +221,24 @@ void main() {
         isFalse,
       );
       expect(NotificationService.isTrustedPrUrl('not a url'), isFalse);
+    });
+
+    test('rejects non-PR paths on a trusted host', () {
+      // A forged payload can't open arbitrary pages on github.com/dev.azure.com.
+      expect(
+        NotificationService.isTrustedPrUrl(
+          'https://github.com/owner/repo/issues/1',
+        ),
+        isFalse,
+      );
+      expect(
+        NotificationService.isTrustedPrUrl('https://github.com/settings'),
+        isFalse,
+      );
+      expect(
+        NotificationService.isTrustedPrUrl('https://dev.azure.com/org/proj'),
+        isFalse,
+      );
     });
   });
 }

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -130,4 +130,97 @@ void main() {
       expect(pending, isEmpty);
     });
   });
+
+  group('payloadFor', () {
+    AttentionItem itemWithUrl(String id, String? url) => AttentionItem(
+      id: id,
+      category: 'reviewRequested',
+      severity: 3000,
+      titleTemplate: id,
+      subtitleTemplate: '',
+      repoDisplay: 'owner/repo',
+      url: url,
+    );
+
+    test('a single item with a trusted https PR URL deep-links to it', () {
+      expect(
+        NotificationService.payloadFor([
+          itemWithUrl('a', 'https://github.com/owner/repo/pull/1'),
+        ]),
+        'https://github.com/owner/repo/pull/1',
+      );
+    });
+
+    test('a single item without a URL opens the inbox', () {
+      expect(
+        NotificationService.payloadFor([itemWithUrl('a', null)]),
+        NotificationService.attentionPayload,
+      );
+    });
+
+    test('a single item with a non-https URL opens the inbox', () {
+      expect(
+        NotificationService.payloadFor([
+          itemWithUrl('a', 'http://github.com/owner/repo/pull/1'),
+        ]),
+        NotificationService.attentionPayload,
+      );
+    });
+
+    test('a single item on an untrusted host opens the inbox', () {
+      expect(
+        NotificationService.payloadFor([
+          itemWithUrl('a', 'https://evil.example.com/owner/repo/pull/1'),
+        ]),
+        NotificationService.attentionPayload,
+      );
+    });
+
+    test('multiple items open the inbox', () {
+      expect(
+        NotificationService.payloadFor([
+          itemWithUrl('a', 'https://github.com/owner/repo/pull/1'),
+          itemWithUrl('b', 'https://github.com/owner/repo/pull/2'),
+        ]),
+        NotificationService.attentionPayload,
+      );
+    });
+
+    test('an empty list opens the inbox', () {
+      expect(
+        NotificationService.payloadFor(const []),
+        NotificationService.attentionPayload,
+      );
+    });
+  });
+
+  group('isTrustedPrUrl', () {
+    test('accepts https github.com and dev.azure.com', () {
+      expect(
+        NotificationService.isTrustedPrUrl(
+          'https://github.com/owner/repo/pull/1',
+        ),
+        isTrue,
+      );
+      expect(
+        NotificationService.isTrustedPrUrl(
+          'https://dev.azure.com/org/proj/_git/repo/pullrequest/2',
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects null, non-https, and other hosts', () {
+      expect(NotificationService.isTrustedPrUrl(null), isFalse);
+      expect(
+        NotificationService.isTrustedPrUrl('http://github.com/x'),
+        isFalse,
+      );
+      expect(
+        NotificationService.isTrustedPrUrl('https://evil.example.com/x'),
+        isFalse,
+      );
+      expect(NotificationService.isTrustedPrUrl('not a url'), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## What

Makes the "items need attention" summary notification **actionable**. Previously tapping it just brought the app to the foreground wherever it was. Now a tap opens the app on the **Attention Inbox** tab, and for a **single-item** notification whose item has a trusted PR URL, it also opens that PR directly.

## How

- **`lib/notification_service.dart`**
  - The summary notification now carries a `payload` from `payloadFor(newItems)`: a single new item's **trusted https PR URL** (so a tap deep-links to the PR), otherwise `attentionPayload` (open the inbox — the right target for a multi-item summary).
  - `_initPlugin` registers `onDidReceiveNotificationResponse`, which publishes the tapped payload to a `ValueNotifier<String?> tappedPayload` for the app shell to route.
  - `takeLaunchPayload()` reads the cold-start launch details (`getNotificationAppLaunchDetails`) **once** per process.
  - `isTrustedPrUrl` only accepts `https` on `github.com` / `dev.azure.com`, rejecting a forged payload (e.g. an Android intent crafted with an arbitrary URL).
- **`lib/main.dart`** (`_MyHomePageState`) listens to `tappedPayload` (live taps) and reads `takeLaunchPayload()` at startup (cold start); `_routeNotificationPayload` opens the Attention Inbox tab and, for a trusted PR URL, `launchUrl` (guarded try/catch). Listener added in `initState`, removed in `dispose`.
- **`ios/Runner/AppDelegate.swift`** sets `UNUserNotificationCenter.current().delegate` — the iOS flutter_local_notifications plugin registers as an application delegate but does **not** set the notification-center delegate itself, so without this taps and launch details never reach Dart.

## Review gate

code-review + rubber-duck pre-open. Rubber-duck caught the **blocking iOS delegate** gap (feature would be dead on iOS) and hardening items — all addressed (host allowlist, one-shot launch payload, guarded launch).

## Tests

`test/notification_service_test.dart`: `payloadFor` (single trusted https → URL; no-URL / non-https / untrusted host / multiple / empty → inbox) and `isTrustedPrUrl` (accepts the two provider hosts; rejects null / non-https / other hosts / unparseable). The tap/launch plumbing is integration-level (plugin callbacks); only the pure helpers are unit-tested, per the repo's pattern.

`dart format` clean, `flutter analyze --fatal-infos` clean, all 340 tests pass.
