### PR TITLE
Add per-repo notification mute

### DIFF
--- a/lib/manage_repos_page.dart
+++ b/lib/manage_repos_page.dart
@@ -332,8 +332,27 @@ class _ManageReposPageState extends State<ManageReposPage> {
         !_mutedDisplays.contains(oldDisplay)) {
       return;
     }
-    await MuteStore.setMuted(oldDisplay, false);
-    await MuteStore.setMuted(newDisplay, true);
+    try {
+      // Mute the new identity first: if the second write fails the mute intent
+      // survives (worst case a harmless orphan on the vanished old display),
+      // rather than being lost.
+      await MuteStore.setMuted(newDisplay, true);
+      await MuteStore.setMuted(oldDisplay, false);
+    } catch (_) {
+      // Best-effort recovery: resync from persisted state so the UI matches
+      // what's stored, and surface the failure.
+      if (!mounted) return;
+      final muted = await MuteStore.mutedDisplays();
+      if (!mounted) return;
+      setState(() => _mutedDisplays = muted);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Could not move mute to $newDisplay'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
     if (!mounted) return;
     setState(() {
       _mutedDisplays = {..._mutedDisplays}

--- a/lib/manage_repos_page.dart
+++ b/lib/manage_repos_page.dart
@@ -12,6 +12,7 @@ import 'ignore_store.dart';
 import 'manage_ignored_page.dart';
 import 'metric_store.dart';
 import 'monitored_repos.dart';
+import 'mute_store.dart';
 import 'repo_discovery_page.dart';
 import 'repo_discovery_service.dart';
 import 'repo_store.dart';
@@ -38,6 +39,7 @@ class _ManageReposPageState extends State<ManageReposPage> {
   List<Map<String, String>> _githubRepos = [];
   List<Map<String, String>> _adoRepos = [];
   Map<String, String> _tokenLabels = {};
+  Set<String> _mutedDisplays = {};
   bool _isLoading = true;
 
   @override
@@ -64,13 +66,38 @@ class _ManageReposPageState extends State<ManageReposPage> {
     final github = _parse(prefs.getStringList(_githubKey) ?? []);
     final ado = _parse(prefs.getStringList(_adoKey) ?? []);
     final tokens = await TokenStore.getTokens();
+    final muted = await MuteStore.mutedDisplays();
     if (!mounted) return;
     setState(() {
       _githubRepos = github;
       _adoRepos = ado;
       _tokenLabels = {for (final t in tokens) t.id: t.label};
+      _mutedDisplays = muted;
       _isLoading = false;
     });
+  }
+
+  Future<void> _toggleMute(String display) async {
+    final nowMuted = !_mutedDisplays.contains(display);
+    // Optimistically update so the icon flips immediately.
+    setState(() {
+      _mutedDisplays = {..._mutedDisplays};
+      if (nowMuted) {
+        _mutedDisplays.add(display);
+      } else {
+        _mutedDisplays.remove(display);
+      }
+    });
+    await MuteStore.setMuted(display, nowMuted);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          nowMuted ? 'Muted notifications for $display' : 'Unmuted $display',
+        ),
+        duration: const Duration(seconds: 2),
+      ),
+    );
   }
 
   Future<void> _deleteRepoAt(String storageKey, int index) async {
@@ -206,6 +233,7 @@ class _ManageReposPageState extends State<ManageReposPage> {
         await RepoDetailStore.removeRepo(repoKey);
         await SyncStateStore.remove(SyncStateStore.repoScope(repoKey));
         await TeamStore.removeRepoFromAll(repoKey);
+        await MuteStore.remove(label);
       }
     }
     if (!mounted) return;
@@ -221,6 +249,7 @@ class _ManageReposPageState extends State<ManageReposPage> {
   }
 
   Future<void> _editGithub(int index, Map<String, String> repo) async {
+    final oldDisplay = _githubLabel(repo);
     await Navigator.push(
       context,
       MaterialPageRoute(
@@ -233,9 +262,15 @@ class _ManageReposPageState extends State<ManageReposPage> {
       ),
     );
     await _loadRepos();
+    if (!mounted) return;
+    await _migrateMuteAfterEdit(
+      oldDisplay,
+      index < _githubRepos.length ? _githubLabel(_githubRepos[index]) : null,
+    );
   }
 
   Future<void> _editAdo(int index, Map<String, String> repo) async {
+    final oldDisplay = _adoLabel(repo);
     await Navigator.push(
       context,
       MaterialPageRoute(
@@ -249,6 +284,32 @@ class _ManageReposPageState extends State<ManageReposPage> {
       ),
     );
     await _loadRepos();
+    if (!mounted) return;
+    await _migrateMuteAfterEdit(
+      oldDisplay,
+      index < _adoRepos.length ? _adoLabel(_adoRepos[index]) : null,
+    );
+  }
+
+  /// Moves any mute from a repo's old display to its new one after an edit that
+  /// changed its identity, so the mute isn't silently lost / left orphaned.
+  Future<void> _migrateMuteAfterEdit(
+    String oldDisplay,
+    String? newDisplay,
+  ) async {
+    if (newDisplay == null ||
+        newDisplay == oldDisplay ||
+        !_mutedDisplays.contains(oldDisplay)) {
+      return;
+    }
+    await MuteStore.setMuted(oldDisplay, false);
+    await MuteStore.setMuted(newDisplay, true);
+    if (!mounted) return;
+    setState(() {
+      _mutedDisplays = {..._mutedDisplays}
+        ..remove(oldDisplay)
+        ..add(newDisplay);
+    });
   }
 
   Future<void> _addRepo() async {
@@ -395,6 +456,8 @@ class _ManageReposPageState extends State<ManageReposPage> {
               icon: Icons.code,
               label: label,
               subtitle: _repoSubtitle('GitHub', repo),
+              muted: _mutedDisplays.contains(label),
+              onToggleMute: invalid ? null : () => _toggleMute(label),
               onEdit: invalid ? null : () => _editGithub(index, repo),
               onDelete: () => _handleDelete(
                 _githubKey,
@@ -418,6 +481,8 @@ class _ManageReposPageState extends State<ManageReposPage> {
               icon: Icons.account_tree,
               label: label,
               subtitle: _repoSubtitle('Azure DevOps', repo),
+              muted: _mutedDisplays.contains(label),
+              onToggleMute: invalid ? null : () => _toggleMute(label),
               onEdit: invalid ? null : () => _editAdo(index, repo),
               onDelete: () => _handleDelete(
                 _adoKey,
@@ -465,6 +530,8 @@ class _ManageReposPageState extends State<ManageReposPage> {
     required IconData icon,
     required String label,
     required String subtitle,
+    required bool muted,
+    required VoidCallback? onToggleMute,
     required VoidCallback? onEdit,
     required VoidCallback onDelete,
   }) {
@@ -475,6 +542,15 @@ class _ManageReposPageState extends State<ManageReposPage> {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (onToggleMute != null)
+            IconButton(
+              icon: Icon(
+                muted ? Icons.notifications_off : Icons.notifications_none,
+              ),
+              color: muted ? Colors.orange : null,
+              tooltip: muted ? 'Unmute notifications' : 'Mute notifications',
+              onPressed: onToggleMute,
+            ),
           if (onEdit != null)
             IconButton(
               icon: const Icon(Icons.edit),

--- a/lib/manage_repos_page.dart
+++ b/lib/manage_repos_page.dart
@@ -88,7 +88,30 @@ class _ManageReposPageState extends State<ManageReposPage> {
         _mutedDisplays.remove(display);
       }
     });
-    await MuteStore.setMuted(display, nowMuted);
+    try {
+      await MuteStore.setMuted(display, nowMuted);
+    } catch (_) {
+      // Persistence failed: roll the optimistic flip back so the icon reflects
+      // the stored state, and surface the failure instead of a false success.
+      if (!mounted) return;
+      setState(() {
+        _mutedDisplays = {..._mutedDisplays};
+        if (nowMuted) {
+          _mutedDisplays.remove(display);
+        } else {
+          _mutedDisplays.add(display);
+        }
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            nowMuted ? 'Could not mute $display' : 'Could not unmute $display',
+          ),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
@@ -223,8 +246,9 @@ class _ManageReposPageState extends State<ManageReposPage> {
     // trend history or team assignments as a stale, otherwise-unbounded key.
     // Skip pruning when a duplicate entry still resolves to the same canonical
     // key, so shared data isn't removed out from under the surviving entry.
+    final remaining = await listMonitoredRepos();
     if (repoKey != null) {
-      final stillMonitored = (await listMonitoredRepos()).any(
+      final stillMonitored = remaining.any(
         (monitored) => monitored.repoKey == repoKey,
       );
       if (!stillMonitored) {
@@ -233,8 +257,14 @@ class _ManageReposPageState extends State<ManageReposPage> {
         await RepoDetailStore.removeRepo(repoKey);
         await SyncStateStore.remove(SyncStateStore.repoScope(repoKey));
         await TeamStore.removeRepoFromAll(repoKey);
-        await MuteStore.remove(label);
       }
+    }
+    // Mutes are keyed by display label, not repoKey, so prune independently:
+    // drop the deleted label's mute only when no surviving entry still shows
+    // that exact display (a same-key duplicate with different casing keeps its
+    // own mute, and doesn't strand the deleted display's mute).
+    if (!remaining.any((monitored) => monitored.displayName == label)) {
+      await MuteStore.remove(label);
     }
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/mute_store.dart
+++ b/lib/mute_store.dart
@@ -1,0 +1,51 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists the set of repositories whose attention notifications are muted.
+///
+/// Muting only suppresses *notifications* for a repo — its items still appear in
+/// the Attention Inbox. Entries are keyed by `repoDisplay` (`owner/name` for
+/// GitHub, `org/project/name` for Azure DevOps) to match
+/// `AttentionItem.repoDisplay` and the notification gate.
+class MuteStore {
+  MuteStore._();
+
+  static const String _storageKey = 'muted_repos';
+
+  // Serializes the read-modify-write of the muted set so rapid toggles can't
+  // clobber one another's persisted state.
+  static Future<void> _lock = Future<void>.value();
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  /// The set of muted repo displays.
+  static Future<Set<String>> mutedDisplays() async {
+    final prefs = await SharedPreferences.getInstance();
+    return (prefs.getStringList(_storageKey) ?? const <String>[]).toSet();
+  }
+
+  /// Whether [display] is currently muted.
+  static Future<bool> isMuted(String display) async =>
+      (await mutedDisplays()).contains(display);
+
+  /// Mutes or unmutes [display].
+  static Future<void> setMuted(String display, bool muted) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final set = (prefs.getStringList(_storageKey) ?? const <String>[])
+          .toSet();
+      if (muted) {
+        set.add(display);
+      } else {
+        set.remove(display);
+      }
+      await prefs.setStringList(_storageKey, set.toList());
+    });
+  }
+
+  /// Removes [display] from the muted set (e.g. when the repo is deleted).
+  static Future<void> remove(String display) => setMuted(display, false);
+}

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -109,10 +109,11 @@ class NotificationService {
       );
       final now = DateTime.now();
       final appPrefs = await PreferencesStore.load();
-      // Quiet hours *defer*: we hold the notification and, crucially, do NOT
-      // advance the baseline, so these items surface on the next refresh after
-      // quiet hours end. A disabled toggle instead *drops* (baseline advances
-      // below) so re-enabling never replays a backlog.
+      // Quiet hours *defer*: we hold the notification and, for unmuted items,
+      // do NOT advance the baseline, so they surface on the next refresh after
+      // quiet hours end. Muted items still have their baseline advanced (below)
+      // so unmuting never replays a backlog — muting drops, it doesn't defer. A
+      // disabled notifications toggle likewise drops (baseline advances below).
       final inQuietHours =
           appPrefs.notificationsEnabled &&
           appPrefs.quietHoursEnabled &&

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'attention_service.dart';
+import 'mute_store.dart';
 import 'notification_seen_store.dart';
 import 'preferences_store.dart';
 import 'repo_store.dart';
@@ -121,33 +122,89 @@ class NotificationService {
             appPrefs.quietEndHour,
           );
 
+      // Read the muted repos once: used both to filter notifications and to
+      // still advance the baseline for muted items during quiet hours (below).
+      final muted = await MuteStore.mutedDisplays();
+
       if (newIds.isNotEmpty &&
           PreferencesStore.notificationsAllowed(appPrefs, now)) {
-        final newItems = attention
-            .where((item) => newIds.contains(item.id))
-            .toList(growable: false);
+        // Exclude items from muted repos (their items still appear in the
+        // inbox; muting only suppresses the notification).
+        final newItems = notifiableItems(attention, newIds, muted);
         await _showSummaryNotification(newItems);
       }
 
-      // Seed on first run always; otherwise hold the baseline while deferring
-      // for quiet hours.
-      if (shouldAdvanceBaseline(
+      // Advance the seen baseline. Normally (first run / outside quiet hours) we
+      // record every current id + mark repos known. During quiet hours we defer
+      // unmuted items (hold their baseline so they surface after quiet hours)
+      // but still record muted items, so unmuting never replays a backlog —
+      // muting drops, it doesn't defer.
+      final advanceAll = shouldAdvanceBaseline(
         firstRun: firstRun,
         inQuietHours: inQuietHours,
-      )) {
+      );
+      final baselineIds = baselineIdsToRecord(
+        currentIds: currentIds,
+        items: attention,
+        mutedDisplays: muted,
+        firstRun: firstRun,
+        inQuietHours: inQuietHours,
+      );
+      if (advanceAll || baselineIds.isNotEmpty) {
         // Additive, atomic union in the DB: ids are never dropped (a
         // transiently-failed repo keeps its baseline) and concurrent isolates
-        // can't clobber each other's snapshot. Repos are recorded so their first
-        // appearance is only ever seeded once.
-        await NotificationSeenStore.recordBaseline(currentIds, monitoredRepos);
+        // can't clobber each other's snapshot. Repos are recorded (only in the
+        // full-advance case) so their first appearance is only ever seeded once.
+        await NotificationSeenStore.recordBaseline(
+          baselineIds,
+          advanceAll ? monitoredRepos : const <String>{},
+        );
       }
     } catch (e) {
       debugPrint('Failed to process attention notifications: $e');
     }
   }
 
+  /// The item ids to record into the seen baseline this cycle. Normally (first
+  /// run or outside quiet hours) that's every id in [currentIds]. During quiet
+  /// hours we defer unmuted items (hold their baseline so they notify after
+  /// quiet hours end) but still record muted items, so unmuting can't replay a
+  /// backlog that accrued while muted.
+  @visibleForTesting
+  static Set<String> baselineIdsToRecord({
+    required Set<String> currentIds,
+    required List<AttentionItem> items,
+    required Set<String> mutedDisplays,
+    required bool firstRun,
+    required bool inQuietHours,
+  }) {
+    if (firstRun || !inQuietHours) return currentIds;
+    return items
+        .where((item) => mutedDisplays.contains(item.repoDisplay))
+        .map((item) => item.id)
+        .toSet();
+  }
+
   static Set<String> diffNew(Set<String> seen, Iterable<String> current) =>
       current.toSet().difference(seen);
+
+  /// The items to actually notify about: those whose id is in [newIds] and whose
+  /// repo isn't in [mutedDisplays]. Muting suppresses only the notification —
+  /// the items still show in the inbox, and the seen baseline still advances.
+  @visibleForTesting
+  static List<AttentionItem> notifiableItems(
+    List<AttentionItem> items,
+    Set<String> newIds,
+    Set<String> mutedDisplays,
+  ) {
+    return items
+        .where(
+          (item) =>
+              newIds.contains(item.id) &&
+              !mutedDisplays.contains(item.repoDisplay),
+        )
+        .toList(growable: false);
+  }
 
   /// The payload for a summary notification. When exactly one new item is being
   /// notified and it has a trusted PR URL, the payload is that URL so a tap can

--- a/test/mute_store_test.dart
+++ b/test/mute_store_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:kode_radar/mute_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('starts empty', () async {
+    expect(await MuteStore.mutedDisplays(), isEmpty);
+  });
+
+  test('mutes and unmutes a repo display', () async {
+    await MuteStore.setMuted('acme/api', true);
+    expect(await MuteStore.mutedDisplays(), {'acme/api'});
+    expect(await MuteStore.isMuted('acme/api'), isTrue);
+    expect(await MuteStore.isMuted('acme/web'), isFalse);
+
+    await MuteStore.setMuted('acme/api', false);
+    expect(await MuteStore.mutedDisplays(), isEmpty);
+  });
+
+  test('muting is idempotent and independent per repo', () async {
+    await MuteStore.setMuted('acme/api', true);
+    await MuteStore.setMuted('acme/api', true);
+    await MuteStore.setMuted('org/proj/site', true);
+    expect(await MuteStore.mutedDisplays(), {'acme/api', 'org/proj/site'});
+
+    await MuteStore.remove('acme/api');
+    expect(await MuteStore.mutedDisplays(), {'org/proj/site'});
+  });
+}

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -248,4 +248,90 @@ void main() {
       );
     });
   });
+
+  group('notifiableItems', () {
+    AttentionItem item(String id, String repo) => AttentionItem(
+      id: id,
+      category: 'reviewRequested',
+      severity: 3000,
+      titleTemplate: id,
+      subtitleTemplate: '',
+      repoDisplay: repo,
+    );
+
+    test('excludes items from muted repos', () {
+      final items = [
+        item('a', 'acme/api'),
+        item('b', 'acme/web'),
+        item('c', 'acme/api'),
+      ];
+      final result = NotificationService.notifiableItems(
+        items,
+        {'a', 'b', 'c'},
+        {'acme/api'},
+      );
+      expect(result.map((i) => i.id), ['b']);
+    });
+
+    test('keeps only new ids when nothing is muted', () {
+      final items = [item('a', 'acme/api'), item('b', 'acme/web')];
+      final result = NotificationService.notifiableItems(items, {
+        'a',
+      }, const {});
+      expect(result.map((i) => i.id), ['a']);
+    });
+  });
+
+  group('baselineIdsToRecord', () {
+    AttentionItem item(String id, String repo) => AttentionItem(
+      id: id,
+      category: 'reviewRequested',
+      severity: 3000,
+      titleTemplate: id,
+      subtitleTemplate: '',
+      repoDisplay: repo,
+    );
+
+    final items = [item('a', 'acme/api'), item('b', 'acme/web')];
+
+    test('records all current ids outside quiet hours', () {
+      expect(
+        NotificationService.baselineIdsToRecord(
+          currentIds: {'a', 'b'},
+          items: items,
+          mutedDisplays: {'acme/api'},
+          firstRun: false,
+          inQuietHours: false,
+        ),
+        {'a', 'b'},
+      );
+    });
+
+    test('records all current ids on the first run during quiet hours', () {
+      expect(
+        NotificationService.baselineIdsToRecord(
+          currentIds: {'a', 'b'},
+          items: items,
+          mutedDisplays: const {},
+          firstRun: true,
+          inQuietHours: true,
+        ),
+        {'a', 'b'},
+      );
+    });
+
+    test('during quiet hours records only muted ids (defers the rest)', () {
+      // 'a' (muted repo) is recorded so unmute can't replay it; 'b' is deferred.
+      expect(
+        NotificationService.baselineIdsToRecord(
+          currentIds: {'a', 'b'},
+          items: items,
+          mutedDisplays: {'acme/api'},
+          firstRun: false,
+          inQuietHours: true,
+        ),
+        {'a'},
+      );
+    });
+  });
 }


### PR DESCRIPTION
## What

Adds **per-repo notification mute**: mute a repo to stop its attention notifications while its items still appear in the Attention Inbox. Toggled per repo in **Manage Repositories** (a bell icon).

## How

- **NEW `lib/mute_store.dart`** — `MuteStore` persists a set of muted `repoDisplay` values in SharedPreferences (`muted_repos`). Keyed by display (`owner/name` / `org/project/name`) to match `AttentionItem.repoDisplay` and the notification gate. Reads are lock-free; writes serialize through a lock chain (mirrors `SnoozeStore`).
- **`lib/notification_service.dart`** — `notifiableItems(items, newIds, mutedDisplays)` filters muted repos out of the notification (inbox unaffected). **Semantics: muting drops, it doesn't defer** — the seen baseline still advances for muted items so unmuting never replays a backlog. To keep that true under **quiet hours** (which otherwise holds the whole baseline), `baselineIdsToRecord(...)` still records muted-item ids while deferring the rest.
- **`lib/manage_repos_page.dart`** — each repo tile gets a mute toggle (bell-off/orange when muted). The delete path prunes the mute entry; an edit that changes a repo's display **migrates** its mute to the new display (no silent loss/orphan).

## Review gate

code-review + rubber-duck pre-open. Rubber-duck caught (blocking) that muted items could **replay after quiet hours** because the baseline was held for everything — fixed via `baselineIdsToRecord` (record muted ids even during quiet hours). Also addressed the edit-time mute orphan (migrate on identity change).

Limitation: an external rename/transfer (display changes outside the app) still orphans the mute — acceptable without stable repo IDs.

## Tests

`test/mute_store_test.dart` (round-trip: mute/unmute/idempotent/independent) and `test/notification_service_test.dart` (`notifiableItems` excludes muted; `baselineIdsToRecord` records all outside quiet hours / on first run, and only muted ids during quiet hours). `dart format` clean, `flutter analyze --fatal-infos` clean, all 353 tests pass.
