### PR TITLE
Show PR triage signals (conflicts + diff size) in repo detail

### DIFF
--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -95,6 +95,10 @@ class RepoPulls extends Table {
   IntColumn get createdAt => integer().nullable()();
   BoolColumn get draft => boolean()();
   TextColumn get url => text().nullable()();
+  TextColumn get mergeable => text().nullable()();
+  IntColumn get additions => integer().nullable()();
+  IntColumn get deletions => integer().nullable()();
+  IntColumn get changedFiles => integer().nullable()();
 }
 
 @DataClassName('RepoRunRow')
@@ -204,7 +208,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -323,6 +327,32 @@ class AppDatabase extends _$AppDatabase {
         } on Exception catch (e) {
           if (!e.toString().toLowerCase().contains('duplicate column')) {
             rethrow;
+          }
+        }
+      }
+      // v9 adds PR triage columns to repo_pulls (mergeable + diff size). Ensure
+      // the table exists, then add each column with an idempotent
+      // `ALTER TABLE ADD COLUMN`, tolerating "duplicate column" (concurrent
+      // migrator, or a jump from <4 where createTable already built the current
+      // schema).
+      if (from < 9) {
+        await m.createTable(repoPulls);
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_repo_pulls_repo_key '
+          'ON repo_pulls (repo_key)',
+        );
+        for (final ddl in const [
+          'ALTER TABLE repo_pulls ADD COLUMN mergeable TEXT',
+          'ALTER TABLE repo_pulls ADD COLUMN additions INTEGER',
+          'ALTER TABLE repo_pulls ADD COLUMN deletions INTEGER',
+          'ALTER TABLE repo_pulls ADD COLUMN changed_files INTEGER',
+        ]) {
+          try {
+            await customStatement(ddl);
+          } on Exception catch (e) {
+            if (!e.toString().toLowerCase().contains('duplicate column')) {
+              rethrow;
+            }
           }
         }
       }

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -2040,6 +2040,50 @@ class $RepoPullsTable extends RepoPulls
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _mergeableMeta = const VerificationMeta(
+    'mergeable',
+  );
+  @override
+  late final GeneratedColumn<String> mergeable = GeneratedColumn<String>(
+    'mergeable',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _additionsMeta = const VerificationMeta(
+    'additions',
+  );
+  @override
+  late final GeneratedColumn<int> additions = GeneratedColumn<int>(
+    'additions',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _deletionsMeta = const VerificationMeta(
+    'deletions',
+  );
+  @override
+  late final GeneratedColumn<int> deletions = GeneratedColumn<int>(
+    'deletions',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _changedFilesMeta = const VerificationMeta(
+    'changedFiles',
+  );
+  @override
+  late final GeneratedColumn<int> changedFiles = GeneratedColumn<int>(
+    'changed_files',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -2052,6 +2096,10 @@ class $RepoPullsTable extends RepoPulls
     createdAt,
     draft,
     url,
+    mergeable,
+    additions,
+    deletions,
+    changedFiles,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -2137,6 +2185,33 @@ class $RepoPullsTable extends RepoPulls
         url.isAcceptableOrUnknown(data['url']!, _urlMeta),
       );
     }
+    if (data.containsKey('mergeable')) {
+      context.handle(
+        _mergeableMeta,
+        mergeable.isAcceptableOrUnknown(data['mergeable']!, _mergeableMeta),
+      );
+    }
+    if (data.containsKey('additions')) {
+      context.handle(
+        _additionsMeta,
+        additions.isAcceptableOrUnknown(data['additions']!, _additionsMeta),
+      );
+    }
+    if (data.containsKey('deletions')) {
+      context.handle(
+        _deletionsMeta,
+        deletions.isAcceptableOrUnknown(data['deletions']!, _deletionsMeta),
+      );
+    }
+    if (data.containsKey('changed_files')) {
+      context.handle(
+        _changedFilesMeta,
+        changedFiles.isAcceptableOrUnknown(
+          data['changed_files']!,
+          _changedFilesMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -2186,6 +2261,22 @@ class $RepoPullsTable extends RepoPulls
         DriftSqlType.string,
         data['${effectivePrefix}url'],
       ),
+      mergeable: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}mergeable'],
+      ),
+      additions: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}additions'],
+      ),
+      deletions: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}deletions'],
+      ),
+      changedFiles: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}changed_files'],
+      ),
     );
   }
 
