### PR TITLE
Add CI health / flaky-workflow trends insight

### DIFF
--- a/lib/activity_service.dart
+++ b/lib/activity_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'ci_run_history.dart';
 import 'repo_discovery_service.dart';
 import 'repo_store.dart';
 import 'token_store.dart';
@@ -20,6 +21,7 @@ class RepoActivity {
     required this.ciStatus,
     required this.contributors,
     required this.activityScore,
+    this.recentRuns = const [],
     this.error,
   });
 
@@ -55,6 +57,11 @@ class RepoActivity {
   final String ciStatus;
   final List<String> contributors;
   final num activityScore;
+
+  /// Recent CI runs observed for this repo this fetch, accumulated into the CI
+  /// run-history store to power the "CI trends" insight. Empty for reference
+  /// entries and providers/repos with no CI.
+  final List<CiRunSample> recentRuns;
   final String? error;
 }
 
@@ -261,6 +268,141 @@ class ActivityService {
     return 'unknown';
   }
 
+  // ---- Per-run CI samples (for the accumulated CI trends history) ----------
+
+  /// Normalized [CiOutcome] for a single GitHub `workflow_run` object. Only a
+  /// real red result counts as a failure — a `cancelled` run (e.g. superseded
+  /// by concurrency) is [CiOutcome.other] so it can't manufacture flakiness.
+  static String githubRunOutcome(Map run) {
+    final conclusion = _lowerString(run['conclusion']);
+    if (conclusion == 'success') return CiOutcome.success;
+    if (const {
+      'failure',
+      'timed_out',
+      'startup_failure',
+    }.contains(conclusion)) {
+      return CiOutcome.failure;
+    }
+    final status = _lowerString(run['status']);
+    if (const {
+      'queued',
+      'requested',
+      'waiting',
+      'pending',
+      'in_progress',
+    }.contains(status)) {
+      return CiOutcome.running;
+    }
+    // cancelled / action_required / neutral / skipped / stale / unknown:
+    // context only, never counted toward pass/fail rates.
+    return CiOutcome.other;
+  }
+
+  /// Normalized [CiOutcome] for a single Azure DevOps build object. Only
+  /// `failed` is a failure — `canceled` and `partiallySucceeded` are
+  /// [CiOutcome.other] so they don't inflate the failure/flakiness rates.
+  static String adoBuildOutcome(Map build) {
+    final result = _lowerString(build['result']);
+    if (result == 'succeeded') return CiOutcome.success;
+    if (result == 'failed') return CiOutcome.failure;
+    final status = _lowerString(build['status']);
+    if (const {
+      'inprogress',
+      'notstarted',
+      'postponed',
+      'cancelling',
+    }.contains(status)) {
+      return CiOutcome.running;
+    }
+    return CiOutcome.other;
+  }
+
+  /// Parses a GitHub Actions `/actions/runs` response into [CiRunSample]s.
+  /// Runs without an `id` are skipped (no stable de-dup key). The de-dup key
+  /// includes `run_attempt` so a failed attempt kept before a successful rerun
+  /// (which reuses the run id) isn't overwritten — preserving the flake signal.
+  static List<CiRunSample> ciRunSamplesFromGithubRuns(
+    dynamic json, {
+    required String repoKey,
+    required String repoDisplay,
+  }) {
+    final runs = json is Map ? json['workflow_runs'] : null;
+    if (runs is! List) return const [];
+    final result = <CiRunSample>[];
+    for (final run in runs) {
+      if (run is! Map) continue;
+      final id = run['id'];
+      if (id == null) continue;
+      final attempt = _intValue(run['run_attempt']) ?? 1;
+      final name =
+          _stringValue(run, 'name') ??
+          _stringValue(run, 'display_title') ??
+          'Workflow';
+      result.add(
+        CiRunSample(
+          provider: TokenStore.providerGithub,
+          repoKey: repoKey,
+          repoDisplay: repoDisplay,
+          workflow: name,
+          workflowId: run['workflow_id']?.toString(),
+          runKey: '$repoKey:$id:$attempt',
+          outcome: githubRunOutcome(run),
+          conclusion: _stringValue(run, 'conclusion') ?? '',
+          branch: _stringValue(run, 'head_branch'),
+          finishedAt: _parseDate(run['updated_at']),
+          url: _stringValue(run, 'html_url'),
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// Parses an Azure DevOps `/build/builds` response into [CiRunSample]s.
+  /// Builds without an `id` are skipped (no stable de-dup key). ADO retries
+  /// create new build ids, so the id alone is a stable per-run key.
+  static List<CiRunSample> ciRunSamplesFromAdoBuilds(
+    dynamic json, {
+    required String repoKey,
+    required String repoDisplay,
+  }) {
+    final builds = json is Map ? json['value'] : json;
+    if (builds is! List) return const [];
+    final result = <CiRunSample>[];
+    for (final build in builds) {
+      if (build is! Map) continue;
+      final id = build['id'];
+      if (id == null) continue;
+      final definition = build['definition'];
+      final defName = definition is Map ? definition['name'] : null;
+      final workflow = defName is String && defName.isNotEmpty
+          ? defName
+          : 'Build';
+      final defId = definition is Map ? definition['id'] : null;
+      String? url;
+      final links = build['_links'];
+      if (links is Map) {
+        final web = links['web'];
+        if (web is Map && web['href'] is String) url = web['href'] as String;
+      }
+      result.add(
+        CiRunSample(
+          provider: TokenStore.providerAdo,
+          repoKey: repoKey,
+          repoDisplay: repoDisplay,
+          workflow: workflow,
+          workflowId: defId?.toString(),
+          runKey: '$repoKey:$id',
+          outcome: adoBuildOutcome(build),
+          conclusion: _stringValue(build, 'result') ?? '',
+          branch: _stringValue(build, 'sourceBranch'),
+          finishedAt: _parseDate(build['finishTime']),
+          url: url,
+        ),
+      );
+    }
+    return result;
+  }
+
   static num scoreActivity({
     required int openPrCount,
     required int needsReviewCount,
@@ -369,6 +511,7 @@ class ActivityService {
       };
       var prs = <dynamic>[];
       var ciStatus = 'unknown';
+      var recentRuns = const <CiRunSample>[];
 
       try {
         final response = await httpClient
@@ -395,16 +538,24 @@ class ActivityService {
       }
 
       try {
+        // Fetch a page of recent runs (not just the latest): the newest still
+        // drives ciStatus, while the rest accumulate into the CI trends history.
         final response = await httpClient
             .get(
               Uri.https('api.github.com', '/repos/$owner/$name/actions/runs', {
-                'per_page': '1',
+                'per_page': '20',
               }),
               headers: headers,
             )
             .timeout(_requestTimeout);
         if (response.statusCode == 200) {
-          ciStatus = ciStatusFromGithubRuns(jsonDecode(response.body));
+          final decoded = jsonDecode(response.body);
+          ciStatus = ciStatusFromGithubRuns(decoded);
+          recentRuns = ciRunSamplesFromGithubRuns(
+            decoded,
+            repoKey: repoKey,
+            repoDisplay: displayName,
+          );
         } else {
           errors.add('GitHub actions returned status ${response.statusCode}');
         }
@@ -434,6 +585,7 @@ class ActivityService {
           ciStatus: ciStatus,
           oldestOpenPrAgeDays: oldestAge,
         ),
+        recentRuns: recentRuns,
         error: errors.isEmpty ? null : errors.join('; '),
       );
     } finally {
@@ -469,6 +621,7 @@ class ActivityService {
       };
       var prs = <dynamic>[];
       var ciStatus = 'unknown';
+      var recentRuns = const <CiRunSample>[];
 
       try {
         final response = await httpClient
@@ -517,6 +670,8 @@ class ActivityService {
         }
 
         if (repositoryId != null) {
+          // Fetch a page of recent builds newest-first: the latest drives
+          // ciStatus, the rest feed the CI trends history.
           final response = await httpClient
               .get(
                 Uri.https(
@@ -525,7 +680,8 @@ class ActivityService {
                   {
                     'repositoryId': repositoryId,
                     'repositoryType': 'TfsGit',
-                    r'$top': '1',
+                    'queryOrder': 'finishTimeDescending',
+                    r'$top': '20',
                     'api-version': '6.0',
                   },
                 ),
@@ -533,7 +689,13 @@ class ActivityService {
               )
               .timeout(_requestTimeout);
           if (response.statusCode == 200) {
-            ciStatus = ciStatusFromAdoBuilds(jsonDecode(response.body));
+            final decoded = jsonDecode(response.body);
+            ciStatus = ciStatusFromAdoBuilds(decoded);
+            recentRuns = ciRunSamplesFromAdoBuilds(
+              decoded,
+              repoKey: repoKey,
+              repoDisplay: displayName,
+            );
           } else {
             errors.add(
               'Azure DevOps builds returned status ${response.statusCode}',
@@ -566,6 +728,7 @@ class ActivityService {
           ciStatus: ciStatus,
           oldestOpenPrAgeDays: oldestAge,
         ),
+        recentRuns: recentRuns,
         error: errors.isEmpty ? null : errors.join('; '),
       );
     } finally {
@@ -711,6 +874,7 @@ class ActivityService {
     String ciStatus = 'unknown',
     List<String> contributors = const [],
     num activityScore = 0,
+    List<CiRunSample> recentRuns = const [],
     String? error,
   }) {
     return RepoActivity(
@@ -725,6 +889,7 @@ class ActivityService {
       ciStatus: ciStatus,
       contributors: contributors,
       activityScore: activityScore,
+      recentRuns: recentRuns,
       error: error,
     );
   }
@@ -740,6 +905,7 @@ class ActivityService {
     String ciStatus = 'unknown',
     List<String> contributors = const [],
     num activityScore = 0,
+    List<CiRunSample> recentRuns = const [],
     String? error,
   }) {
     return RepoActivity(
@@ -754,6 +920,7 @@ class ActivityService {
       ciStatus: ciStatus,
       contributors: contributors,
       activityScore: activityScore,
+      recentRuns: recentRuns,
       error: error,
     );
   }

--- a/lib/ci_run_history.dart
+++ b/lib/ci_run_history.dart
@@ -44,7 +44,9 @@ class CiRunSample {
   /// The workflow / pipeline / build-definition name this run belongs to.
   final String workflow;
 
-  /// Stable de-duplication key, e.g. `github:<repoKey>:<runId>:<attempt>`.
+  /// Stable de-duplication key, e.g. `<repoKey>:<runId>:<attempt>` — repoKey
+  /// already carries the provider prefix (`github:owner/name`), so it's not
+  /// repeated here.
   final String runKey;
 
   /// Normalized [CiOutcome].

--- a/lib/ci_run_history.dart
+++ b/lib/ci_run_history.dart
@@ -1,0 +1,240 @@
+// Models for the CI run history that powers the "CI trends" insight: the
+// per-run samples accumulated across syncs and the per-workflow trend rolled
+// up from them (failure rate + flakiness), all provider-agnostic and pure so
+// they're easy to persist and unit-test.
+
+/// Normalized outcomes we bucket every provider run into. Trend stats only
+/// consider [success] / [failure] (a completed run); [running] (still going)
+/// and [other] (cancelled/skipped/neutral) are shown for context but excluded
+/// from rates so a queued run can't skew a workflow's health.
+class CiOutcome {
+  const CiOutcome._();
+
+  static const String success = 'success';
+  static const String failure = 'failure';
+  static const String running = 'running';
+  static const String other = 'other';
+
+  /// Whether [outcome] is a completed pass/fail that counts toward stats.
+  static bool isCompleted(String outcome) =>
+      outcome == success || outcome == failure;
+}
+
+/// A single observed CI run/build, keyed by [runKey] (a provider-stable id) so
+/// repeated syncs that re-see the same run don't double-count it.
+class CiRunSample {
+  const CiRunSample({
+    required this.provider,
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.workflow,
+    required this.runKey,
+    required this.outcome,
+    required this.conclusion,
+    this.workflowId,
+    this.branch,
+    this.finishedAt,
+    this.url,
+  });
+
+  final String provider;
+  final String repoKey;
+  final String repoDisplay;
+
+  /// The workflow / pipeline / build-definition name this run belongs to.
+  final String workflow;
+
+  /// Stable de-duplication key, e.g. `github:<repoKey>:<runId>:<attempt>`.
+  final String runKey;
+
+  /// Normalized [CiOutcome].
+  final String outcome;
+
+  /// The raw provider conclusion/result (kept for display / future logic).
+  final String conclusion;
+
+  /// Stable workflow/definition id (GitHub `workflow_id` / ADO `definition.id`)
+  /// used to group runs so a rename doesn't split a workflow's history and two
+  /// same-named workflows don't merge. Falls back to [workflow] when absent.
+  final String? workflowId;
+
+  final String? branch;
+  final DateTime? finishedAt;
+  final String? url;
+
+  /// The key runs are grouped by for trends: the stable id when known, else the
+  /// display name.
+  String get groupKey => workflowId ?? workflow;
+}
+
+/// A per-workflow rollup over a recency window: how often it fails and how
+/// much it flip-flops (flakiness), plus a newest-first strip of recent
+/// outcomes for a sparkline.
+class CiWorkflowTrend {
+  const CiWorkflowTrend({
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.workflow,
+    required this.successes,
+    required this.failures,
+    required this.flips,
+    required this.lastOutcome,
+    required this.lastCompletedOutcome,
+    required this.recentOutcomes,
+    required this.lastRunAt,
+    required this.url,
+  });
+
+  final String repoKey;
+  final String repoDisplay;
+  final String workflow;
+
+  /// Completed (pass/fail) run counts in the window.
+  final int successes;
+  final int failures;
+
+  /// Adjacent outcome changes across the completed-run sequence (a proxy for
+  /// flakiness — a workflow that alternates pass/fail rather than staying one).
+  final int flips;
+
+  /// The newest run's outcome (may be [CiOutcome.running] / [CiOutcome.other]).
+  final String lastOutcome;
+
+  /// The newest run that was a pass/fail (skips running/other), or '' if none.
+  /// Used so a recovered workflow (latest completed run passed) isn't labeled
+  /// chronically failing on the strength of its older failures.
+  final String lastCompletedOutcome;
+
+  /// Newest-first outcomes (incl. running/other), capped for the sparkline.
+  final List<String> recentOutcomes;
+
+  final DateTime? lastRunAt;
+  final String? url;
+
+  /// Completed runs considered for the rates.
+  int get total => successes + failures;
+
+  /// Share of completed runs that failed (0 when there are none).
+  double get failureRate => total == 0 ? 0 : failures / total;
+
+  /// Share of adjacent completed-run pairs that changed outcome (0 with <2).
+  double get flakeRate => total < 2 ? 0 : flips / (total - 1);
+
+  /// A workflow that both passes and fails and alternates enough to be noise —
+  /// requires a minimum sample so a lone pass/fail pair can't read as flaky.
+  bool get isFlaky =>
+      total >= minRunsForFlaky &&
+      successes > 0 &&
+      failures > 0 &&
+      flakeRate >= flakyThreshold;
+
+  /// A workflow that is red at least half the time, *stays* red (low flip
+  /// rate), and is currently red (its latest completed run failed) — a
+  /// persistent break rather than flapping or an already-recovered one.
+  bool get isChronicallyFailing =>
+      total >= minRunsForChronic &&
+      failureRate >= 0.5 &&
+      flakeRate < flakyThreshold &&
+      lastCompletedOutcome == CiOutcome.failure;
+
+  bool get hasProblem => isFlaky || isChronicallyFailing;
+
+  /// Shrinks a small sample's weight so a 1-fail / 1-pass workflow can't rank
+  /// alongside a 20-run one with the same rate.
+  double get _confidence => total == 0 ? 0 : total / (total + 3);
+
+  /// Worst-first ranking weight: failing dominates, flakiness adds to it, both
+  /// damped by sample confidence.
+  double get severity => _confidence * (failureRate + 0.5 * flakeRate);
+
+  /// Minimum flip rate for a mixed workflow to read as flaky (~1 in 3).
+  static const double flakyThreshold = 0.34;
+
+  /// Minimum completed runs before a workflow can be labeled flaky / failing.
+  static const int minRunsForFlaky = 4;
+  static const int minRunsForChronic = 3;
+
+  /// Newest-first outcomes kept in [recentOutcomes] / persisted strips.
+  static const int recentCap = 16;
+
+  /// Rolls [samples] up into per-workflow trends, newest-run first within each
+  /// workflow, sorted worst-first. Only samples finished within [window] of
+  /// [now] are considered (a sample with no finish time — typically an
+  /// in-progress run — is always included). Pure: no I/O, safe to unit-test.
+  static List<CiWorkflowTrend> aggregate(
+    Iterable<CiRunSample> samples, {
+    DateTime? now,
+    Duration window = const Duration(days: 30),
+  }) {
+    final at = now ?? DateTime.now();
+    final cutoff = at.subtract(window);
+    final groups = <String, List<CiRunSample>>{};
+    for (final s in samples) {
+      final finished = s.finishedAt;
+      if (finished != null && finished.isBefore(cutoff)) continue;
+      groups.putIfAbsent('${s.repoKey}\u0000${s.groupKey}', () => []).add(s);
+    }
+
+    final trends = <CiWorkflowTrend>[];
+    for (final group in groups.values) {
+      // Newest first; runs without a finish time (in-progress) sort ahead of
+      // finished ones so the latest state leads the strip.
+      group.sort((a, b) {
+        final af = a.finishedAt;
+        final bf = b.finishedAt;
+        if (af == null && bf == null) return 0;
+        if (af == null) return -1;
+        if (bf == null) return 1;
+        return bf.compareTo(af);
+      });
+
+      var successes = 0;
+      var failures = 0;
+      final completed = <String>[]; // newest-first pass/fail sequence
+      final recent = <String>[];
+      for (final s in group) {
+        if (recent.length < recentCap) recent.add(s.outcome);
+        if (s.outcome == CiOutcome.success) {
+          successes++;
+          completed.add(CiOutcome.success);
+        } else if (s.outcome == CiOutcome.failure) {
+          failures++;
+          completed.add(CiOutcome.failure);
+        }
+      }
+      var flips = 0;
+      for (var i = 1; i < completed.length; i++) {
+        if (completed[i] != completed[i - 1]) flips++;
+      }
+      final newest = group.first;
+      trends.add(
+        CiWorkflowTrend(
+          repoKey: newest.repoKey,
+          repoDisplay: newest.repoDisplay,
+          workflow: newest.workflow,
+          successes: successes,
+          failures: failures,
+          flips: flips,
+          lastOutcome: newest.outcome,
+          lastCompletedOutcome: completed.isEmpty ? '' : completed.first,
+          recentOutcomes: recent,
+          lastRunAt: newest.finishedAt,
+          url: newest.url,
+        ),
+      );
+    }
+
+    trends.sort((a, b) {
+      final bySeverity = b.severity.compareTo(a.severity);
+      if (bySeverity != 0) return bySeverity;
+      final byTotal = b.total.compareTo(a.total);
+      if (byTotal != 0) return byTotal;
+      final byRepo = a.repoDisplay.toLowerCase().compareTo(
+        b.repoDisplay.toLowerCase(),
+      );
+      if (byRepo != 0) return byRepo;
+      return a.workflow.toLowerCase().compareTo(b.workflow.toLowerCase());
+    });
+    return trends;
+  }
+}

--- a/lib/ci_run_history_store.dart
+++ b/lib/ci_run_history_store.dart
@@ -67,11 +67,14 @@ class CiRunHistoryStore {
     return _runLocked(() async {
       final db = _database;
       await db.transaction(() async {
-        for (final s in rows) {
-          await db
-              .into(db.ciRunHistory)
-              .insert(_companion(s), mode: InsertMode.insertOrReplace);
-        }
+        // One batched insert-or-replace rather than a statement per sample.
+        await db.batch((b) {
+          b.insertAll(
+            db.ciRunHistory,
+            rows.map(_companion).toList(),
+            mode: InsertMode.insertOrReplace,
+          );
+        });
         // Age prune. Every stored row has a finish time (see the filter above),
         // so nothing escapes this by being null.
         final cutoff = at.subtract(retention).millisecondsSinceEpoch;

--- a/lib/ci_run_history_store.dart
+++ b/lib/ci_run_history_store.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+
+import 'ci_run_history.dart';
+import 'database/app_database.dart';
+
+/// Persists observed CI runs on the local SQLite database (drift) so the "CI
+/// trends" insight can surface chronically-failing / flaky workflows across
+/// syncs, rather than just the single latest run the Radar keeps.
+///
+/// Rows are de-duplicated by `runKey` (a provider-stable id) via an
+/// `INSERT OR REPLACE` on its UNIQUE index, so repeated syncs that re-see the
+/// same recent runs union rather than double-count. After each write the table
+/// is pruned to stay bounded: rows older than [retention] are dropped, and each
+/// repo is capped at [perRepoCap] newest rows.
+///
+/// Like the other local-DB stores, this owns its own [AppDatabase] singleton
+/// (a separate connection to the shared WAL file) and serializes its writes
+/// through a static lock chain.
+class CiRunHistoryStore {
+  CiRunHistoryStore._();
+
+  static AppDatabase? _db;
+
+  static Future<void> _lock = SynchronousFuture<void>(null);
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  static AppDatabase get _database => _db ??= AppDatabase();
+
+  /// How long a run stays in history before it's pruned.
+  static const Duration retention = Duration(days: 45);
+
+  /// Cap on rows kept per repo so a very active repo can't grow unbounded.
+  static const int perRepoCap = 400;
+
+  /// Test hook: back the store with an injected (e.g. in-memory) database and
+  /// reset the mutation lock.
+  @visibleForTesting
+  static void debugUseDatabase(AppDatabase db) {
+    _db = db;
+    _lock = SynchronousFuture<void>(null);
+  }
+
+  /// Records [samples], de-duplicating by `runKey`, then prunes by age and the
+  /// per-repo cap. Skips runs that can't be safely persisted as history: those
+  /// without a `runKey`, still running, or lacking a finish time (so every
+  /// stored row has a real completion timestamp for pruning and ordering). A
+  /// no-op for an empty result so a sync with no CI data doesn't churn.
+  static Future<void> record(Iterable<CiRunSample> samples, {DateTime? now}) {
+    final rows = samples
+        .where(
+          (s) =>
+              s.runKey.isNotEmpty &&
+              s.finishedAt != null &&
+              s.outcome != CiOutcome.running,
+        )
+        .toList();
+    if (rows.isEmpty) return Future<void>.value();
+    final at = now ?? DateTime.now();
+    return _runLocked(() async {
+      final db = _database;
+      await db.transaction(() async {
+        for (final s in rows) {
+          await db
+              .into(db.ciRunHistory)
+              .insert(_companion(s), mode: InsertMode.insertOrReplace);
+        }
+        // Age prune. Every stored row has a finish time (see the filter above),
+        // so nothing escapes this by being null.
+        final cutoff = at.subtract(retention).millisecondsSinceEpoch;
+        await (db.delete(
+          db.ciRunHistory,
+        )..where((t) => t.finishedAt.isSmallerThanValue(cutoff))).go();
+        // Per-repo cap: for each repo touched this round, keep only the newest
+        // [perRepoCap] rows (by finish time, then insert order).
+        for (final repoKey in rows.map((s) => s.repoKey).toSet()) {
+          await _capRepo(db, repoKey);
+        }
+      });
+    });
+  }
+
+  /// Like [record] but never throws — logs and swallows — for UI load paths
+  /// where a history-write hiccup must not fail the surrounding refresh.
+  static Future<void> recordSafely(
+    Iterable<CiRunSample> samples, {
+    DateTime? now,
+  }) async {
+    try {
+      await record(samples, now: now);
+    } catch (e, st) {
+      debugPrint('CiRunHistoryStore.record failed: $e\n$st');
+    }
+  }
+
+  static Future<void> _capRepo(AppDatabase db, String repoKey) async {
+    final ids =
+        await (db.selectOnly(db.ciRunHistory)
+              ..addColumns([db.ciRunHistory.id])
+              ..where(db.ciRunHistory.repoKey.equals(repoKey))
+              ..orderBy([
+                OrderingTerm.desc(db.ciRunHistory.finishedAt),
+                OrderingTerm.desc(db.ciRunHistory.id),
+              ]))
+            .map((row) => row.read(db.ciRunHistory.id)!)
+            .get();
+    if (ids.length <= perRepoCap) return;
+    final toDrop = ids.sublist(perRepoCap);
+    await (db.delete(db.ciRunHistory)..where((t) => t.id.isIn(toDrop))).go();
+  }
+
+  /// The per-workflow trends over [window], worst-first (see
+  /// [CiWorkflowTrend.aggregate]). Reads within the store lock so a concurrent
+  /// [record] can't interleave with the read.
+  static Future<List<CiWorkflowTrend>> trends({
+    DateTime? now,
+    Duration window = const Duration(days: 30),
+  }) {
+    final at = now ?? DateTime.now();
+    return _runLocked(() async {
+      final db = _database;
+      final rows = await db.select(db.ciRunHistory).get();
+      final samples = rows.map(_toSample).toList();
+      return CiWorkflowTrend.aggregate(samples, now: at, window: window);
+    });
+  }
+
+  /// Drops all history for [repoKey] (e.g. after the repo is removed from
+  /// monitoring), so its workflows stop appearing in the trends.
+  static Future<void> removeRepo(String repoKey) async {
+    final key = repoKey.trim();
+    if (key.isEmpty) return;
+    await _runLocked(() async {
+      final db = _database;
+      await (db.delete(
+        db.ciRunHistory,
+      )..where((t) => t.repoKey.equals(key))).go();
+    });
+  }
+
+  static CiRunSample _toSample(CiRunHistoryRow row) => CiRunSample(
+    provider: row.provider,
+    repoKey: row.repoKey,
+    repoDisplay: row.repoDisplay,
+    workflow: row.workflow,
+    workflowId: row.workflowId,
+    runKey: row.runKey,
+    outcome: row.outcome,
+    conclusion: row.conclusion,
+    branch: row.branch,
+    finishedAt: row.finishedAt == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(row.finishedAt!, isUtc: true),
+    url: row.url,
+  );
+
+  static CiRunHistoryCompanion _companion(CiRunSample s) =>
+      CiRunHistoryCompanion.insert(
+        provider: s.provider,
+        repoKey: s.repoKey,
+        repoDisplay: s.repoDisplay,
+        workflow: s.workflow,
+        workflowId: Value(s.workflowId),
+        runKey: s.runKey,
+        outcome: s.outcome,
+        conclusion: s.conclusion,
+        branch: Value(s.branch),
+        finishedAt: Value(s.finishedAt?.toUtc().millisecondsSinceEpoch),
+        url: Value(s.url),
+      );
+}

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -126,6 +126,36 @@ class RepoReleases extends Table {
   TextColumn get url => text().nullable()();
 }
 
+/// Accumulated CI run history (Phase 5): one row per observed workflow/build
+/// run, de-duplicated by [runKey] (a provider-stable id), so repeated syncs
+/// that re-see the same recent runs union rather than double-count. Powers the
+/// "CI trends" insight (per-workflow failure rate + flakiness). Rows are pruned
+/// by age and a per-repo cap so the table stays bounded. `outcome` is the
+/// normalized bucket (success/failure/running/other); `conclusion` keeps the
+/// raw provider result for display.
+@DataClassName('CiRunHistoryRow')
+@TableIndex(
+  name: 'idx_ci_run_history_run_key',
+  columns: {#runKey},
+  unique: true,
+)
+@TableIndex(name: 'idx_ci_run_history_repo_key', columns: {#repoKey})
+@TableIndex(name: 'idx_ci_run_history_finished_at', columns: {#finishedAt})
+class CiRunHistory extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get provider => text()();
+  TextColumn get repoKey => text()();
+  TextColumn get repoDisplay => text()();
+  TextColumn get workflow => text()();
+  TextColumn get workflowId => text().nullable()();
+  TextColumn get runKey => text()();
+  TextColumn get outcome => text()();
+  TextColumn get conclusion => text()();
+  TextColumn get branch => text().nullable()();
+  IntColumn get finishedAt => integer().nullable()();
+  TextColumn get url => text().nullable()();
+}
+
 /// Per-scope sync provenance (Phase 3): when a cache scope was last refreshed
 /// successfully from the network, so the UI can show an accurate "updated Xh
 /// ago" instead of "just now" when it's actually displaying stale cached data.
@@ -198,6 +228,7 @@ class AppMeta extends Table {
     SyncState,
     NotificationSeen,
     NotificationKnownRepos,
+    CiRunHistory,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -208,7 +239,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 9;
+  int get schemaVersion => 10;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -355,6 +386,27 @@ class AppDatabase extends _$AppDatabase {
             }
           }
         }
+      }
+      // v10 adds the CI run-history table (Phase 5). Same idempotent-DDL
+      // reasoning as the earlier steps: `createTable` emits only
+      // `CREATE TABLE IF NOT EXISTS`, so create each @TableIndex explicitly with
+      // `CREATE [UNIQUE] INDEX IF NOT EXISTS` — the unique run_key index the
+      // record() upsert relies on especially — so a concurrent open from the
+      // background-sync isolate can't crash on an already-existing object.
+      if (from < 10) {
+        await m.createTable(ciRunHistory);
+        await customStatement(
+          'CREATE UNIQUE INDEX IF NOT EXISTS idx_ci_run_history_run_key '
+          'ON ci_run_history (run_key)',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_ci_run_history_repo_key '
+          'ON ci_run_history (repo_key)',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_ci_run_history_finished_at '
+          'ON ci_run_history (finished_at)',
+        );
       }
     },
   );

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -4362,6 +4362,707 @@ class NotificationKnownReposCompanion
   }
 }
 
+class $CiRunHistoryTable extends CiRunHistory
+    with TableInfo<$CiRunHistoryTable, CiRunHistoryRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CiRunHistoryTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _providerMeta = const VerificationMeta(
+    'provider',
+  );
+  @override
+  late final GeneratedColumn<String> provider = GeneratedColumn<String>(
+    'provider',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _repoKeyMeta = const VerificationMeta(
+    'repoKey',
+  );
+  @override
+  late final GeneratedColumn<String> repoKey = GeneratedColumn<String>(
+    'repo_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _repoDisplayMeta = const VerificationMeta(
+    'repoDisplay',
+  );
+  @override
+  late final GeneratedColumn<String> repoDisplay = GeneratedColumn<String>(
+    'repo_display',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _workflowMeta = const VerificationMeta(
+    'workflow',
+  );
+  @override
+  late final GeneratedColumn<String> workflow = GeneratedColumn<String>(
+    'workflow',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _workflowIdMeta = const VerificationMeta(
+    'workflowId',
+  );
+  @override
+  late final GeneratedColumn<String> workflowId = GeneratedColumn<String>(
+    'workflow_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _runKeyMeta = const VerificationMeta('runKey');
+  @override
+  late final GeneratedColumn<String> runKey = GeneratedColumn<String>(
+    'run_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _outcomeMeta = const VerificationMeta(
+    'outcome',
+  );
+  @override
+  late final GeneratedColumn<String> outcome = GeneratedColumn<String>(
+    'outcome',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _conclusionMeta = const VerificationMeta(
+    'conclusion',
+  );
+  @override
+  late final GeneratedColumn<String> conclusion = GeneratedColumn<String>(
+    'conclusion',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _branchMeta = const VerificationMeta('branch');
+  @override
+  late final GeneratedColumn<String> branch = GeneratedColumn<String>(
+    'branch',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _finishedAtMeta = const VerificationMeta(
+    'finishedAt',
+  );
+  @override
+  late final GeneratedColumn<int> finishedAt = GeneratedColumn<int>(
+    'finished_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _urlMeta = const VerificationMeta('url');
+  @override
+  late final GeneratedColumn<String> url = GeneratedColumn<String>(
+    'url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    provider,
+    repoKey,
+    repoDisplay,
+    workflow,
+    workflowId,
+    runKey,
+    outcome,
+    conclusion,
+    branch,
+    finishedAt,
+    url,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'ci_run_history';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<CiRunHistoryRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('provider')) {
+      context.handle(
+        _providerMeta,
+        provider.isAcceptableOrUnknown(data['provider']!, _providerMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_providerMeta);
+    }
+    if (data.containsKey('repo_key')) {
+      context.handle(
+        _repoKeyMeta,
+        repoKey.isAcceptableOrUnknown(data['repo_key']!, _repoKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_repoKeyMeta);
+    }
+    if (data.containsKey('repo_display')) {
+      context.handle(
+        _repoDisplayMeta,
+        repoDisplay.isAcceptableOrUnknown(
+          data['repo_display']!,
+          _repoDisplayMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_repoDisplayMeta);
+    }
+    if (data.containsKey('workflow')) {
+      context.handle(
+        _workflowMeta,
+        workflow.isAcceptableOrUnknown(data['workflow']!, _workflowMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_workflowMeta);
+    }
+    if (data.containsKey('workflow_id')) {
+      context.handle(
+        _workflowIdMeta,
+        workflowId.isAcceptableOrUnknown(data['workflow_id']!, _workflowIdMeta),
+      );
+    }
+    if (data.containsKey('run_key')) {
+      context.handle(
+        _runKeyMeta,
+        runKey.isAcceptableOrUnknown(data['run_key']!, _runKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_runKeyMeta);
+    }
+    if (data.containsKey('outcome')) {
+      context.handle(
+        _outcomeMeta,
+        outcome.isAcceptableOrUnknown(data['outcome']!, _outcomeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_outcomeMeta);
+    }
+    if (data.containsKey('conclusion')) {
+      context.handle(
+        _conclusionMeta,
+        conclusion.isAcceptableOrUnknown(data['conclusion']!, _conclusionMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_conclusionMeta);
+    }
+    if (data.containsKey('branch')) {
+      context.handle(
+        _branchMeta,
+        branch.isAcceptableOrUnknown(data['branch']!, _branchMeta),
+      );
+    }
+    if (data.containsKey('finished_at')) {
+      context.handle(
+        _finishedAtMeta,
+        finishedAt.isAcceptableOrUnknown(data['finished_at']!, _finishedAtMeta),
+      );
+    }
+    if (data.containsKey('url')) {
+      context.handle(
+        _urlMeta,
+        url.isAcceptableOrUnknown(data['url']!, _urlMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  CiRunHistoryRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CiRunHistoryRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      provider: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}provider'],
+      )!,
+      repoKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_key'],
+      )!,
+      repoDisplay: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_display'],
+      )!,
+      workflow: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}workflow'],
+      )!,
+      workflowId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}workflow_id'],
+      ),
+      runKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}run_key'],
+      )!,
+      outcome: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}outcome'],
+      )!,
+      conclusion: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}conclusion'],
+      )!,
+      branch: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}branch'],
+      ),
+      finishedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}finished_at'],
+      ),
+      url: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}url'],
+      ),
+    );
+  }
+
+  @override
+  $CiRunHistoryTable createAlias(String alias) {
+    return $CiRunHistoryTable(attachedDatabase, alias);
+  }
+}
+
+class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
+  final int id;
+  final String provider;
+  final String repoKey;
+  final String repoDisplay;
+  final String workflow;
+  final String? workflowId;
+  final String runKey;
+  final String outcome;
+  final String conclusion;
+  final String? branch;
+  final int? finishedAt;
+  final String? url;
+  const CiRunHistoryRow({
+    required this.id,
+    required this.provider,
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.workflow,
+    this.workflowId,
+    required this.runKey,
+    required this.outcome,
+    required this.conclusion,
+    this.branch,
+    this.finishedAt,
+    this.url,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['provider'] = Variable<String>(provider);
+    map['repo_key'] = Variable<String>(repoKey);
+    map['repo_display'] = Variable<String>(repoDisplay);
+    map['workflow'] = Variable<String>(workflow);
+    if (!nullToAbsent || workflowId != null) {
+      map['workflow_id'] = Variable<String>(workflowId);
+    }
+    map['run_key'] = Variable<String>(runKey);
+    map['outcome'] = Variable<String>(outcome);
+    map['conclusion'] = Variable<String>(conclusion);
+    if (!nullToAbsent || branch != null) {
+      map['branch'] = Variable<String>(branch);
+    }
+    if (!nullToAbsent || finishedAt != null) {
+      map['finished_at'] = Variable<int>(finishedAt);
+    }
+    if (!nullToAbsent || url != null) {
+      map['url'] = Variable<String>(url);
+    }
+    return map;
+  }
+
+  CiRunHistoryCompanion toCompanion(bool nullToAbsent) {
+    return CiRunHistoryCompanion(
+      id: Value(id),
+      provider: Value(provider),
+      repoKey: Value(repoKey),
+      repoDisplay: Value(repoDisplay),
+      workflow: Value(workflow),
+      workflowId: workflowId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(workflowId),
+      runKey: Value(runKey),
+      outcome: Value(outcome),
+      conclusion: Value(conclusion),
+      branch: branch == null && nullToAbsent
+          ? const Value.absent()
+          : Value(branch),
+      finishedAt: finishedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(finishedAt),
+      url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+    );
+  }
+
+  factory CiRunHistoryRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CiRunHistoryRow(
+      id: serializer.fromJson<int>(json['id']),
+      provider: serializer.fromJson<String>(json['provider']),
+      repoKey: serializer.fromJson<String>(json['repoKey']),
+      repoDisplay: serializer.fromJson<String>(json['repoDisplay']),
+      workflow: serializer.fromJson<String>(json['workflow']),
+      workflowId: serializer.fromJson<String?>(json['workflowId']),
+      runKey: serializer.fromJson<String>(json['runKey']),
+      outcome: serializer.fromJson<String>(json['outcome']),
+      conclusion: serializer.fromJson<String>(json['conclusion']),
+      branch: serializer.fromJson<String?>(json['branch']),
+      finishedAt: serializer.fromJson<int?>(json['finishedAt']),
+      url: serializer.fromJson<String?>(json['url']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'provider': serializer.toJson<String>(provider),
+      'repoKey': serializer.toJson<String>(repoKey),
+      'repoDisplay': serializer.toJson<String>(repoDisplay),
+      'workflow': serializer.toJson<String>(workflow),
+      'workflowId': serializer.toJson<String?>(workflowId),
+      'runKey': serializer.toJson<String>(runKey),
+      'outcome': serializer.toJson<String>(outcome),
+      'conclusion': serializer.toJson<String>(conclusion),
+      'branch': serializer.toJson<String?>(branch),
+      'finishedAt': serializer.toJson<int?>(finishedAt),
+      'url': serializer.toJson<String?>(url),
+    };
+  }
+
+  CiRunHistoryRow copyWith({
+    int? id,
+    String? provider,
+    String? repoKey,
+    String? repoDisplay,
+    String? workflow,
+    Value<String?> workflowId = const Value.absent(),
+    String? runKey,
+    String? outcome,
+    String? conclusion,
+    Value<String?> branch = const Value.absent(),
+    Value<int?> finishedAt = const Value.absent(),
+    Value<String?> url = const Value.absent(),
+  }) => CiRunHistoryRow(
+    id: id ?? this.id,
+    provider: provider ?? this.provider,
+    repoKey: repoKey ?? this.repoKey,
+    repoDisplay: repoDisplay ?? this.repoDisplay,
+    workflow: workflow ?? this.workflow,
+    workflowId: workflowId.present ? workflowId.value : this.workflowId,
+    runKey: runKey ?? this.runKey,
+    outcome: outcome ?? this.outcome,
+    conclusion: conclusion ?? this.conclusion,
+    branch: branch.present ? branch.value : this.branch,
+    finishedAt: finishedAt.present ? finishedAt.value : this.finishedAt,
+    url: url.present ? url.value : this.url,
+  );
+  CiRunHistoryRow copyWithCompanion(CiRunHistoryCompanion data) {
+    return CiRunHistoryRow(
+      id: data.id.present ? data.id.value : this.id,
+      provider: data.provider.present ? data.provider.value : this.provider,
+      repoKey: data.repoKey.present ? data.repoKey.value : this.repoKey,
+      repoDisplay: data.repoDisplay.present
+          ? data.repoDisplay.value
+          : this.repoDisplay,
+      workflow: data.workflow.present ? data.workflow.value : this.workflow,
+      workflowId: data.workflowId.present
+          ? data.workflowId.value
+          : this.workflowId,
+      runKey: data.runKey.present ? data.runKey.value : this.runKey,
+      outcome: data.outcome.present ? data.outcome.value : this.outcome,
+      conclusion: data.conclusion.present
+          ? data.conclusion.value
+          : this.conclusion,
+      branch: data.branch.present ? data.branch.value : this.branch,
+      finishedAt: data.finishedAt.present
+          ? data.finishedAt.value
+          : this.finishedAt,
+      url: data.url.present ? data.url.value : this.url,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CiRunHistoryRow(')
+          ..write('id: $id, ')
+          ..write('provider: $provider, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('repoDisplay: $repoDisplay, ')
+          ..write('workflow: $workflow, ')
+          ..write('workflowId: $workflowId, ')
+          ..write('runKey: $runKey, ')
+          ..write('outcome: $outcome, ')
+          ..write('conclusion: $conclusion, ')
+          ..write('branch: $branch, ')
+          ..write('finishedAt: $finishedAt, ')
+          ..write('url: $url')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    provider,
+    repoKey,
+    repoDisplay,
+    workflow,
+    workflowId,
+    runKey,
+    outcome,
+    conclusion,
+    branch,
+    finishedAt,
+    url,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CiRunHistoryRow &&
+          other.id == this.id &&
+          other.provider == this.provider &&
+          other.repoKey == this.repoKey &&
+          other.repoDisplay == this.repoDisplay &&
+          other.workflow == this.workflow &&
+          other.workflowId == this.workflowId &&
+          other.runKey == this.runKey &&
+          other.outcome == this.outcome &&
+          other.conclusion == this.conclusion &&
+          other.branch == this.branch &&
+          other.finishedAt == this.finishedAt &&
+          other.url == this.url);
+}
+
+class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
+  final Value<int> id;
+  final Value<String> provider;
+  final Value<String> repoKey;
+  final Value<String> repoDisplay;
+  final Value<String> workflow;
+  final Value<String?> workflowId;
+  final Value<String> runKey;
+  final Value<String> outcome;
+  final Value<String> conclusion;
+  final Value<String?> branch;
+  final Value<int?> finishedAt;
+  final Value<String?> url;
+  const CiRunHistoryCompanion({
+    this.id = const Value.absent(),
+    this.provider = const Value.absent(),
+    this.repoKey = const Value.absent(),
+    this.repoDisplay = const Value.absent(),
+    this.workflow = const Value.absent(),
+    this.workflowId = const Value.absent(),
+    this.runKey = const Value.absent(),
+    this.outcome = const Value.absent(),
+    this.conclusion = const Value.absent(),
+    this.branch = const Value.absent(),
+    this.finishedAt = const Value.absent(),
+    this.url = const Value.absent(),
+  });
+  CiRunHistoryCompanion.insert({
+    this.id = const Value.absent(),
+    required String provider,
+    required String repoKey,
+    required String repoDisplay,
+    required String workflow,
+    this.workflowId = const Value.absent(),
+    required String runKey,
+    required String outcome,
+    required String conclusion,
+    this.branch = const Value.absent(),
+    this.finishedAt = const Value.absent(),
+    this.url = const Value.absent(),
+  }) : provider = Value(provider),
+       repoKey = Value(repoKey),
+       repoDisplay = Value(repoDisplay),
+       workflow = Value(workflow),
+       runKey = Value(runKey),
+       outcome = Value(outcome),
+       conclusion = Value(conclusion);
+  static Insertable<CiRunHistoryRow> custom({
+    Expression<int>? id,
+    Expression<String>? provider,
+    Expression<String>? repoKey,
+    Expression<String>? repoDisplay,
+    Expression<String>? workflow,
+    Expression<String>? workflowId,
+    Expression<String>? runKey,
+    Expression<String>? outcome,
+    Expression<String>? conclusion,
+    Expression<String>? branch,
+    Expression<int>? finishedAt,
+    Expression<String>? url,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (provider != null) 'provider': provider,
+      if (repoKey != null) 'repo_key': repoKey,
+      if (repoDisplay != null) 'repo_display': repoDisplay,
+      if (workflow != null) 'workflow': workflow,
+      if (workflowId != null) 'workflow_id': workflowId,
+      if (runKey != null) 'run_key': runKey,
+      if (outcome != null) 'outcome': outcome,
+      if (conclusion != null) 'conclusion': conclusion,
+      if (branch != null) 'branch': branch,
+      if (finishedAt != null) 'finished_at': finishedAt,
+      if (url != null) 'url': url,
+    });
+  }
+
+  CiRunHistoryCompanion copyWith({
+    Value<int>? id,
+    Value<String>? provider,
+    Value<String>? repoKey,
+    Value<String>? repoDisplay,
+    Value<String>? workflow,
+    Value<String?>? workflowId,
+    Value<String>? runKey,
+    Value<String>? outcome,
+    Value<String>? conclusion,
+    Value<String?>? branch,
+    Value<int?>? finishedAt,
+    Value<String?>? url,
+  }) {
+    return CiRunHistoryCompanion(
+      id: id ?? this.id,
+      provider: provider ?? this.provider,
+      repoKey: repoKey ?? this.repoKey,
+      repoDisplay: repoDisplay ?? this.repoDisplay,
+      workflow: workflow ?? this.workflow,
+      workflowId: workflowId ?? this.workflowId,
+      runKey: runKey ?? this.runKey,
+      outcome: outcome ?? this.outcome,
+      conclusion: conclusion ?? this.conclusion,
+      branch: branch ?? this.branch,
+      finishedAt: finishedAt ?? this.finishedAt,
+      url: url ?? this.url,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (provider.present) {
+      map['provider'] = Variable<String>(provider.value);
+    }
+    if (repoKey.present) {
+      map['repo_key'] = Variable<String>(repoKey.value);
+    }
+    if (repoDisplay.present) {
+      map['repo_display'] = Variable<String>(repoDisplay.value);
+    }
+    if (workflow.present) {
+      map['workflow'] = Variable<String>(workflow.value);
+    }
+    if (workflowId.present) {
+      map['workflow_id'] = Variable<String>(workflowId.value);
+    }
+    if (runKey.present) {
+      map['run_key'] = Variable<String>(runKey.value);
+    }
+    if (outcome.present) {
+      map['outcome'] = Variable<String>(outcome.value);
+    }
+    if (conclusion.present) {
+      map['conclusion'] = Variable<String>(conclusion.value);
+    }
+    if (branch.present) {
+      map['branch'] = Variable<String>(branch.value);
+    }
+    if (finishedAt.present) {
+      map['finished_at'] = Variable<int>(finishedAt.value);
+    }
+    if (url.present) {
+      map['url'] = Variable<String>(url.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CiRunHistoryCompanion(')
+          ..write('id: $id, ')
+          ..write('provider: $provider, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('repoDisplay: $repoDisplay, ')
+          ..write('workflow: $workflow, ')
+          ..write('workflowId: $workflowId, ')
+          ..write('runKey: $runKey, ')
+          ..write('outcome: $outcome, ')
+          ..write('conclusion: $conclusion, ')
+          ..write('branch: $branch, ')
+          ..write('finishedAt: $finishedAt, ')
+          ..write('url: $url')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -4380,6 +5081,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   );
   late final $NotificationKnownReposTable notificationKnownRepos =
       $NotificationKnownReposTable(this);
+  late final $CiRunHistoryTable ciRunHistory = $CiRunHistoryTable(this);
   late final Index idxMetricSnapshotsRepoKey = Index(
     'idx_metric_snapshots_repo_key',
     'CREATE INDEX idx_metric_snapshots_repo_key ON metric_snapshots (repo_key)',
@@ -4416,6 +5118,18 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'idx_notification_seen_seen_id',
     'CREATE UNIQUE INDEX idx_notification_seen_seen_id ON notification_seen (seen_id)',
   );
+  late final Index idxCiRunHistoryRunKey = Index(
+    'idx_ci_run_history_run_key',
+    'CREATE UNIQUE INDEX idx_ci_run_history_run_key ON ci_run_history (run_key)',
+  );
+  late final Index idxCiRunHistoryRepoKey = Index(
+    'idx_ci_run_history_repo_key',
+    'CREATE INDEX idx_ci_run_history_repo_key ON ci_run_history (repo_key)',
+  );
+  late final Index idxCiRunHistoryFinishedAt = Index(
+    'idx_ci_run_history_finished_at',
+    'CREATE INDEX idx_ci_run_history_finished_at ON ci_run_history (finished_at)',
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -4431,6 +5145,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     syncState,
     notificationSeen,
     notificationKnownRepos,
+    ciRunHistory,
     idxMetricSnapshotsRepoKey,
     idxActivityEventsRepoKey,
     idxActivityEventsOccurredAt,
@@ -4440,6 +5155,9 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     idxRepoRunsRepoKey,
     idxRepoReleasesRepoKey,
     idxNotificationSeenSeenId,
+    idxCiRunHistoryRunKey,
+    idxCiRunHistoryRepoKey,
+    idxCiRunHistoryFinishedAt,
   ];
 }
 
@@ -6756,6 +7474,341 @@ typedef $$NotificationKnownReposTableProcessedTableManager =
       NotificationKnownRepoRow,
       PrefetchHooks Function()
     >;
+typedef $$CiRunHistoryTableCreateCompanionBuilder =
+    CiRunHistoryCompanion Function({
+      Value<int> id,
+      required String provider,
+      required String repoKey,
+      required String repoDisplay,
+      required String workflow,
+      Value<String?> workflowId,
+      required String runKey,
+      required String outcome,
+      required String conclusion,
+      Value<String?> branch,
+      Value<int?> finishedAt,
+      Value<String?> url,
+    });
+typedef $$CiRunHistoryTableUpdateCompanionBuilder =
+    CiRunHistoryCompanion Function({
+      Value<int> id,
+      Value<String> provider,
+      Value<String> repoKey,
+      Value<String> repoDisplay,
+      Value<String> workflow,
+      Value<String?> workflowId,
+      Value<String> runKey,
+      Value<String> outcome,
+      Value<String> conclusion,
+      Value<String?> branch,
+      Value<int?> finishedAt,
+      Value<String?> url,
+    });
+
+class $$CiRunHistoryTableFilterComposer
+    extends Composer<_$AppDatabase, $CiRunHistoryTable> {
+  $$CiRunHistoryTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get provider => $composableBuilder(
+    column: $table.provider,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get workflow => $composableBuilder(
+    column: $table.workflow,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get workflowId => $composableBuilder(
+    column: $table.workflowId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get runKey => $composableBuilder(
+    column: $table.runKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get outcome => $composableBuilder(
+    column: $table.outcome,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get conclusion => $composableBuilder(
+    column: $table.conclusion,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get branch => $composableBuilder(
+    column: $table.branch,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get finishedAt => $composableBuilder(
+    column: $table.finishedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$CiRunHistoryTableOrderingComposer
+    extends Composer<_$AppDatabase, $CiRunHistoryTable> {
+  $$CiRunHistoryTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get provider => $composableBuilder(
+    column: $table.provider,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get workflow => $composableBuilder(
+    column: $table.workflow,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get workflowId => $composableBuilder(
+    column: $table.workflowId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get runKey => $composableBuilder(
+    column: $table.runKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get outcome => $composableBuilder(
+    column: $table.outcome,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get conclusion => $composableBuilder(
+    column: $table.conclusion,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get branch => $composableBuilder(
+    column: $table.branch,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get finishedAt => $composableBuilder(
+    column: $table.finishedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$CiRunHistoryTableAnnotationComposer
+    extends Composer<_$AppDatabase, $CiRunHistoryTable> {
+  $$CiRunHistoryTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get provider =>
+      $composableBuilder(column: $table.provider, builder: (column) => column);
+
+  GeneratedColumn<String> get repoKey =>
+      $composableBuilder(column: $table.repoKey, builder: (column) => column);
+
+  GeneratedColumn<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get workflow =>
+      $composableBuilder(column: $table.workflow, builder: (column) => column);
+
+  GeneratedColumn<String> get workflowId => $composableBuilder(
+    column: $table.workflowId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get runKey =>
+      $composableBuilder(column: $table.runKey, builder: (column) => column);
+
+  GeneratedColumn<String> get outcome =>
+      $composableBuilder(column: $table.outcome, builder: (column) => column);
+
+  GeneratedColumn<String> get conclusion => $composableBuilder(
+    column: $table.conclusion,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get branch =>
+      $composableBuilder(column: $table.branch, builder: (column) => column);
+
+  GeneratedColumn<int> get finishedAt => $composableBuilder(
+    column: $table.finishedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get url =>
+      $composableBuilder(column: $table.url, builder: (column) => column);
+}
+
+class $$CiRunHistoryTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $CiRunHistoryTable,
+          CiRunHistoryRow,
+          $$CiRunHistoryTableFilterComposer,
+          $$CiRunHistoryTableOrderingComposer,
+          $$CiRunHistoryTableAnnotationComposer,
+          $$CiRunHistoryTableCreateCompanionBuilder,
+          $$CiRunHistoryTableUpdateCompanionBuilder,
+          (
+            CiRunHistoryRow,
+            BaseReferences<_$AppDatabase, $CiRunHistoryTable, CiRunHistoryRow>,
+          ),
+          CiRunHistoryRow,
+          PrefetchHooks Function()
+        > {
+  $$CiRunHistoryTableTableManager(_$AppDatabase db, $CiRunHistoryTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$CiRunHistoryTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$CiRunHistoryTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$CiRunHistoryTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> provider = const Value.absent(),
+                Value<String> repoKey = const Value.absent(),
+                Value<String> repoDisplay = const Value.absent(),
+                Value<String> workflow = const Value.absent(),
+                Value<String?> workflowId = const Value.absent(),
+                Value<String> runKey = const Value.absent(),
+                Value<String> outcome = const Value.absent(),
+                Value<String> conclusion = const Value.absent(),
+                Value<String?> branch = const Value.absent(),
+                Value<int?> finishedAt = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+              }) => CiRunHistoryCompanion(
+                id: id,
+                provider: provider,
+                repoKey: repoKey,
+                repoDisplay: repoDisplay,
+                workflow: workflow,
+                workflowId: workflowId,
+                runKey: runKey,
+                outcome: outcome,
+                conclusion: conclusion,
+                branch: branch,
+                finishedAt: finishedAt,
+                url: url,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String provider,
+                required String repoKey,
+                required String repoDisplay,
+                required String workflow,
+                Value<String?> workflowId = const Value.absent(),
+                required String runKey,
+                required String outcome,
+                required String conclusion,
+                Value<String?> branch = const Value.absent(),
+                Value<int?> finishedAt = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+              }) => CiRunHistoryCompanion.insert(
+                id: id,
+                provider: provider,
+                repoKey: repoKey,
+                repoDisplay: repoDisplay,
+                workflow: workflow,
+                workflowId: workflowId,
+                runKey: runKey,
+                outcome: outcome,
+                conclusion: conclusion,
+                branch: branch,
+                finishedAt: finishedAt,
+                url: url,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$CiRunHistoryTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $CiRunHistoryTable,
+      CiRunHistoryRow,
+      $$CiRunHistoryTableFilterComposer,
+      $$CiRunHistoryTableOrderingComposer,
+      $$CiRunHistoryTableAnnotationComposer,
+      $$CiRunHistoryTableCreateCompanionBuilder,
+      $$CiRunHistoryTableUpdateCompanionBuilder,
+      (
+        CiRunHistoryRow,
+        BaseReferences<_$AppDatabase, $CiRunHistoryTable, CiRunHistoryRow>,
+      ),
+      CiRunHistoryRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -6783,4 +7836,6 @@ class $AppDatabaseManager {
         _db,
         _db.notificationKnownRepos,
       );
+  $$CiRunHistoryTableTableManager get ciRunHistory =>
+      $$CiRunHistoryTableTableManager(_db, _db.ciRunHistory);
 }

--- a/lib/digest_page.dart
+++ b/lib/digest_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'activity_service.dart';
 import 'app_http.dart';
+import 'ci_run_history_store.dart';
 import 'digest_service.dart';
 import 'metric_store.dart';
 import 'team_store.dart';
@@ -38,6 +39,9 @@ class _DigestPageState extends State<DigestPage> {
       // Record a trend snapshot from this load too (deduped ~1/day) before
       // reading history, so the digest reflects the latest observation.
       await MetricStore.capture(activities, restrictToMonitored: true);
+      await CiRunHistoryStore.recordSafely(
+        activities.expand((a) => a.recentRuns),
+      );
       final history = await MetricStore.all();
       final digest = DigestService.buildDigest(
         teams: teams,

--- a/lib/manage_repos_page.dart
+++ b/lib/manage_repos_page.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'register_github_repo.dart';
 import 'register_ado_repo.dart';
 import 'activity_event_store.dart';
+import 'ci_run_history_store.dart';
 import 'repo_detail_store.dart';
 import 'sync_state_store.dart';
 import 'ignore_store.dart';
@@ -257,6 +258,7 @@ class _ManageReposPageState extends State<ManageReposPage> {
         await RepoDetailStore.removeRepo(repoKey);
         await SyncStateStore.remove(SyncStateStore.repoScope(repoKey));
         await TeamStore.removeRepoFromAll(repoKey);
+        await CiRunHistoryStore.removeRepo(repoKey);
       }
     }
     // Mutes are keyed by display label, not repoKey, so prune independently:

--- a/lib/radar_page.dart
+++ b/lib/radar_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'activity_service.dart';
 import 'app_http.dart';
+import 'ci_run_history_store.dart';
 import 'config_revision.dart';
 import 'home_menu.dart';
 import 'metric_store.dart';
@@ -57,6 +58,11 @@ class _RadarPageState extends State<RadarPage> {
       if (!mounted || seq != _loadSeq) return;
       // Record a trend snapshot (deduped ~1/day), then load per-repo series.
       await MetricStore.capture(activities, restrictToMonitored: true);
+      // Accumulate observed CI runs so the CI trends insight keeps building on
+      // desktop too, where there's no periodic background sync.
+      await CiRunHistoryStore.recordSafely(
+        activities.expand((a) => a.recentRuns),
+      );
       final history = await MetricStore.all();
       if (!mounted || seq != _loadSeq) return;
       setState(() {

--- a/lib/sync_service.dart
+++ b/lib/sync_service.dart
@@ -8,6 +8,7 @@ import 'activity_service.dart';
 import 'app_http.dart';
 import 'attention_service.dart';
 import 'attention_store.dart';
+import 'ci_run_history_store.dart';
 import 'identity_store.dart';
 import 'metric_store.dart';
 import 'monitored_repos.dart';
@@ -80,6 +81,11 @@ class SyncService {
           activities,
           restrictToMonitored: true,
           force: force,
+        );
+        // Accumulate the CI runs this fetch observed so the "CI trends" insight
+        // can surface chronically-failing / flaky workflows over time.
+        await CiRunHistoryStore.recordSafely(
+          activities.expand((a) => a.recentRuns),
         );
         return SyncResult(activityOk: true, repoCount: activities.length);
       } catch (e, st) {

--- a/lib/teams_page.dart
+++ b/lib/teams_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'activity_service.dart';
 import 'app_http.dart';
+import 'ci_run_history_store.dart';
 import 'digest_page.dart';
 import 'manage_teams_page.dart';
 import 'metric_snapshot.dart';
@@ -46,6 +47,9 @@ class _TeamsPageState extends State<TeamsPage> {
       );
       // Record a trend snapshot from this load too (deduped ~1/day).
       await MetricStore.capture(activities, restrictToMonitored: true);
+      await CiRunHistoryStore.recordSafely(
+        activities.expand((a) => a.recentRuns),
+      );
       final rollups = TeamService.rollupAll(teams, activities);
       final history = await MetricStore.all();
       final series = <String, List<num>>{

--- a/lib/views/ci_trends_view.dart
+++ b/lib/views/ci_trends_view.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+
+import '../ci_run_history.dart';
+import 'views_common.dart';
+
+/// Ranks each workflow/pipeline by how much it needs attention — chronically
+/// failing and flaky ones first — from the accumulated CI run history, with a
+/// pass/fail sparkline of recent runs. Complements the CI health board (current
+/// state) with the trend over time.
+class CiTrendsView extends StatelessWidget {
+  const CiTrendsView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final trends = data.ciTrends;
+    final problems = trends.where((t) => t.hasProblem).length;
+
+    return ViewScaffold(
+      title: 'CI trends',
+      loadedAt: data.loadedAt,
+      child: trends.isEmpty
+          ? const ViewEmpty(
+              message:
+                  'No CI history yet.\nWorkflow runs accumulate as syncs '
+                  'observe them — check back after a few refreshes.',
+            )
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      problems == 0
+                          ? '${trends.length} workflows · all healthy'
+                          : '$problems needing attention · '
+                                '${trends.length} workflows',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: problems == 0
+                            ? Theme.of(context).colorScheme.onSurfaceVariant
+                            : ciColor('failure'),
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 2, 16, 4),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'From recent sampled runs across all branches.',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: ListView.separated(
+                    padding: const EdgeInsets.all(12),
+                    itemCount: trends.length,
+                    separatorBuilder: (_, _) => const SizedBox(height: 8),
+                    itemBuilder: (context, i) => _TrendTile(trend: trends[i]),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}
+
+class _TrendTile extends StatelessWidget {
+  const _TrendTile({required this.trend});
+
+  final CiWorkflowTrend trend;
+
+  ({String label, Color color})? _badge() {
+    if (trend.isChronicallyFailing) {
+      return (label: 'Failing', color: ciColor('failure'));
+    }
+    if (trend.isFlaky) return (label: 'Flaky', color: ciColor('running'));
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final badge = _badge();
+    final url = trend.url;
+    final ratePct = (trend.failureRate * 100).round();
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: url == null ? null : () => openUrl(url),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    ciIcon(trend.lastOutcome),
+                    size: 18,
+                    color: ciColor(trend.lastOutcome),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      trend.workflow,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  if (badge != null)
+                    _Badge(label: badge.label, color: badge.color),
+                ],
+              ),
+              const SizedBox(height: 2),
+              Text(
+                trend.repoDisplay,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 8),
+              _Sparkline(outcomes: trend.recentOutcomes),
+              const SizedBox(height: 6),
+              Text(
+                trend.total == 0
+                    ? 'No completed runs in range'
+                    : '$ratePct% failed · ${trend.failures}/${trend.total} runs'
+                          '${trend.flips > 0 ? ' · ${trend.flips} flips' : ''}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Badge extends StatelessWidget {
+  const _Badge({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// A compact strip of recent run outcomes (oldest on the left) so the pass/fail
+/// rhythm — and any flip-flopping — is visible at a glance.
+class _Sparkline extends StatelessWidget {
+  const _Sparkline({required this.outcomes});
+
+  /// Newest-first outcomes; rendered reversed so time reads left→right.
+  final List<String> outcomes;
+
+  @override
+  Widget build(BuildContext context) {
+    if (outcomes.isEmpty) return const SizedBox.shrink();
+    return Row(
+      children: [
+        for (final outcome in outcomes.reversed)
+          Padding(
+            padding: const EdgeInsets.only(right: 3),
+            child: Container(
+              width: 10,
+              height: 14,
+              decoration: BoxDecoration(
+                color: ciColor(outcome).withValues(alpha: 0.85),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../activity_service.dart';
 import '../app_http.dart';
+import '../ci_run_history_store.dart';
 import '../metric_store.dart';
 import '../people_service.dart';
 import '../team_service.dart';
@@ -9,6 +10,7 @@ import '../team_store.dart';
 import 'age_histogram_view.dart';
 import 'bubble_view.dart';
 import 'ci_grid_view.dart';
+import 'ci_trends_view.dart';
 import 'contributor_cloud_view.dart';
 import 'donut_view.dart';
 import 'freshness_view.dart';
@@ -77,6 +79,12 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       blurb: 'Status board, failures first',
       icon: Icons.grid_view,
       builder: (d) => CiGridView(data: d),
+    ),
+    ViewInfo(
+      title: 'CI trends',
+      blurb: 'Flaky & chronically-failing workflows',
+      icon: Icons.timeline,
+      builder: (d) => CiTrendsView(data: d),
     ),
     ViewInfo(
       title: 'Treemap',
@@ -168,6 +176,12 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       // Record a trend snapshot from this load too (deduped ~1/day), matching
       // Radar/Teams/Digest, so opening Insights also advances trend history.
       await MetricStore.capture(activities, restrictToMonitored: true);
+      // Accumulate this fetch's CI runs, then read back the rolled-up trends so
+      // the CI trends view reflects the freshest history.
+      await CiRunHistoryStore.recordSafely(
+        activities.expand((a) => a.recentRuns),
+      );
+      final ciTrends = await CiRunHistoryStore.trends();
       final history = await MetricStore.all();
       final teams = await TeamStore.list();
       final rollups = TeamService.rollupAll(teams, activities);
@@ -179,6 +193,7 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
           teams: teams,
           rollups: rollups,
           people: people,
+          ciTrends: ciTrends,
           loadedAt: DateTime.now(),
         );
         _loading = false;

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../activity_service.dart';
+import '../ci_run_history.dart';
 import '../metric_snapshot.dart';
 import '../person.dart';
 import '../team.dart';
@@ -19,6 +20,7 @@ class InsightsData {
     required List<Team> teams,
     required Map<String, TeamRollup> rollups,
     required List<Person> people,
+    List<CiWorkflowTrend> ciTrends = const [],
     required this.loadedAt,
   }) : activities = List.unmodifiable(activities),
        history = Map.unmodifiable({
@@ -29,13 +31,18 @@ class InsightsData {
        rollups = Map.unmodifiable({
          for (final e in rollups.entries) e.key: _readonlyRollup(e.value),
        }),
-       people = List.unmodifiable(people);
+       people = List.unmodifiable(people),
+       ciTrends = List.unmodifiable(ciTrends);
 
   final List<RepoActivity> activities;
   final Map<String, List<MetricSnapshot>> history;
   final List<Team> teams;
   final Map<String, TeamRollup> rollups;
   final List<Person> people;
+
+  /// Per-workflow CI trends (failure rate + flakiness), worst-first, from the
+  /// accumulated run history. Empty until the sync/insights load records runs.
+  final List<CiWorkflowTrend> ciTrends;
   final DateTime loadedAt;
 
   /// Repos whose fetch succeeded (errored repos would read as healthy zeros).

--- a/test/activity_service_test.dart
+++ b/test/activity_service_test.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:kode_radar/activity_service.dart';
+import 'package:kode_radar/ci_run_history.dart';
 import 'package:kode_radar/token_store.dart';
 
 void main() {
@@ -122,6 +123,148 @@ void main() {
     expect(ActivityService.ciStatusFromAdoBuilds({'value': []}), 'unknown');
   });
 
+  test(
+    'ciRunSamplesFromGithubRuns keys by run id + attempt, groups by workflow id',
+    () {
+      final samples = ActivityService.ciRunSamplesFromGithubRuns(
+        {
+          'workflow_runs': [
+            {
+              'id': 101,
+              'workflow_id': 7,
+              'run_attempt': 2,
+              'name': 'CI',
+              'status': 'completed',
+              'conclusion': 'success',
+              'head_branch': 'main',
+              'updated_at': '2026-03-01T10:00:00Z',
+              'html_url': 'https://github.com/o/r/actions/runs/101',
+            },
+            {
+              'id': 102,
+              'workflow_id': 7,
+              'name': 'CI',
+              'status': 'completed',
+              'conclusion': 'failure',
+              'updated_at': '2026-03-01T09:00:00Z',
+            },
+            {'name': 'no-id', 'status': 'completed', 'conclusion': 'success'},
+          ],
+        },
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      );
+      expect(samples, hasLength(2));
+      // run id + attempt in the key; provider prefix comes from repoKey (no
+      // double "github:github").
+      expect(samples[0].runKey, 'github:o/r:101:2');
+      expect(samples[0].workflowId, '7');
+      expect(samples[0].workflow, 'CI');
+      expect(samples[0].outcome, CiOutcome.success);
+      expect(samples[0].branch, 'main');
+      // run_attempt defaults to 1 when absent.
+      expect(samples[1].runKey, 'github:o/r:102:1');
+      expect(samples[1].outcome, CiOutcome.failure);
+    },
+  );
+
+  test('githubRunOutcome buckets conclusions; cancelled is not a failure', () {
+    expect(
+      ActivityService.githubRunOutcome({'conclusion': 'success'}),
+      CiOutcome.success,
+    );
+    expect(
+      ActivityService.githubRunOutcome({'conclusion': 'timed_out'}),
+      CiOutcome.failure,
+    );
+    expect(
+      ActivityService.githubRunOutcome({
+        'conclusion': null,
+        'status': 'in_progress',
+      }),
+      CiOutcome.running,
+    );
+    expect(
+      ActivityService.githubRunOutcome({
+        'conclusion': 'cancelled',
+        'status': 'completed',
+      }),
+      CiOutcome.other,
+    );
+    expect(
+      ActivityService.githubRunOutcome({
+        'conclusion': 'skipped',
+        'status': 'completed',
+      }),
+      CiOutcome.other,
+    );
+  });
+
+  test(
+    'adoBuildOutcome: only failed is a failure; canceled/partial are other',
+    () {
+      expect(
+        ActivityService.adoBuildOutcome({
+          'status': 'completed',
+          'result': 'failed',
+        }),
+        CiOutcome.failure,
+      );
+      expect(
+        ActivityService.adoBuildOutcome({
+          'status': 'completed',
+          'result': 'canceled',
+        }),
+        CiOutcome.other,
+      );
+      expect(
+        ActivityService.adoBuildOutcome({
+          'status': 'completed',
+          'result': 'partiallySucceeded',
+        }),
+        CiOutcome.other,
+      );
+      expect(
+        ActivityService.adoBuildOutcome({
+          'status': 'inProgress',
+          'result': null,
+        }),
+        CiOutcome.running,
+      );
+    },
+  );
+
+  test('ciRunSamplesFromAdoBuilds parses builds, skips id-less', () {
+    final samples = ActivityService.ciRunSamplesFromAdoBuilds(
+      {
+        'value': [
+          {
+            'id': 55,
+            'definition': {'id': 3, 'name': 'Pipeline'},
+            'status': 'completed',
+            'result': 'succeeded',
+            'sourceBranch': 'refs/heads/main',
+            'finishTime': '2026-03-01T10:00:00Z',
+            '_links': {
+              'web': {
+                'href': 'https://dev.azure.com/o/p/_build/results?buildId=55',
+              },
+            },
+          },
+          {'status': 'completed', 'result': 'failed'},
+        ],
+      },
+      repoKey: 'ado:o/p/r',
+      repoDisplay: 'o/p/r',
+    );
+    expect(samples, hasLength(1));
+    expect(samples.single.runKey, 'ado:o/p/r:55');
+    expect(samples.single.workflow, 'Pipeline');
+    expect(samples.single.workflowId, '3');
+    expect(samples.single.outcome, CiOutcome.success);
+    expect(samples.single.url, contains('buildId=55'));
+  });
+
   test('ADO PR helpers parse authors review needs and age', () {
     final now = DateTime.parse('2026-07-13T00:00:00Z');
     final data = [
@@ -203,11 +346,17 @@ void main() {
       }
 
       if (request.url.path == '/repos/acme/kode/actions/runs') {
-        expect(request.url.queryParameters['per_page'], '1');
+        expect(request.url.queryParameters['per_page'], '20');
         return http.Response(
           jsonEncode({
             'workflow_runs': [
-              {'status': 'completed', 'conclusion': 'success'},
+              {
+                'id': 1,
+                'name': 'CI',
+                'status': 'completed',
+                'conclusion': 'success',
+                'updated_at': '2026-03-01T10:00:00Z',
+              },
             ],
           }),
           200,
@@ -230,6 +379,8 @@ void main() {
     expect(activity.needsReviewCount, 1);
     expect(activity.contributors, ['alice']);
     expect(activity.ciStatus, 'success');
+    expect(activity.recentRuns.single.outcome, CiOutcome.success);
+    expect(activity.recentRuns.single.runKey, 'github:acme/kode:1:1');
     expect(activity.error, isNull);
   });
 

--- a/test/ci_run_history_store_test.dart
+++ b/test/ci_run_history_store_test.dart
@@ -1,0 +1,222 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/ci_run_history.dart';
+import 'package:kode_radar/ci_run_history_store.dart';
+import 'package:kode_radar/database/app_database.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+CiRunSample _sample(
+  String workflow, {
+  required String runKey,
+  String outcome = CiOutcome.success,
+  String repoKey = 'github:owner/name',
+  String repoDisplay = 'owner/name',
+  String conclusion = 'success',
+  String? workflowId,
+  DateTime? finishedAt,
+  String? url,
+}) => CiRunSample(
+  provider: 'github',
+  repoKey: repoKey,
+  repoDisplay: repoDisplay,
+  workflow: workflow,
+  workflowId: workflowId,
+  runKey: runKey,
+  outcome: outcome,
+  conclusion: conclusion,
+  finishedAt: finishedAt ?? DateTime.utc(2026, 1, 10),
+  url: url ?? 'https://example.com/$runKey',
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forExecutor(NativeDatabase.memory());
+    CiRunHistoryStore.debugUseDatabase(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test(
+    'record de-duplicates by runKey (re-seen run does not double-count)',
+    () async {
+      final now = DateTime.utc(2026, 1, 11);
+      await CiRunHistoryStore.record([
+        _sample(
+          'build',
+          runKey: 'github:owner/name:1',
+          outcome: CiOutcome.failure,
+        ),
+        _sample(
+          'build',
+          runKey: 'github:owner/name:2',
+          outcome: CiOutcome.success,
+        ),
+      ], now: now);
+      // A later sync re-sees run 1 (same runKey) plus a new run 3.
+      await CiRunHistoryStore.record([
+        _sample(
+          'build',
+          runKey: 'github:owner/name:1',
+          outcome: CiOutcome.failure,
+        ),
+        _sample(
+          'build',
+          runKey: 'github:owner/name:3',
+          outcome: CiOutcome.success,
+        ),
+      ], now: now);
+
+      final trends = await CiRunHistoryStore.trends(now: now);
+      expect(trends, hasLength(1));
+      // 3 distinct runs: 1 failure + 2 successes (not 4).
+      expect(trends.single.total, 3);
+      expect(trends.single.failures, 1);
+      expect(trends.single.successes, 2);
+    },
+  );
+
+  test('record skips samples without a runKey', () async {
+    final now = DateTime.utc(2026, 1, 11);
+    await CiRunHistoryStore.record([
+      _sample('build', runKey: ''),
+      _sample('build', runKey: 'github:owner/name:9'),
+    ], now: now);
+    final trends = await CiRunHistoryStore.trends(now: now);
+    expect(trends.single.total, 1);
+  });
+
+  test('record skips still-running and finish-time-less runs', () async {
+    final now = DateTime.utc(2026, 1, 11);
+    await CiRunHistoryStore.record([
+      _sample(
+        'build',
+        runKey: 'github:owner/name:r',
+        outcome: CiOutcome.running,
+      ),
+      CiRunSample(
+        provider: 'github',
+        repoKey: 'github:owner/name',
+        repoDisplay: 'owner/name',
+        workflow: 'build',
+        runKey: 'github:owner/name:nofinish',
+        outcome: CiOutcome.success,
+        conclusion: 'success',
+        finishedAt: null,
+      ),
+      _sample('build', runKey: 'github:owner/name:ok'),
+    ], now: now);
+    final trends = await CiRunHistoryStore.trends(now: now);
+    expect(
+      trends.single.total,
+      1,
+      reason: 'only the completed, finished run is kept',
+    );
+  });
+
+  test('age prune drops runs older than the retention window', () async {
+    final now = DateTime.utc(2026, 6, 1);
+    await CiRunHistoryStore.record([
+      _sample(
+        'build',
+        runKey: 'github:owner/name:old',
+        finishedAt: now.subtract(const Duration(days: 100)),
+      ),
+      _sample(
+        'build',
+        runKey: 'github:owner/name:fresh',
+        finishedAt: now.subtract(const Duration(days: 1)),
+      ),
+    ], now: now);
+    final trends = await CiRunHistoryStore.trends(
+      now: now,
+      window: const Duration(days: 365),
+    );
+    expect(trends.single.total, 1, reason: 'the 100-day-old run is pruned');
+  });
+
+  test('removeRepo drops only that repo history', () async {
+    final now = DateTime.utc(2026, 1, 11);
+    await CiRunHistoryStore.record([
+      _sample(
+        'build',
+        runKey: 'github:owner/a:1',
+        repoKey: 'github:owner/a',
+        repoDisplay: 'owner/a',
+      ),
+      _sample(
+        'build',
+        runKey: 'github:owner/b:1',
+        repoKey: 'github:owner/b',
+        repoDisplay: 'owner/b',
+      ),
+    ], now: now);
+    await CiRunHistoryStore.removeRepo('github:owner/a');
+    final trends = await CiRunHistoryStore.trends(now: now);
+    expect(trends, hasLength(1));
+    expect(trends.single.repoKey, 'github:owner/b');
+  });
+
+  test('persists workflowId so trends group by it across a rename', () async {
+    final now = DateTime.utc(2026, 1, 11);
+    await CiRunHistoryStore.record([
+      _sample('CI', runKey: 'github:owner/name:1', workflowId: '42'),
+      _sample(
+        'Build',
+        runKey: 'github:owner/name:2',
+        workflowId: '42',
+        outcome: CiOutcome.failure,
+        conclusion: 'failure',
+      ),
+    ], now: now);
+    final trends = await CiRunHistoryStore.trends(now: now);
+    // Same workflowId '42' under two names collapses to one trend after the
+    // DB round-trip (workflowId must be persisted for this to hold).
+    expect(trends, hasLength(1));
+    expect(trends.single.total, 2);
+    expect(trends.single.successes, 1);
+    expect(trends.single.failures, 1);
+  });
+
+  test(
+    'v9 -> v10 upgrade creates ci_run_history with a working unique index',
+    () async {
+      // A database at the pre-v10 schema (user_version = 9): opening AppDatabase
+      // over it runs onUpgrade(9 -> 10), which must create ci_run_history and its
+      // UNIQUE run_key index (the record() insert-or-replace de-dup relies on it).
+      final native = sqlite3.openInMemory();
+      native.execute('PRAGMA user_version = 9;');
+      final upgraded = AppDatabase.forExecutor(
+        NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+      );
+      CiRunHistoryStore.debugUseDatabase(upgraded);
+
+      final now = DateTime.utc(2026, 1, 11);
+      await CiRunHistoryStore.record([
+        _sample(
+          'build',
+          runKey: 'github:owner/name:1',
+          outcome: CiOutcome.failure,
+        ),
+      ], now: now);
+      await CiRunHistoryStore.record([
+        _sample(
+          'build',
+          runKey: 'github:owner/name:1',
+          outcome: CiOutcome.success,
+        ),
+      ], now: now);
+
+      final trends = await CiRunHistoryStore.trends(now: now);
+      // The same runKey replaced rather than duplicated: one run, now a success.
+      expect(trends.single.total, 1);
+      expect(trends.single.successes, 1);
+      await upgraded.close();
+    },
+  );
+}

--- a/test/ci_run_history_test.dart
+++ b/test/ci_run_history_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/ci_run_history.dart';
+
+CiRunSample _s(
+  String workflow,
+  String outcome,
+  DateTime finishedAt, {
+  String repoKey = 'github:owner/name',
+  String repoDisplay = 'owner/name',
+}) => CiRunSample(
+  provider: 'github',
+  repoKey: repoKey,
+  repoDisplay: repoDisplay,
+  workflow: workflow,
+  runKey: '$repoKey:$workflow:${finishedAt.millisecondsSinceEpoch}',
+  outcome: outcome,
+  conclusion: outcome,
+  finishedAt: finishedAt,
+);
+
+void main() {
+  final base = DateTime.utc(2026, 3, 1, 12);
+  DateTime ago(int hours) => base.subtract(Duration(hours: hours));
+
+  group('CiWorkflowTrend.aggregate', () {
+    test('groups by workflow and counts completed outcomes', () {
+      final trends = CiWorkflowTrend.aggregate([
+        _s('build', CiOutcome.success, ago(1)),
+        _s('build', CiOutcome.failure, ago(2)),
+        _s('build', CiOutcome.running, ago(0)), // excluded from totals
+        _s('deploy', CiOutcome.success, ago(3)),
+      ], now: base);
+
+      final build = trends.firstWhere((t) => t.workflow == 'build');
+      expect(build.total, 2);
+      expect(build.successes, 1);
+      expect(build.failures, 1);
+      // Newest run (running) leads the outcome strip and lastOutcome.
+      expect(build.lastOutcome, CiOutcome.running);
+      expect(build.recentOutcomes.first, CiOutcome.running);
+
+      final deploy = trends.firstWhere((t) => t.workflow == 'deploy');
+      expect(deploy.total, 1);
+      expect(deploy.failureRate, 0);
+    });
+
+    test(
+      'does not label a recovered workflow (latest run passed) as failing',
+      () {
+        // Newest-first: latest completed run is a success despite older failures.
+        final trends = CiWorkflowTrend.aggregate([
+          _s('recovered', CiOutcome.success, ago(1)),
+          _s('recovered', CiOutcome.failure, ago(2)),
+          _s('recovered', CiOutcome.failure, ago(3)),
+          _s('recovered', CiOutcome.failure, ago(4)),
+        ], now: base);
+        final t = trends.single;
+        expect(t.failureRate, closeTo(0.75, 1e-9));
+        expect(t.lastCompletedOutcome, CiOutcome.success);
+        expect(t.isChronicallyFailing, isFalse);
+      },
+    );
+
+    test('flags a chronically-failing workflow, not a flaky one', () {
+      final trends = CiWorkflowTrend.aggregate([
+        _s('nightly', CiOutcome.failure, ago(1)),
+        _s('nightly', CiOutcome.failure, ago(2)),
+        _s('nightly', CiOutcome.failure, ago(3)),
+        _s('nightly', CiOutcome.failure, ago(4)),
+      ], now: base);
+      final t = trends.single;
+      expect(t.failureRate, 1.0);
+      expect(t.flips, 0);
+      expect(t.isChronicallyFailing, isTrue);
+      expect(t.isFlaky, isFalse);
+    });
+
+    test('flags a flaky workflow that alternates pass/fail', () {
+      final trends = CiWorkflowTrend.aggregate([
+        _s('flappy', CiOutcome.success, ago(1)),
+        _s('flappy', CiOutcome.failure, ago(2)),
+        _s('flappy', CiOutcome.success, ago(3)),
+        _s('flappy', CiOutcome.failure, ago(4)),
+      ], now: base);
+      final t = trends.single;
+      expect(t.flips, 3);
+      expect(t.flakeRate, closeTo(1.0, 1e-9));
+      expect(t.isFlaky, isTrue);
+      // Flaky and chronic are mutually exclusive (flip-rate split).
+      expect(t.isChronicallyFailing, isFalse);
+    });
+
+    test('a lone pass/fail pair is not yet flaky (min sample)', () {
+      final trends = CiWorkflowTrend.aggregate([
+        _s('young', CiOutcome.success, ago(1)),
+        _s('young', CiOutcome.failure, ago(2)),
+      ], now: base);
+      final t = trends.single;
+      expect(t.isFlaky, isFalse);
+      expect(t.isChronicallyFailing, isFalse);
+    });
+
+    test('groups by workflow id, not name (rename-safe, dup-name-safe)', () {
+      CiRunSample s(String name, String id, String outcome, DateTime at) =>
+          CiRunSample(
+            provider: 'github',
+            repoKey: 'github:o/r',
+            repoDisplay: 'o/r',
+            workflow: name,
+            workflowId: id,
+            runKey: 'github:o/r:$id:${at.millisecondsSinceEpoch}',
+            outcome: outcome,
+            conclusion: outcome,
+            finishedAt: at,
+          );
+      final trends = CiWorkflowTrend.aggregate([
+        // Same id, different display name (a rename) -> one group.
+        s('CI', '1', CiOutcome.success, ago(1)),
+        s('Build', '1', CiOutcome.failure, ago(2)),
+        // Same name as the first, different id -> a separate group.
+        s('CI', '2', CiOutcome.success, ago(1)),
+      ], now: base);
+      expect(trends, hasLength(2));
+      // id 1 collapses two differently-named runs into one trend.
+      final merged = trends.firstWhere((t) => t.total == 2);
+      expect(merged.successes, 1);
+      expect(merged.failures, 1);
+      // id 2 stays its own single-run trend despite sharing the name "CI".
+      expect(trends.firstWhere((t) => t.total == 1).successes, 1);
+    });
+
+    test('small samples rank below a confident chronic failure', () {
+      final trends = CiWorkflowTrend.aggregate([
+        // 2-run 100% fail: high rate but low confidence.
+        _s(
+          'tiny',
+          CiOutcome.failure,
+          ago(1),
+          repoKey: 'github:o/tiny',
+          repoDisplay: 'o/tiny',
+        ),
+        _s(
+          'tiny',
+          CiOutcome.failure,
+          ago(2),
+          repoKey: 'github:o/tiny',
+          repoDisplay: 'o/tiny',
+        ),
+        // 4-run 100% fail: chronic, more confident.
+        _s('chronic', CiOutcome.failure, ago(1)),
+        _s('chronic', CiOutcome.failure, ago(2)),
+        _s('chronic', CiOutcome.failure, ago(3)),
+        _s('chronic', CiOutcome.failure, ago(4)),
+      ], now: base);
+      expect(trends.first.workflow, 'chronic');
+      expect(trends.first.isChronicallyFailing, isTrue);
+      final tiny = trends.firstWhere((t) => t.workflow == 'tiny');
+      expect(tiny.isChronicallyFailing, isFalse);
+      expect(trends.first.severity, greaterThan(tiny.severity));
+    });
+
+    test('excludes runs finished before the window', () {
+      final trends = CiWorkflowTrend.aggregate(
+        [
+          _s(
+            'build',
+            CiOutcome.failure,
+            base.subtract(const Duration(days: 40)),
+          ),
+          _s('build', CiOutcome.success, ago(1)),
+        ],
+        now: base,
+        window: const Duration(days: 30),
+      );
+      expect(trends.single.total, 1);
+      expect(trends.single.failures, 0);
+    });
+
+    test('sorts worst-first (highest severity leads)', () {
+      final trends = CiWorkflowTrend.aggregate([
+        // healthy: all green
+        _s('green', CiOutcome.success, ago(1)),
+        _s('green', CiOutcome.success, ago(2)),
+        _s('green', CiOutcome.success, ago(3)),
+        // failing: all red
+        _s(
+          'red',
+          CiOutcome.failure,
+          ago(1),
+          repoKey: 'github:o/r',
+          repoDisplay: 'o/r',
+        ),
+        _s(
+          'red',
+          CiOutcome.failure,
+          ago(2),
+          repoKey: 'github:o/r',
+          repoDisplay: 'o/r',
+        ),
+        _s(
+          'red',
+          CiOutcome.failure,
+          ago(3),
+          repoKey: 'github:o/r',
+          repoDisplay: 'o/r',
+        ),
+      ], now: base);
+      expect(trends.first.workflow, 'red');
+      expect(trends.last.workflow, 'green');
+    });
+  });
+}

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kode_radar/activity_service.dart';
+import 'package:kode_radar/ci_run_history.dart';
 import 'package:kode_radar/metric_snapshot.dart';
 import 'package:kode_radar/person.dart';
 import 'package:kode_radar/team.dart';
@@ -8,6 +9,7 @@ import 'package:kode_radar/team_service.dart';
 import 'package:kode_radar/views/age_histogram_view.dart';
 import 'package:kode_radar/views/bubble_view.dart';
 import 'package:kode_radar/views/ci_grid_view.dart';
+import 'package:kode_radar/views/ci_trends_view.dart';
 import 'package:kode_radar/views/contributor_cloud_view.dart';
 import 'package:kode_radar/views/donut_view.dart';
 import 'package:kode_radar/views/freshness_view.dart';
@@ -111,6 +113,19 @@ InsightsData _sampleData() {
         reviewRequests: 2,
       ),
     ],
+    ciTrends: CiWorkflowTrend.aggregate([
+      for (var i = 0; i < 4; i++)
+        CiRunSample(
+          provider: 'github',
+          repoKey: 'github:acme/kode',
+          repoDisplay: 'acme/kode',
+          workflow: 'CI',
+          runKey: 'github:acme/kode:$i',
+          outcome: i.isEven ? CiOutcome.success : CiOutcome.failure,
+          conclusion: i.isEven ? 'success' : 'failure',
+          finishedAt: DateTime.utc(2026, 3, 1, 12 - i),
+        ),
+    ], now: DateTime.utc(2026, 3, 1, 13)),
     loadedAt: DateTime.now(),
   );
 }
@@ -133,6 +148,7 @@ void main() {
     'Quadrant': (d) => QuadrantView(data: d),
     'Donut': (d) => DonutView(data: d),
     'CiGrid': (d) => CiGridView(data: d),
+    'CiTrends': (d) => CiTrendsView(data: d),
     'Treemap': (d) => TreemapView(data: d),
     'AgeHistogram': (d) => AgeHistogramView(data: d),
     'Heatmap': (d) => HeatmapView(data: d),


### PR DESCRIPTION
## What

Adds a **CI trends** insight that surfaces **chronically-failing** and **flaky** workflows/pipelines over time, complementing the existing CI health board (which only shows each repo's *current* status).

## How

- **NEW `lib/ci_run_history.dart`** — `CiRunSample` (one observed run) + `CiWorkflowTrend` with a **pure** `aggregate()` that groups runs by **workflow id** (rename-safe, dup-name-safe), counts pass/fail, and computes failure rate + flip-based flakiness.
  - **Flaky** vs **chronically-failing** are mutually exclusive (a flip-rate split) and each need a minimum sample. "Chronic" also requires the **latest completed run to be failing**, so a *recovered* workflow isn't flagged. Ranking severity is confidence-weighted so a 2-run sample can't outrank a 20-run one.
- **NEW `lib/ci_run_history_store.dart`** — accumulates runs on the local SQLite DB, de-duplicated by a provider-stable `runKey` (GitHub run id **+ run_attempt** so a failed attempt kept before a successful rerun survives; ADO build id). Pruned by age (45d) and a per-repo cap (400). Only **completed, finished** runs are stored, so every row has a real timestamp for pruning/ordering. `record`/`recordSafely`, `trends`, `removeRepo`.
- **`lib/database/app_database.dart`** — new `CiRunHistory` table (unique `run_key` index + `repo_key`/`finished_at` indexes, `workflow_id` column), **schemaVersion 9→10**, idempotent `from<10` migration.
- **`lib/activity_service.dart`** — fetches ~20 recent runs (was 1) on the **same** endpoints (no extra API calls), attaches them to `RepoActivity.recentRuns`. Per-run outcome mapping treats **cancelled / partiallySucceeded** as neither pass nor fail (they can't manufacture flakiness); `ciStatus` still comes from the newest run.
- **Persistence** — recorded from the background sync **and** every fetch-and-capture surface (Radar / Teams / Digest / Insights), so history accrues even on desktop (no background sync). Repo deletion prunes its history.
- **NEW `lib/views/ci_trends_view.dart`** + registration — ranks workflows worst-first with a pass/fail sparkline and Flaky/Failing badges; empty-state until history accrues. Copy is honest that it's "from recent sampled runs across all branches."

## Review gate

code-review (no significant issues) + rubber-duck pre-open. Rubber-duck caught and I fixed (all blocking): cancelled runs counted as failures; two-run samples read as flaky + flaky/chronic overlap; GitHub reruns overwriting the failed attempt (added `run_attempt` to the key); null-finish (running) rows never pruned / mis-sorted (now skipped); and a *recovered* workflow still labeled failing (now requires latest completed run = failure). Also switched grouping to workflow id and added foreground accrual coverage.

Known limitation (documented in-view): trends are **all-branch and sampled** (last ~20 runs/repo/sync); default-branch scoping and pagination are possible follow-ups.

## Tests

`test/ci_run_history_test.dart` (aggregate: grouping by id, flaky vs chronic, recency guard, small-sample ranking, window filtering, sorting), `test/ci_run_history_store_test.dart` (dedup, skip running/null-finish, age prune, per-repo removal, **workflowId persistence**, **v9→v10 migration**), parser/outcome tests in `test/activity_service_test.dart`, and a smoke test for the view. `dart format` clean, `flutter analyze --fatal-infos` clean, all 375 tests pass.