@@ -2206,6 +2297,10 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
   final int? createdAt;
   final bool draft;
   final String? url;
+  final String? mergeable;
+  final int? additions;
+  final int? deletions;
+  final int? changedFiles;
   const RepoPrRow({
     required this.id,
     required this.repoKey,
@@ -2217,6 +2312,10 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
     this.createdAt,
     required this.draft,
     this.url,
+    this.mergeable,
+    this.additions,
+    this.deletions,
+    this.changedFiles,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -2237,6 +2336,18 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
     if (!nullToAbsent || url != null) {
       map['url'] = Variable<String>(url);
     }
+    if (!nullToAbsent || mergeable != null) {
+      map['mergeable'] = Variable<String>(mergeable);
+    }
+    if (!nullToAbsent || additions != null) {
+      map['additions'] = Variable<int>(additions);
+    }
+    if (!nullToAbsent || deletions != null) {
+      map['deletions'] = Variable<int>(deletions);
+    }
+    if (!nullToAbsent || changedFiles != null) {
+      map['changed_files'] = Variable<int>(changedFiles);
+    }
     return map;
   }
 
@@ -2256,6 +2367,18 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
           : Value(createdAt),
       draft: Value(draft),
       url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+      mergeable: mergeable == null && nullToAbsent
+          ? const Value.absent()
+          : Value(mergeable),
+      additions: additions == null && nullToAbsent
+          ? const Value.absent()
+          : Value(additions),
+      deletions: deletions == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletions),
+      changedFiles: changedFiles == null && nullToAbsent
+          ? const Value.absent()
+          : Value(changedFiles),
     );
   }
 
@@ -2275,6 +2398,10 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
       createdAt: serializer.fromJson<int?>(json['createdAt']),
       draft: serializer.fromJson<bool>(json['draft']),
       url: serializer.fromJson<String?>(json['url']),
+      mergeable: serializer.fromJson<String?>(json['mergeable']),
+      additions: serializer.fromJson<int?>(json['additions']),
+      deletions: serializer.fromJson<int?>(json['deletions']),
+      changedFiles: serializer.fromJson<int?>(json['changedFiles']),
     );
   }
   @override
@@ -2291,6 +2418,10 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
       'createdAt': serializer.toJson<int?>(createdAt),
       'draft': serializer.toJson<bool>(draft),
       'url': serializer.toJson<String?>(url),
+      'mergeable': serializer.toJson<String?>(mergeable),
+      'additions': serializer.toJson<int?>(additions),
+      'deletions': serializer.toJson<int?>(deletions),
+      'changedFiles': serializer.toJson<int?>(changedFiles),
     };
   }
 
@@ -2305,6 +2436,10 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
     Value<int?> createdAt = const Value.absent(),
     bool? draft,
     Value<String?> url = const Value.absent(),
+    Value<String?> mergeable = const Value.absent(),
+    Value<int?> additions = const Value.absent(),
+    Value<int?> deletions = const Value.absent(),
+    Value<int?> changedFiles = const Value.absent(),
   }) => RepoPrRow(
     id: id ?? this.id,
     repoKey: repoKey ?? this.repoKey,
@@ -2316,6 +2451,10 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
     createdAt: createdAt.present ? createdAt.value : this.createdAt,
     draft: draft ?? this.draft,
     url: url.present ? url.value : this.url,
+    mergeable: mergeable.present ? mergeable.value : this.mergeable,
+    additions: additions.present ? additions.value : this.additions,
+    deletions: deletions.present ? deletions.value : this.deletions,
+    changedFiles: changedFiles.present ? changedFiles.value : this.changedFiles,
   );
   RepoPrRow copyWithCompanion(RepoPullsCompanion data) {
     return RepoPrRow(
@@ -2331,6 +2470,12 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       draft: data.draft.present ? data.draft.value : this.draft,
       url: data.url.present ? data.url.value : this.url,
+      mergeable: data.mergeable.present ? data.mergeable.value : this.mergeable,
+      additions: data.additions.present ? data.additions.value : this.additions,
+      deletions: data.deletions.present ? data.deletions.value : this.deletions,
+      changedFiles: data.changedFiles.present
+          ? data.changedFiles.value
+          : this.changedFiles,
     );
   }
 
@@ -2346,7 +2491,11 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
           ..write('ageDays: $ageDays, ')
           ..write('createdAt: $createdAt, ')
           ..write('draft: $draft, ')
-          ..write('url: $url')
+          ..write('url: $url, ')
+          ..write('mergeable: $mergeable, ')
+          ..write('additions: $additions, ')
+          ..write('deletions: $deletions, ')
+          ..write('changedFiles: $changedFiles')
           ..write(')'))
         .toString();
   }
@@ -2363,6 +2512,10 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
     createdAt,
     draft,
     url,
+    mergeable,
+    additions,
+    deletions,
+    changedFiles,
   );
   @override
   bool operator ==(Object other) =>
@@ -2377,7 +2530,11 @@ class RepoPrRow extends DataClass implements Insertable<RepoPrRow> {
           other.ageDays == this.ageDays &&
           other.createdAt == this.createdAt &&
           other.draft == this.draft &&
-          other.url == this.url);
+          other.url == this.url &&
+          other.mergeable == this.mergeable &&
+          other.additions == this.additions &&
+          other.deletions == this.deletions &&
+          other.changedFiles == this.changedFiles);
 }
 
 class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
@@ -2391,6 +2548,10 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
   final Value<int?> createdAt;
   final Value<bool> draft;
   final Value<String?> url;
+  final Value<String?> mergeable;
+  final Value<int?> additions;
+  final Value<int?> deletions;
+  final Value<int?> changedFiles;
   const RepoPullsCompanion({
     this.id = const Value.absent(),
     this.repoKey = const Value.absent(),
@@ -2402,6 +2563,10 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
     this.createdAt = const Value.absent(),
     this.draft = const Value.absent(),
     this.url = const Value.absent(),
+    this.mergeable = const Value.absent(),
+    this.additions = const Value.absent(),
+    this.deletions = const Value.absent(),
+    this.changedFiles = const Value.absent(),
   });
   RepoPullsCompanion.insert({
     this.id = const Value.absent(),
@@ -2414,6 +2579,10 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
     this.createdAt = const Value.absent(),
     required bool draft,
     this.url = const Value.absent(),
+    this.mergeable = const Value.absent(),
+    this.additions = const Value.absent(),
+    this.deletions = const Value.absent(),
+    this.changedFiles = const Value.absent(),
   }) : repoKey = Value(repoKey),
        label = Value(label),
        title = Value(title),
@@ -2431,6 +2600,10 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
     Expression<int>? createdAt,
     Expression<bool>? draft,
     Expression<String>? url,
+    Expression<String>? mergeable,
+    Expression<int>? additions,
+    Expression<int>? deletions,
+    Expression<int>? changedFiles,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -2443,6 +2616,10 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
       if (createdAt != null) 'created_at': createdAt,
       if (draft != null) 'draft': draft,
       if (url != null) 'url': url,
+      if (mergeable != null) 'mergeable': mergeable,
+      if (additions != null) 'additions': additions,
+      if (deletions != null) 'deletions': deletions,
+      if (changedFiles != null) 'changed_files': changedFiles,
     });
   }
 
@@ -2457,6 +2634,10 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
     Value<int?>? createdAt,
     Value<bool>? draft,
     Value<String?>? url,
+    Value<String?>? mergeable,
+    Value<int?>? additions,
+    Value<int?>? deletions,
+    Value<int?>? changedFiles,
   }) {
     return RepoPullsCompanion(
       id: id ?? this.id,
@@ -2469,6 +2650,10 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
       createdAt: createdAt ?? this.createdAt,
       draft: draft ?? this.draft,
       url: url ?? this.url,
+      mergeable: mergeable ?? this.mergeable,
+      additions: additions ?? this.additions,
+      deletions: deletions ?? this.deletions,
+      changedFiles: changedFiles ?? this.changedFiles,
     );
   }
 
@@ -2505,6 +2690,18 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
     if (url.present) {
       map['url'] = Variable<String>(url.value);
     }
+    if (mergeable.present) {
+      map['mergeable'] = Variable<String>(mergeable.value);
+    }
+    if (additions.present) {
+      map['additions'] = Variable<int>(additions.value);
+    }
+    if (deletions.present) {
+      map['deletions'] = Variable<int>(deletions.value);
+    }
+    if (changedFiles.present) {
+      map['changed_files'] = Variable<int>(changedFiles.value);
+    }
     return map;
   }
 
@@ -2520,7 +2717,11 @@ class RepoPullsCompanion extends UpdateCompanion<RepoPrRow> {
           ..write('ageDays: $ageDays, ')
           ..write('createdAt: $createdAt, ')
           ..write('draft: $draft, ')
-          ..write('url: $url')
+          ..write('url: $url, ')
+          ..write('mergeable: $mergeable, ')
+          ..write('additions: $additions, ')
+          ..write('deletions: $deletions, ')
+          ..write('changedFiles: $changedFiles')
           ..write(')'))
         .toString();
   }
@@ -5252,6 +5453,10 @@ typedef $$RepoPullsTableCreateCompanionBuilder =
       Value<int?> createdAt,
       required bool draft,
       Value<String?> url,
+      Value<String?> mergeable,
+      Value<int?> additions,
+      Value<int?> deletions,
+      Value<int?> changedFiles,
     });
 typedef $$RepoPullsTableUpdateCompanionBuilder =
     RepoPullsCompanion Function({
@@ -5265,6 +5470,10 @@ typedef $$RepoPullsTableUpdateCompanionBuilder =
       Value<int?> createdAt,
       Value<bool> draft,
       Value<String?> url,
+      Value<String?> mergeable,
+      Value<int?> additions,
+      Value<int?> deletions,
+      Value<int?> changedFiles,
     });
 
 class $$RepoPullsTableFilterComposer
@@ -5323,6 +5532,26 @@ class $$RepoPullsTableFilterComposer
 
   ColumnFilters<String> get url => $composableBuilder(
     column: $table.url,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get mergeable => $composableBuilder(
+    column: $table.mergeable,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get additions => $composableBuilder(
+    column: $table.additions,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get deletions => $composableBuilder(
+    column: $table.deletions,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get changedFiles => $composableBuilder(
+    column: $table.changedFiles,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -5385,6 +5614,26 @@ class $$RepoPullsTableOrderingComposer
     column: $table.url,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get mergeable => $composableBuilder(
+    column: $table.mergeable,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get additions => $composableBuilder(
+    column: $table.additions,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get deletions => $composableBuilder(
+    column: $table.deletions,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get changedFiles => $composableBuilder(
+    column: $table.changedFiles,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$RepoPullsTableAnnotationComposer
@@ -5427,6 +5676,20 @@ class $$RepoPullsTableAnnotationComposer
 
   GeneratedColumn<String> get url =>
       $composableBuilder(column: $table.url, builder: (column) => column);
+
+  GeneratedColumn<String> get mergeable =>
+      $composableBuilder(column: $table.mergeable, builder: (column) => column);
+
+  GeneratedColumn<int> get additions =>
+      $composableBuilder(column: $table.additions, builder: (column) => column);
+
+  GeneratedColumn<int> get deletions =>
+      $composableBuilder(column: $table.deletions, builder: (column) => column);
+
+  GeneratedColumn<int> get changedFiles => $composableBuilder(
+    column: $table.changedFiles,
+    builder: (column) => column,
+  );
 }
 
 class $$RepoPullsTableTableManager
@@ -5470,6 +5733,10 @@ class $$RepoPullsTableTableManager
                 Value<int?> createdAt = const Value.absent(),
                 Value<bool> draft = const Value.absent(),
                 Value<String?> url = const Value.absent(),
+                Value<String?> mergeable = const Value.absent(),
+                Value<int?> additions = const Value.absent(),
+                Value<int?> deletions = const Value.absent(),
+                Value<int?> changedFiles = const Value.absent(),
               }) => RepoPullsCompanion(
                 id: id,
                 repoKey: repoKey,
@@ -5481,6 +5748,10 @@ class $$RepoPullsTableTableManager
                 createdAt: createdAt,
                 draft: draft,
                 url: url,
+                mergeable: mergeable,
+                additions: additions,
+                deletions: deletions,
+                changedFiles: changedFiles,
               ),
           createCompanionCallback:
               ({
@@ -5494,6 +5765,10 @@ class $$RepoPullsTableTableManager
                 Value<int?> createdAt = const Value.absent(),
                 required bool draft,
                 Value<String?> url = const Value.absent(),
+                Value<String?> mergeable = const Value.absent(),
+                Value<int?> additions = const Value.absent(),
+                Value<int?> deletions = const Value.absent(),
+                Value<int?> changedFiles = const Value.absent(),
               }) => RepoPullsCompanion.insert(
                 id: id,
                 repoKey: repoKey,
@@ -5505,6 +5780,10 @@ class $$RepoPullsTableTableManager
                 createdAt: createdAt,
                 draft: draft,
                 url: url,
+                mergeable: mergeable,
+                additions: additions,
+                deletions: deletions,
+                changedFiles: changedFiles,
               ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))

--- a/lib/repo_detail_page.dart
+++ b/lib/repo_detail_page.dart
@@ -369,6 +369,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
 
   Widget _prTile(RepoPr pr) {
     final review = _reviewVisual(pr.reviewState);
+    final scheme = Theme.of(context).colorScheme;
     return ListTile(
       leading: Icon(review.icon, color: review.color),
       title: Row(
@@ -378,15 +379,40 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
             const SizedBox(width: 6),
             const _MiniChip(label: 'Draft'),
           ],
+          if (pr.mergeable == PrMergeable.conflicting) ...[
+            const SizedBox(width: 6),
+            _MiniChip(
+              label: 'Conflicts',
+              color: scheme.errorContainer,
+              textColor: scheme.onErrorContainer,
+            ),
+          ],
         ],
       ),
       subtitle: Text(
-        'by ${pr.author} · ${_ageText(pr.ageDays)} · ${review.label}',
+        _prSubtitle(pr, review.label),
         style: TextStyle(color: Colors.grey[600], fontSize: 12),
       ),
       trailing: pr.url != null ? const Icon(Icons.open_in_new, size: 16) : null,
       onTap: pr.url == null ? null : () => _open(pr.url!),
     );
+  }
+
+  /// The PR subtitle line, appending a `+adds −dels · N files` diff-size summary
+  /// when the provider reported it (GitHub does; Azure DevOps' list API
+  /// doesn't).
+  static String _prSubtitle(RepoPr pr, String reviewLabel) {
+    final buffer = StringBuffer(
+      'by ${pr.author} · ${_ageText(pr.ageDays)} · $reviewLabel',
+    );
+    if (pr.additions != null && pr.deletions != null) {
+      buffer.write(' · +${pr.additions} −${pr.deletions}');
+    }
+    final files = pr.changedFiles;
+    if (files != null) {
+      buffer.write(' · $files ${files == 1 ? 'file' : 'files'}');
+    }
+    return buffer.toString();
   }
 
   Widget _buildCiTab() {
@@ -544,7 +570,7 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
     }
   }
 
-  String _ageText(int? ageDays) {
+  static String _ageText(int? ageDays) {
     if (ageDays == null) return 'opened recently';
     if (ageDays <= 0) return 'opened today';
     if (ageDays == 1) return 'opened 1 day ago';
@@ -614,19 +640,21 @@ class _RepoDetailPageState extends State<RepoDetailPage> {
 }
 
 class _MiniChip extends StatelessWidget {
-  const _MiniChip({required this.label});
+  const _MiniChip({required this.label, this.color, this.textColor});
 
   final String label;
+  final Color? color;
+  final Color? textColor;
 
   @override
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        color: color ?? Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(4),
       ),
-      child: Text(label, style: const TextStyle(fontSize: 10)),
+      child: Text(label, style: TextStyle(fontSize: 10, color: textColor)),
     );
   }
 }

--- a/lib/repo_detail_service.dart
+++ b/lib/repo_detail_service.dart
@@ -16,6 +16,13 @@ abstract final class PrReviewState {
   static const String none = 'none';
 }
 
+/// Whether a PR can be merged cleanly (a triage signal).
+abstract final class PrMergeable {
+  static const String mergeable = 'mergeable';
+  static const String conflicting = 'conflicting';
+  static const String unknown = 'unknown';
+}
+
 /// An open pull request shown on the repo detail screen.
 class RepoPr {
   const RepoPr({
@@ -27,6 +34,10 @@ class RepoPr {
     this.createdAt,
     this.draft = false,
     this.url,
+    this.mergeable = PrMergeable.unknown,
+    this.additions,
+    this.deletions,
+    this.changedFiles,
   });
 
   final String label; // e.g. "PR #7"
@@ -40,6 +51,16 @@ class RepoPr {
   final DateTime? createdAt;
   final bool draft;
   final String? url;
+
+  /// Whether the PR merges cleanly (one of [PrMergeable]). GitHub reports this
+  /// directly; Azure DevOps maps from `mergeStatus`. Defaults to `unknown`.
+  final String mergeable;
+
+  /// Diff size, when the provider reports it (GitHub does; ADO's list API does
+  /// not, so these stay null there).
+  final int? additions;
+  final int? deletions;
+  final int? changedFiles;
 }
 
 /// A CI run/build for the repo.
@@ -130,7 +151,8 @@ class RepoDetailService {
       r'query($owner:String!,$name:String!){'
       r'repository(owner:$owner,name:$name){'
       r'pullRequests(states:OPEN,first:50,orderBy:{field:UPDATED_AT,direction:DESC}){'
-      r'nodes{number title url isDraft createdAt '
+      r'nodes{number title url isDraft createdAt mergeable '
+      r'additions deletions changedFiles '
       r'author{login} reviewDecision reviewRequests(first:1){totalCount}}'
       r'}}}';
 
@@ -162,6 +184,10 @@ class RepoDetailService {
           createdAt: _parseDate(pr['createdAt']),
           draft: pr['isDraft'] == true,
           url: _str(pr, 'url'),
+          mergeable: _mergeableFromGithub(_str(pr, 'mergeable')),
+          additions: _int(pr['additions']),
+          deletions: _int(pr['deletions']),
+          changedFiles: _int(pr['changedFiles']),
         ),
       );
     }
@@ -248,6 +274,7 @@ class RepoDetailService {
           createdAt: _parseDate(pr['creationDate']),
           draft: draft,
           url: url,
+          mergeable: _mergeableFromAdo(_str(pr, 'mergeStatus')),
         ),
       );
     }
@@ -629,6 +656,37 @@ class RepoDetailService {
   static String? _str(Map map, String key) {
     final value = map[key];
     return value is String ? value : null;
+  }
+
+  static int? _int(dynamic value) => value is int ? value : null;
+
+  /// Normalizes GitHub GraphQL `mergeable` (MERGEABLE / CONFLICTING / UNKNOWN)
+  /// to a [PrMergeable] value.
+  static String _mergeableFromGithub(String? value) {
+    switch (value) {
+      case 'MERGEABLE':
+        return PrMergeable.mergeable;
+      case 'CONFLICTING':
+        return PrMergeable.conflicting;
+      default:
+        return PrMergeable.unknown;
+    }
+  }
+
+  /// Normalizes an Azure DevOps `mergeStatus` to a [PrMergeable] value. Only
+  /// `conflicts` is a real merge conflict; `failure`/`rejectedByPolicy` are
+  /// policy/other blocks (not git conflicts) and everything else
+  /// (queued/notSet/succeeded-not-yet) is treated as `unknown` so the
+  /// "Conflicts" chip means exactly that.
+  static String _mergeableFromAdo(String? value) {
+    switch (value) {
+      case 'succeeded':
+        return PrMergeable.mergeable;
+      case 'conflicts':
+        return PrMergeable.conflicting;
+      default:
+        return PrMergeable.unknown;
+    }
   }
 
   static Map<String, dynamic>? _decode(String raw) {

--- a/lib/repo_detail_store.dart
+++ b/lib/repo_detail_store.dart
@@ -248,6 +248,10 @@ class RepoDetailStore {
       createdAt: createdAt,
       draft: row.draft,
       url: row.url,
+      mergeable: row.mergeable ?? PrMergeable.unknown,
+      additions: row.additions,
+      deletions: row.deletions,
+      changedFiles: row.changedFiles,
     );
   }
 
@@ -283,6 +287,10 @@ class RepoDetailStore {
         createdAt: Value(pr.createdAt?.toUtc().millisecondsSinceEpoch),
         draft: pr.draft,
         url: Value(pr.url),
+        mergeable: Value(pr.mergeable),
+        additions: Value(pr.additions),
+        deletions: Value(pr.deletions),
+        changedFiles: Value(pr.changedFiles),
       );
 
   static RepoRunsCompanion _runCompanion(String repoKey, RepoRun run) =>

--- a/test/repo_detail_service_test.dart
+++ b/test/repo_detail_service_test.dart
@@ -68,6 +68,43 @@ void main() {
       );
       expect(RepoDetailService.parseGithubGraphqlPulls('nope', now), isEmpty);
     });
+
+    test('parses mergeable and diff size', () {
+      List<RepoPr> parse(String? mergeable) =>
+          RepoDetailService.parseGithubGraphqlPulls({
+            'data': {
+              'repository': {
+                'pullRequests': {
+                  'nodes': [
+                    {
+                      'number': 7,
+                      'title': 'PR 7',
+                      'url': 'https://github.com/acme/api/pull/7',
+                      'isDraft': false,
+                      'createdAt': '2026-07-13T12:00:00Z',
+                      'author': {'login': 'alice'},
+                      'reviewDecision': 'APPROVED',
+                      'reviewRequests': {'totalCount': 0},
+                      'mergeable': mergeable,
+                      'additions': 120,
+                      'deletions': 30,
+                      'changedFiles': 4,
+                    },
+                  ],
+                },
+              },
+            },
+          }, now);
+
+      final conflicting = parse('CONFLICTING').single;
+      expect(conflicting.mergeable, PrMergeable.conflicting);
+      expect(conflicting.additions, 120);
+      expect(conflicting.deletions, 30);
+      expect(conflicting.changedFiles, 4);
+      expect(parse('MERGEABLE').single.mergeable, PrMergeable.mergeable);
+      expect(parse('UNKNOWN').single.mergeable, PrMergeable.unknown);
+      expect(parse(null).single.mergeable, PrMergeable.unknown);
+    });
   });
 
   group('parseAdoPulls', () {
@@ -105,6 +142,35 @@ void main() {
         parse([10]).single.url,
         'https://dev.azure.com/contoso/web/_git/site/pullrequest/12',
       );
+    });
+
+    test('maps mergeStatus to a mergeable state', () {
+      RepoPr parse(String? mergeStatus) => RepoDetailService.parseAdoPulls(
+        [
+          {
+            'pullRequestId': 12,
+            'title': 'Ship',
+            'createdBy': {'displayName': 'Jane Doe'},
+            'creationDate': '2026-07-14T12:00:00Z',
+            'reviewers': const [],
+            'mergeStatus': mergeStatus,
+          },
+        ],
+        now,
+        organization: 'contoso',
+        project: 'web',
+        name: 'site',
+      ).single;
+
+      expect(parse('succeeded').mergeable, PrMergeable.mergeable);
+      expect(parse('conflicts').mergeable, PrMergeable.conflicting);
+      // Only a real merge conflict is "conflicting"; policy/other blocks aren't.
+      expect(parse('rejectedByPolicy').mergeable, PrMergeable.unknown);
+      expect(parse('failure').mergeable, PrMergeable.unknown);
+      expect(parse('queued').mergeable, PrMergeable.unknown);
+      expect(parse(null).mergeable, PrMergeable.unknown);
+      // ADO's list API carries no diff size.
+      expect(parse('succeeded').additions, isNull);
     });
   });
 

--- a/test/repo_detail_store_test.dart
+++ b/test/repo_detail_store_test.dart
@@ -9,6 +9,10 @@ RepoPr _pr(
   String label, {
   String reviewState = 'waiting',
   DateTime? createdAt,
+  String mergeable = PrMergeable.unknown,
+  int? additions,
+  int? deletions,
+  int? changedFiles,
 }) => RepoPr(
   label: label,
   title: 'title $label',
@@ -17,6 +21,10 @@ RepoPr _pr(
   ageDays: 3,
   createdAt: createdAt,
   url: 'https://example.com/$label',
+  mergeable: mergeable,
+  additions: additions,
+  deletions: deletions,
+  changedFiles: changedFiles,
 );
 
 RepoRun _run(String name, {String conclusion = 'success'}) => RepoRun(
@@ -299,6 +307,70 @@ void main() {
     // recomputed from the created_at added by the migration.
     expect(cached.pulls.map((p) => p.label).toList(), ['PR #1']);
     expect(cached.pulls.single.ageDays, 5);
+
+    await upgraded.close();
+  });
+
+  test('save/cached round-trips PR triage signals', () async {
+    await RepoDetailStore.save(
+      repo,
+      RepoDetailData(
+        pulls: [
+          _pr(
+            'PR #1',
+            mergeable: PrMergeable.conflicting,
+            additions: 120,
+            deletions: 30,
+            changedFiles: 4,
+          ),
+        ],
+      ),
+    );
+    final cached = await RepoDetailStore.cached(repo, releasesSupported: true);
+    final pr = cached.pulls.single;
+    expect(pr.mergeable, PrMergeable.conflicting);
+    expect(pr.additions, 120);
+    expect(pr.deletions, 30);
+    expect(pr.changedFiles, 4);
+  });
+
+  test('v8 -> v9 upgrade adds the PR triage columns', () async {
+    // Build a v8-era database: repo_pulls WITHOUT the triage columns (plus the
+    // sibling tables cached() reads). Opening AppDatabase runs onUpgrade(8 -> 9),
+    // which ADDs mergeable/additions/deletions/changed_files.
+    final native = sqlite3.openInMemory();
+    native.execute(
+      'CREATE TABLE repo_pulls (id INTEGER PRIMARY KEY AUTOINCREMENT, '
+      'repo_key TEXT NOT NULL, label TEXT NOT NULL, title TEXT NOT NULL, '
+      'author TEXT NOT NULL, review_state TEXT NOT NULL, age_days INTEGER, '
+      'created_at INTEGER, draft INTEGER NOT NULL, url TEXT)',
+    );
+    native.execute(
+      'CREATE TABLE repo_runs (id INTEGER PRIMARY KEY AUTOINCREMENT, '
+      'repo_key TEXT NOT NULL, name TEXT NOT NULL, status TEXT NOT NULL, '
+      'conclusion TEXT NOT NULL, branch TEXT, finished_at INTEGER, url TEXT)',
+    );
+    native.execute(
+      'CREATE TABLE repo_releases (id INTEGER PRIMARY KEY AUTOINCREMENT, '
+      'repo_key TEXT NOT NULL, tag TEXT NOT NULL, name TEXT, author TEXT, '
+      'published_at INTEGER, url TEXT)',
+    );
+    native.execute('PRAGMA user_version = 8;');
+
+    final upgraded = AppDatabase.forExecutor(
+      NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+    );
+    RepoDetailStore.debugUseDatabase(upgraded);
+
+    await RepoDetailStore.save(
+      repo,
+      RepoDetailData(
+        pulls: [_pr('PR #1', mergeable: PrMergeable.conflicting, additions: 5)],
+      ),
+    );
+    final cached = await RepoDetailStore.cached(repo, releasesSupported: true);
+    expect(cached.pulls.single.mergeable, PrMergeable.conflicting);
+    expect(cached.pulls.single.additions, 5);
 
     await upgraded.close();
   });


### PR DESCRIPTION
## What

Adds **PR triage signals** to the repo-detail page's open-PR list so reviewers can triage faster: **mergeability** (a red "Conflicts" chip) and **diff size** (`+adds −dels · N files`). Draft was already shown.

## How

- **`lib/repo_detail_service.dart`** — new `PrMergeable {mergeable, conflicting, unknown}`. `RepoPr` gains `mergeable` (default `unknown`) + `additions`/`deletions`/`changedFiles`. The GitHub GraphQL open-PR query now requests `mergeable additions deletions changedFiles`; `parseGithubGraphqlPulls` maps them. `parseAdoPulls` maps `mergeStatus` — **only `conflicts` → conflicting**; `failure`/`rejectedByPolicy`/`queued`/… → `unknown` (a policy/other block isn't a git conflict, so the chip means exactly "merge conflicts"). ADO's list API carries no diff size, so those stay null there.
- **DB** — `repo_pulls` gains `mergeable` + `additions`/`deletions`/`changed_files`; `schemaVersion` 8→9 with an idempotent `ALTER TABLE ADD COLUMN` migration (tolerating "duplicate column"); `RepoDetailStore` persists/reads them. `app_database.g.dart` regenerated.
- **`lib/repo_detail_page.dart`** — the PR tile shows a red "Conflicts" `_MiniChip` (`errorContainer`) when conflicting, and `_prSubtitle` appends `+adds −dels · N files` when known. `_MiniChip` gained optional colors; `_ageText` is now static.

Notes: GitHub reports `mergeable` as `UNKNOWN` briefly after a PR opens (it computes async), so the chip only appears once it's genuinely `CONFLICTING` — intentionally non-alarming. Legacy cached rows (pre-v9) render fine (columns null → `unknown`/no size) until the next refresh.

## Review gate

code-review + rubber-duck pre-open. Rubber-duck flagged mapping ADO `failure`/`rejectedByPolicy` to "Conflicts" as misleading — fixed (only `conflicts` is conflicting). Also surfaced `changedFiles` in the subtitle (was stored but unused).

## Tests

GitHub parse (mergeable + size), ADO parse (`mergeStatus` mapping incl. `rejectedByPolicy`/`failure`→unknown; null size), store round-trip of the new fields, and a v8→v9 migration test. `dart format` clean, `flutter analyze --fatal-infos` clean, all 345 tests pass.
