### PR TITLE
CI trends: default-branch scoping, window selector, workflow drill-down

### DIFF
--- a/lib/activity_service.dart
+++ b/lib/activity_service.dart
@@ -321,10 +321,17 @@ class ActivityService {
   /// Runs without an `id` are skipped (no stable de-dup key). The de-dup key
   /// includes `run_attempt` so a failed attempt kept before a successful rerun
   /// (which reuses the run id) isn't overwritten — preserving the flake signal.
+  ///
+  /// Only runs on the repo's **default branch** are kept (the run payload's
+  /// `repository.default_branch`), so PR / feature-branch runs — which
+  /// legitimately fail — don't pollute a workflow's trend. A [defaultBranch]
+  /// override wins over the payload; when neither is known, all branches are
+  /// kept (a safe fallback).
   static List<CiRunSample> ciRunSamplesFromGithubRuns(
     dynamic json, {
     required String repoKey,
     required String repoDisplay,
+    String? defaultBranch,
   }) {
     final runs = json is Map ? json['workflow_runs'] : null;
     if (runs is! List) return const [];
@@ -333,6 +340,14 @@ class ActivityService {
       if (run is! Map) continue;
       final id = run['id'];
       if (id == null) continue;
+      final repository = run['repository'];
+      final payloadDefault = repository is Map
+          ? _stringValue(repository, 'default_branch')
+          : null;
+      final effectiveDefault = defaultBranch ?? payloadDefault;
+      final headBranch = _stringValue(run, 'head_branch');
+      // Scope to the default branch when we can determine it.
+      if (effectiveDefault != null && headBranch != effectiveDefault) continue;
       final attempt = _intValue(run['run_attempt']) ?? 1;
       final name =
           _stringValue(run, 'name') ??
@@ -348,7 +363,7 @@ class ActivityService {
           runKey: '$repoKey:$id:$attempt',
           outcome: githubRunOutcome(run),
           conclusion: _stringValue(run, 'conclusion') ?? '',
-          branch: _stringValue(run, 'head_branch'),
+          branch: headBranch,
           finishedAt: _parseDate(run['updated_at']),
           url: _stringValue(run, 'html_url'),
         ),
@@ -359,11 +374,18 @@ class ActivityService {
 
   /// Parses an Azure DevOps `/build/builds` response into [CiRunSample]s.
   /// Builds without an `id` are skipped (no stable de-dup key). ADO retries
+  /// Parses an Azure DevOps `/build/builds` response into [CiRunSample]s.
+  /// Builds without an `id` are skipped (no stable de-dup key). ADO retries
   /// create new build ids, so the id alone is a stable per-run key.
+  ///
+  /// Only builds on the repo's [defaultBranch] (e.g. `refs/heads/main`, from
+  /// the repository GET) are kept, so PR / topic-branch builds don't pollute a
+  /// pipeline's trend. When [defaultBranch] is null, all branches are kept.
   static List<CiRunSample> ciRunSamplesFromAdoBuilds(
     dynamic json, {
     required String repoKey,
     required String repoDisplay,
+    String? defaultBranch,
   }) {
     final builds = json is Map ? json['value'] : json;
     if (builds is! List) return const [];
@@ -372,6 +394,9 @@ class ActivityService {
       if (build is! Map) continue;
       final id = build['id'];
       if (id == null) continue;
+      final sourceBranch = _stringValue(build, 'sourceBranch');
+      // Scope to the default branch when we know it.
+      if (defaultBranch != null && sourceBranch != defaultBranch) continue;
       final definition = build['definition'];
       final defName = definition is Map ? definition['name'] : null;
       final workflow = defName is String && defName.isNotEmpty
@@ -394,13 +419,39 @@ class ActivityService {
           runKey: '$repoKey:$id',
           outcome: adoBuildOutcome(build),
           conclusion: _stringValue(build, 'result') ?? '',
-          branch: _stringValue(build, 'sourceBranch'),
+          branch: sourceBranch,
           finishedAt: _parseDate(build['finishTime']),
           url: url,
         ),
       );
     }
     return result;
+  }
+
+  /// Whether [runs] contains a run that will both persist and count toward
+  /// trends — a completed (pass/fail) run with a finish time. Mirrors the
+  /// store's record filter, so a page with only in-progress / cancelled
+  /// default-branch runs still triggers the branch-scoped trend follow-up.
+  static bool _hasCompletedTrendRun(List<CiRunSample> runs) => runs.any(
+    (run) => CiOutcome.isCompleted(run.outcome) && run.finishedAt != null,
+  );
+
+  /// The repo's default branch as reported inside a GitHub `/actions/runs`
+  /// payload (each run carries a minimal `repository` with `default_branch`),
+  /// or null when no run exposes it. Lets a caller do a branch-scoped follow-up
+  /// fetch when the unscoped page contained no default-branch runs.
+  static String? defaultBranchFromGithubRuns(dynamic json) {
+    final runs = json is Map ? json['workflow_runs'] : null;
+    if (runs is! List) return null;
+    for (final run in runs) {
+      if (run is! Map) continue;
+      final repository = run['repository'];
+      if (repository is Map) {
+        final branch = _stringValue(repository, 'default_branch');
+        if (branch != null) return branch;
+      }
+    }
+    return null;
   }
 
   static num scoreActivity({
@@ -540,10 +591,12 @@ class ActivityService {
       try {
         // Fetch a page of recent runs (not just the latest): the newest still
         // drives ciStatus, while the rest accumulate into the CI trends history.
+        // A wider page reduces the chance that default-branch runs (kept for
+        // trends) are all pushed past the window by a burst of PR-branch runs.
         final response = await httpClient
             .get(
               Uri.https('api.github.com', '/repos/$owner/$name/actions/runs', {
-                'per_page': '20',
+                'per_page': '50',
               }),
               headers: headers,
             )
@@ -556,6 +609,36 @@ class ActivityService {
             repoKey: repoKey,
             repoDisplay: displayName,
           );
+          // Trends need a completed (pass/fail) default-branch run. If the
+          // all-branch page yielded none — e.g. a PR-heavy repo whose main-
+          // branch runs are past the window — and the page was full (so older
+          // runs exist), do a branch-scoped follow-up just for trends. ciStatus
+          // stays all-branch (from the first page above).
+          final runsList = decoded is Map ? decoded['workflow_runs'] : null;
+          final pageWasFull = runsList is List && runsList.length >= 50;
+          if (pageWasFull && !_hasCompletedTrendRun(recentRuns)) {
+            final defaultBranch = defaultBranchFromGithubRuns(decoded);
+            if (defaultBranch != null) {
+              final scoped = await httpClient
+                  .get(
+                    Uri.https(
+                      'api.github.com',
+                      '/repos/$owner/$name/actions/runs',
+                      {'branch': defaultBranch, 'per_page': '20'},
+                    ),
+                    headers: headers,
+                  )
+                  .timeout(_requestTimeout);
+              if (scoped.statusCode == 200) {
+                recentRuns = ciRunSamplesFromGithubRuns(
+                  jsonDecode(scoped.body),
+                  repoKey: repoKey,
+                  repoDisplay: displayName,
+                  defaultBranch: defaultBranch,
+                );
+              }
+            }
+          }
         } else {
           errors.add('GitHub actions returned status ${response.statusCode}');
         }
@@ -654,6 +737,7 @@ class ActivityService {
         // resolving its GUID first. If we can't, we leave CI 'unknown' rather
         // than show an unrelated project build.
         String? repositoryId;
+        String? defaultBranch;
         final repoResp = await httpClient
             .get(
               Uri.https(
@@ -666,12 +750,18 @@ class ActivityService {
             .timeout(_requestTimeout);
         if (repoResp.statusCode == 200) {
           final decoded = jsonDecode(repoResp.body);
-          if (decoded is Map) repositoryId = decoded['id'] as String?;
+          if (decoded is Map) {
+            repositoryId = decoded['id'] as String?;
+            defaultBranch = decoded['defaultBranch'] as String?;
+          }
         }
 
         if (repositoryId != null) {
           // Fetch a page of recent builds newest-first: the latest drives
-          // ciStatus, the rest feed the CI trends history.
+          // ciStatus (all-branch, like GitHub), the rest feed the CI trends
+          // history. A wider page reduces the chance default-branch builds are
+          // crowded out of the window by a burst of PR-branch builds; the
+          // default-branch scoping itself happens in the parser.
           final response = await httpClient
               .get(
                 Uri.https(
@@ -681,7 +771,7 @@ class ActivityService {
                     'repositoryId': repositoryId,
                     'repositoryType': 'TfsGit',
                     'queryOrder': 'finishTimeDescending',
-                    r'$top': '20',
+                    r'$top': '50',
                     'api-version': '6.0',
                   },
                 ),
@@ -695,7 +785,42 @@ class ActivityService {
               decoded,
               repoKey: repoKey,
               repoDisplay: displayName,
+              defaultBranch: defaultBranch,
             );
+            // As with GitHub: if the all-branch page had no completed default-
+            // branch build and was full (older builds exist), do a scoped
+            // follow-up just for trends. ciStatus stays all-branch.
+            final buildsList = decoded is Map ? decoded['value'] : null;
+            final pageWasFull = buildsList is List && buildsList.length >= 50;
+            if (pageWasFull &&
+                defaultBranch != null &&
+                !_hasCompletedTrendRun(recentRuns)) {
+              final scoped = await httpClient
+                  .get(
+                    Uri.https(
+                      'dev.azure.com',
+                      '/$organization/$project/_apis/build/builds',
+                      {
+                        'repositoryId': repositoryId,
+                        'repositoryType': 'TfsGit',
+                        'queryOrder': 'finishTimeDescending',
+                        'branchName': defaultBranch,
+                        r'$top': '20',
+                        'api-version': '6.0',
+                      },
+                    ),
+                    headers: headers,
+                  )
+                  .timeout(_requestTimeout);
+              if (scoped.statusCode == 200) {
+                recentRuns = ciRunSamplesFromAdoBuilds(
+                  jsonDecode(scoped.body),
+                  repoKey: repoKey,
+                  repoDisplay: displayName,
+                  defaultBranch: defaultBranch,
+                );
+              }
+            }
           } else {
             errors.add(
               'Azure DevOps builds returned status ${response.statusCode}',

--- a/lib/activity_service.dart
+++ b/lib/activity_service.dart
@@ -617,9 +617,11 @@ class ActivityService {
           );
           // Trends need a completed (pass/fail) default-branch run. If the
           // all-branch page yielded none — e.g. a PR-heavy repo whose main-
-          // branch runs are past the window — and the page was full (so older
-          // runs exist), do a branch-scoped follow-up just for trends. ciStatus
-          // stays all-branch (from the first page above).
+          // branch runs are past the window — and the page hit the per_page
+          // limit (so older runs likely exist beyond it), do a branch-scoped
+          // follow-up just for trends. ciStatus stays all-branch (from the
+          // first page above). Worst case (exactly a full page with no more
+          // runs) is one extra scoped request that returns nothing.
           final runsList = decoded is Map ? decoded['workflow_runs'] : null;
           final pageWasFull = runsList is List && runsList.length >= 50;
           if (pageWasFull && !_hasCompletedTrendRun(recentRuns)) {
@@ -794,8 +796,10 @@ class ActivityService {
               defaultBranch: defaultBranch,
             );
             // As with GitHub: if the all-branch page had no completed default-
-            // branch build and was full (older builds exist), do a scoped
-            // follow-up just for trends. ciStatus stays all-branch.
+            // branch build and hit the page limit (older builds likely exist
+            // beyond it), do a scoped follow-up just for trends. ciStatus stays
+            // all-branch. Worst case is one extra scoped request that finds
+            // nothing.
             final buildsList = decoded is Map ? decoded['value'] : null;
             final pageWasFull = buildsList is List && buildsList.length >= 50;
             if (pageWasFull &&

--- a/lib/activity_service.dart
+++ b/lib/activity_service.dart
@@ -426,10 +426,11 @@ class ActivityService {
     return result;
   }
 
-  /// Whether [runs] contains a run that will both persist and count toward
-  /// trends — a completed (pass/fail) run with a finish time. Mirrors the
-  /// store's record filter, so a page with only in-progress / cancelled
-  /// default-branch runs still triggers the branch-scoped trend follow-up.
+  /// Whether [runs] contains a run that counts toward trend rates — a completed
+  /// (pass/fail) run with a finish time. This is stricter than the store's
+  /// record filter (which also persists `other`/cancelled runs): a page whose
+  /// only default-branch runs are in-progress or cancelled has no rate-bearing
+  /// sample, so we still want the branch-scoped trend follow-up to fire.
   static bool _hasCompletedTrendRun(List<CiRunSample> runs) => runs.any(
     (run) => CiOutcome.isCompleted(run.outcome) && run.finishedAt != null,
   );

--- a/lib/activity_service.dart
+++ b/lib/activity_service.dart
@@ -374,8 +374,6 @@ class ActivityService {
 
   /// Parses an Azure DevOps `/build/builds` response into [CiRunSample]s.
   /// Builds without an `id` are skipped (no stable de-dup key). ADO retries
-  /// Parses an Azure DevOps `/build/builds` response into [CiRunSample]s.
-  /// Builds without an `id` are skipped (no stable de-dup key). ADO retries
   /// create new build ids, so the id alone is a stable per-run key.
   ///
   /// Only builds on the repo's [defaultBranch] (e.g. `refs/heads/main`, from

--- a/lib/activity_service.dart
+++ b/lib/activity_service.dart
@@ -346,7 +346,11 @@ class ActivityService {
           : null;
       final effectiveDefault = defaultBranch ?? payloadDefault;
       final headBranch = _stringValue(run, 'head_branch');
-      // Scope to the default branch when we can determine it.
+      // Keep only runs we can confirm are on the default branch. When the
+      // default is known, a run whose head_branch is missing/mismatched is
+      // excluded rather than risk polluting the trend with a non-default run
+      // (head_branch is present for normal push/PR runs, so this rarely drops
+      // real default-branch runs).
       if (effectiveDefault != null && headBranch != effectiveDefault) continue;
       final attempt = _intValue(run['run_attempt']) ?? 1;
       final name =
@@ -393,7 +397,10 @@ class ActivityService {
       final id = build['id'];
       if (id == null) continue;
       final sourceBranch = _stringValue(build, 'sourceBranch');
-      // Scope to the default branch when we know it.
+      // Keep only builds we can confirm are on the default branch; when the
+      // default is known, a build whose sourceBranch is missing/mismatched is
+      // excluded rather than risk polluting the trend (sourceBranch is present
+      // for normal builds, so this rarely drops real default-branch builds).
       if (defaultBranch != null && sourceBranch != defaultBranch) continue;
       final definition = build['definition'];
       final defName = definition is Map ? definition['name'] : null;

--- a/lib/ci_run_history.dart
+++ b/lib/ci_run_history.dart
@@ -65,8 +65,10 @@ class CiRunSample {
   final String? url;
 
   /// The key runs are grouped by for trends: the stable id when known, else the
-  /// display name.
-  String get groupKey => workflowId ?? workflow;
+  /// display name. Namespaced (`id:` vs `name:`) so a workflow whose id equals
+  /// another workflow's name can't collide.
+  String get groupKey =>
+      workflowId != null ? 'id:$workflowId' : 'name:$workflow';
 }
 
 /// A per-workflow rollup over a recency window: how often it fails and how
@@ -77,6 +79,7 @@ class CiWorkflowTrend {
     required this.repoKey,
     required this.repoDisplay,
     required this.workflow,
+    required this.workflowId,
     required this.successes,
     required this.failures,
     required this.flips,
@@ -90,6 +93,10 @@ class CiWorkflowTrend {
   final String repoKey;
   final String repoDisplay;
   final String workflow;
+
+  /// Stable workflow/definition id (or null), so a caller can filter the raw
+  /// samples back to exactly this workflow via [groupKey].
+  final String? workflowId;
 
   /// Completed (pass/fail) run counts in the window.
   final int successes;
@@ -112,6 +119,10 @@ class CiWorkflowTrend {
 
   final DateTime? lastRunAt;
   final String? url;
+
+  /// The key its runs are grouped by (matches [CiRunSample.groupKey]).
+  String get groupKey =>
+      workflowId != null ? 'id:$workflowId' : 'name:$workflow';
 
   /// Completed runs considered for the rates.
   int get total => successes + failures;
@@ -214,6 +225,7 @@ class CiWorkflowTrend {
           repoKey: newest.repoKey,
           repoDisplay: newest.repoDisplay,
           workflow: newest.workflow,
+          workflowId: newest.workflowId,
           successes: successes,
           failures: failures,
           flips: flips,

--- a/lib/ci_run_history_store.dart
+++ b/lib/ci_run_history_store.dart
@@ -35,10 +35,12 @@ class CiRunHistoryStore {
   static AppDatabase get _database => _db ??= AppDatabase();
 
   /// How long a run stays in history before it's pruned.
-  static const Duration retention = Duration(days: 45);
+  static const Duration retention = Duration(days: 90);
 
   /// Cap on rows kept per repo so a very active repo can't grow unbounded.
-  static const int perRepoCap = 400;
+  /// Sized to comfortably cover the 90-day [retention] for default-branch runs
+  /// (which are far fewer than all-branch runs).
+  static const int perRepoCap = 600;
 
   /// Test hook: back the store with an injected (e.g. in-memory) database and
   /// reset the mutation lock.
@@ -132,6 +134,17 @@ class CiRunHistoryStore {
       final rows = await db.select(db.ciRunHistory).get();
       final samples = rows.map(_toSample).toList();
       return CiWorkflowTrend.aggregate(samples, now: at, window: window);
+    });
+  }
+
+  /// All stored run samples (bounded by [retention] and the per-repo cap), so a
+  /// caller (e.g. the CI trends view) can aggregate client-side across a
+  /// user-chosen window without re-hitting the DB per toggle.
+  static Future<List<CiRunSample>> allSamples() {
+    return _runLocked(() async {
+      final db = _database;
+      final rows = await db.select(db.ciRunHistory).get();
+      return rows.map(_toSample).toList();
     });
   }
 

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -239,7 +239,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 10;
+  int get schemaVersion => 11;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -407,6 +407,19 @@ class AppDatabase extends _$AppDatabase {
           'CREATE INDEX IF NOT EXISTS idx_ci_run_history_finished_at '
           'ON ci_run_history (finished_at)',
         );
+      }
+      // v11 changes CI-trend semantics to default-branch-only. ci_run_history
+      // is a derived cache (re-populated from the API on the next sync), so
+      // clear the now-stale all-branch rows rather than let them linger for the
+      // retention window. Idempotent and safe to race: DELETE on an empty/just-
+      // created table is a no-op, and `from < 10` above guarantees the table
+      // exists first on a multi-version jump. In the rare case two connections
+      // both observe v10 and one records fresh rows before the other's DELETE
+      // runs, the only effect is that those rows are cleared and later re-
+      // observed from the API on a subsequent sync — a derived cache self-
+      // heals, so no serialization/marker is warranted here.
+      if (from < 11) {
+        await customStatement('DELETE FROM ci_run_history');
       }
     },
   );

--- a/lib/views/ci_trends_view.dart
+++ b/lib/views/ci_trends_view.dart
@@ -1,81 +1,143 @@
 import 'package:flutter/material.dart';
 
 import '../ci_run_history.dart';
+import 'ci_workflow_detail_page.dart';
 import 'views_common.dart';
 
 /// Ranks each workflow/pipeline by how much it needs attention — chronically
-/// failing and flaky ones first — from the accumulated CI run history, with a
-/// pass/fail sparkline of recent runs. Complements the CI health board (current
-/// state) with the trend over time.
-class CiTrendsView extends StatelessWidget {
+/// failing and flaky ones first — from the accumulated (default-branch) CI run
+/// history, with a pass/fail sparkline of recent runs. A window selector
+/// re-aggregates the already-loaded samples client-side; tapping a workflow
+/// drills into its individual runs.
+class CiTrendsView extends StatefulWidget {
   const CiTrendsView({super.key, required this.data});
 
   final InsightsData data;
 
   @override
+  State<CiTrendsView> createState() => _CiTrendsViewState();
+}
+
+class _CiTrendsViewState extends State<CiTrendsView> {
+  static const List<int> _windowChoices = [7, 30, 90];
+  int _windowDays = 30;
+
+  Duration get _window => Duration(days: _windowDays);
+
+  @override
   Widget build(BuildContext context) {
-    final trends = data.ciTrends;
+    final samples = widget.data.ciRunSamples;
+    // Anchor aggregation to the load time so it matches the drill-down cutoff
+    // (both use loadedAt), even if the view lingers open across the cutoff.
+    final trends = CiWorkflowTrend.aggregate(
+      samples,
+      now: widget.data.loadedAt,
+      window: _window,
+    );
     final problems = trends.where((t) => t.hasProblem).length;
 
     return ViewScaffold(
       title: 'CI trends',
-      loadedAt: data.loadedAt,
-      child: trends.isEmpty
-          ? const ViewEmpty(
-              message:
-                  'No CI history yet.\nWorkflow runs accumulate as syncs '
-                  'observe them — check back after a few refreshes.',
-            )
-          : Column(
+      loadedAt: widget.data.loadedAt,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: Row(
               children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text(
-                      problems == 0
-                          ? '${trends.length} workflows · all healthy'
-                          : '$problems needing attention · '
-                                '${trends.length} workflows',
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: problems == 0
-                            ? Theme.of(context).colorScheme.onSurfaceVariant
-                            : ciColor('failure'),
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 2, 16, 4),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text(
-                      'From recent sampled runs across all branches.',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ),
-                ),
                 Expanded(
-                  child: ListView.separated(
-                    padding: const EdgeInsets.all(12),
-                    itemCount: trends.length,
-                    separatorBuilder: (_, _) => const SizedBox(height: 8),
-                    itemBuilder: (context, i) => _TrendTile(trend: trends[i]),
+                  child: Text(
+                    trends.isEmpty
+                        ? 'No CI history yet'
+                        : problems == 0
+                        ? '${trends.length} workflows · all healthy'
+                        : '$problems needing attention · '
+                              '${trends.length} workflows',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: problems == 0
+                          ? Theme.of(context).colorScheme.onSurfaceVariant
+                          : ciColor('failure'),
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
+                ),
+                SegmentedButton<int>(
+                  showSelectedIcon: false,
+                  style: const ButtonStyle(
+                    visualDensity: VisualDensity.compact,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  segments: [
+                    for (final d in _windowChoices)
+                      ButtonSegment(value: d, label: Text('${d}d')),
+                  ],
+                  selected: {_windowDays},
+                  onSelectionChanged: (s) =>
+                      setState(() => _windowDays = s.first),
                 ),
               ],
             ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'Default-branch runs seen in the last $_windowDays days.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: trends.isEmpty
+                ? const ViewEmpty(
+                    message:
+                        'No CI history yet.\nWorkflow runs accumulate as syncs '
+                        'observe them — check back after a few refreshes.',
+                  )
+                : ListView.separated(
+                    padding: const EdgeInsets.all(12),
+                    itemCount: trends.length,
+                    separatorBuilder: (_, _) => const SizedBox(height: 8),
+                    itemBuilder: (context, i) => _TrendTile(
+                      trend: trends[i],
+                      onTap: () => _openDetail(trends[i]),
+                    ),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _openDetail(CiWorkflowTrend trend) {
+    // Same anchor as aggregation (loadedAt) so the drill-down list can't drift
+    // out of sync with the tile's run count.
+    final cutoff = widget.data.loadedAt.subtract(_window);
+    final runs = widget.data.ciRunSamples
+        .where(
+          (s) =>
+              s.repoKey == trend.repoKey &&
+              s.groupKey == trend.groupKey &&
+              (s.finishedAt == null || !s.finishedAt!.isBefore(cutoff)),
+        )
+        .toList();
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => CiWorkflowDetailPage(trend: trend, samples: runs),
+      ),
     );
   }
 }
 
 class _TrendTile extends StatelessWidget {
-  const _TrendTile({required this.trend});
+  const _TrendTile({required this.trend, required this.onTap});
 
   final CiWorkflowTrend trend;
+  final VoidCallback onTap;
 
   ({String label, Color color})? _badge() {
     if (trend.isChronicallyFailing) {
@@ -89,13 +151,12 @@ class _TrendTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final badge = _badge();
-    final url = trend.url;
     final ratePct = (trend.failureRate * 100).round();
 
     return Card(
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: url == null ? null : () => openUrl(url),
+        onTap: onTap,
         child: Padding(
           padding: const EdgeInsets.all(12),
           child: Column(
@@ -121,6 +182,12 @@ class _TrendTile extends StatelessWidget {
                   ),
                   if (badge != null)
                     _Badge(label: badge.label, color: badge.color),
+                  const SizedBox(width: 4),
+                  Icon(
+                    Icons.chevron_right,
+                    size: 18,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ],
               ),
               const SizedBox(height: 2),

--- a/lib/views/ci_workflow_detail_page.dart
+++ b/lib/views/ci_workflow_detail_page.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+
+import '../ci_run_history.dart';
+import 'views_common.dart';
+
+/// A drill-down for one workflow/pipeline: its rolled-up stats plus a list of
+/// the individual runs behind them (newest first), each tappable to its run
+/// page. Pure — it's handed the already-loaded [samples] for this workflow.
+class CiWorkflowDetailPage extends StatelessWidget {
+  const CiWorkflowDetailPage({
+    super.key,
+    required this.trend,
+    required this.samples,
+  });
+
+  final CiWorkflowTrend trend;
+
+  /// The runs for this workflow within the selected window, any order.
+  final List<CiRunSample> samples;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final runs = [...samples]
+      ..sort((a, b) {
+        final af = a.finishedAt;
+        final bf = b.finishedAt;
+        if (af == null && bf == null) return 0;
+        if (af == null) return -1;
+        if (bf == null) return 1;
+        return bf.compareTo(af);
+      });
+    final ratePct = (trend.failureRate * 100).round();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(trend.workflow),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(20),
+          child: Padding(
+            padding: const EdgeInsets.only(left: 16, bottom: 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                trend.repoDisplay,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: Row(
+              children: [
+                _Stat(label: 'Failure rate', value: '$ratePct%'),
+                _Stat(label: 'Runs', value: '${trend.total}'),
+                _Stat(label: 'Flips', value: '${trend.flips}'),
+                if (trend.isFlaky)
+                  const _Stat(label: 'Verdict', value: 'Flaky')
+                else if (trend.isChronicallyFailing)
+                  const _Stat(label: 'Verdict', value: 'Failing')
+                else
+                  const _Stat(label: 'Verdict', value: 'OK'),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: runs.isEmpty
+                ? const ViewEmpty(message: 'No runs in this window.')
+                : ListView.separated(
+                    itemCount: runs.length,
+                    separatorBuilder: (_, _) => const Divider(height: 1),
+                    itemBuilder: (context, i) => _RunTile(run: runs[i]),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Stat extends StatelessWidget {
+  const _Stat({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            value,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RunTile extends StatelessWidget {
+  const _RunTile({required this.run});
+
+  final CiRunSample run;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final url = run.url;
+    final when = run.finishedAt;
+    final subtitleParts = <String>[
+      if (run.conclusion.isNotEmpty) run.conclusion,
+      if (when != null) relativeTime(when),
+      if (run.branch != null && run.branch!.isNotEmpty) run.branch!,
+    ];
+    return ListTile(
+      leading: Icon(ciIcon(run.outcome), color: ciColor(run.outcome)),
+      title: Text(ciLabel(run.outcome)),
+      subtitle: subtitleParts.isEmpty
+          ? null
+          : Text(
+              subtitleParts.join(' · '),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall,
+            ),
+      trailing: url == null ? null : const Icon(Icons.open_in_new, size: 16),
+      onTap: url == null ? null : () => openUrl(url),
+    );
+  }
+}

--- a/lib/views/ci_workflow_detail_page.dart
+++ b/lib/views/ci_workflow_detail_page.dart
@@ -58,7 +58,7 @@ class CiWorkflowDetailPage extends StatelessWidget {
             child: Row(
               children: [
                 _Stat(label: 'Failure rate', value: '$ratePct%'),
-                _Stat(label: 'Runs', value: '${trend.total}'),
+                _Stat(label: 'Completed', value: '${trend.total}'),
                 _Stat(label: 'Flips', value: '${trend.flips}'),
                 if (trend.isFlaky)
                   const _Stat(label: 'Verdict', value: 'Flaky')

--- a/lib/views/ci_workflow_detail_page.dart
+++ b/lib/views/ci_workflow_detail_page.dart
@@ -26,8 +26,10 @@ class CiWorkflowDetailPage extends StatelessWidget {
         final af = a.finishedAt;
         final bf = b.finishedAt;
         if (af == null && bf == null) return 0;
-        if (af == null) return -1;
-        if (bf == null) return 1;
+        // Newest first; a run with no finish time sorts last (its time is
+        // unknown, so it isn't "newest").
+        if (af == null) return 1;
+        if (bf == null) return -1;
         return bf.compareTo(af);
       });
     final ratePct = (trend.failureRate * 100).round();

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -176,12 +176,12 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       // Record a trend snapshot from this load too (deduped ~1/day), matching
       // Radar/Teams/Digest, so opening Insights also advances trend history.
       await MetricStore.capture(activities, restrictToMonitored: true);
-      // Accumulate this fetch's CI runs, then read back the rolled-up trends so
-      // the CI trends view reflects the freshest history.
+      // Accumulate this fetch's CI runs, then read back the raw history so the
+      // CI trends view can aggregate per its selected window.
       await CiRunHistoryStore.recordSafely(
         activities.expand((a) => a.recentRuns),
       );
-      final ciTrends = await CiRunHistoryStore.trends();
+      final ciRunSamples = await CiRunHistoryStore.allSamples();
       final history = await MetricStore.all();
       final teams = await TeamStore.list();
       final rollups = TeamService.rollupAll(teams, activities);
@@ -193,7 +193,7 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
           teams: teams,
           rollups: rollups,
           people: people,
-          ciTrends: ciTrends,
+          ciRunSamples: ciRunSamples,
           loadedAt: DateTime.now(),
         );
         _loading = false;

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -20,7 +20,7 @@ class InsightsData {
     required List<Team> teams,
     required Map<String, TeamRollup> rollups,
     required List<Person> people,
-    List<CiWorkflowTrend> ciTrends = const [],
+    List<CiRunSample> ciRunSamples = const [],
     required this.loadedAt,
   }) : activities = List.unmodifiable(activities),
        history = Map.unmodifiable({
@@ -32,7 +32,7 @@ class InsightsData {
          for (final e in rollups.entries) e.key: _readonlyRollup(e.value),
        }),
        people = List.unmodifiable(people),
-       ciTrends = List.unmodifiable(ciTrends);
+       ciRunSamples = List.unmodifiable(ciRunSamples);
 
   final List<RepoActivity> activities;
   final Map<String, List<MetricSnapshot>> history;
@@ -40,9 +40,9 @@ class InsightsData {
   final Map<String, TeamRollup> rollups;
   final List<Person> people;
 
-  /// Per-workflow CI trends (failure rate + flakiness), worst-first, from the
-  /// accumulated run history. Empty until the sync/insights load records runs.
-  final List<CiWorkflowTrend> ciTrends;
+  /// Raw CI run history (default-branch, bounded by retention) from which the
+  /// CI trends view aggregates per-workflow trends for a user-chosen window.
+  final List<CiRunSample> ciRunSamples;
   final DateTime loadedAt;
 
   /// Repos whose fetch succeeded (errored repos would read as healthy zeros).

--- a/test/activity_service_test.dart
+++ b/test/activity_service_test.dart
@@ -168,6 +168,72 @@ void main() {
     },
   );
 
+  test('ciRunSamplesFromGithubRuns keeps only default-branch runs', () {
+    final samples = ActivityService.ciRunSamplesFromGithubRuns(
+      {
+        'workflow_runs': [
+          {
+            'id': 1,
+            'workflow_id': 7,
+            'name': 'CI',
+            'status': 'completed',
+            'conclusion': 'success',
+            'head_branch': 'main',
+            'updated_at': '2026-03-01T10:00:00Z',
+            'repository': {'default_branch': 'main'},
+          },
+          {
+            'id': 2,
+            'workflow_id': 7,
+            'name': 'CI',
+            'status': 'completed',
+            'conclusion': 'failure',
+            'head_branch': 'feature/x',
+            'updated_at': '2026-03-01T09:00:00Z',
+            'repository': {'default_branch': 'main'},
+          },
+        ],
+      },
+      repoKey: 'github:o/r',
+      repoDisplay: 'o/r',
+    );
+    // The feature-branch run is dropped; only the default-branch run is kept.
+    expect(samples, hasLength(1));
+    expect(samples.single.runKey, 'github:o/r:1:1');
+    expect(samples.single.branch, 'main');
+  });
+
+  test(
+    'ciRunSamplesFromGithubRuns keeps all branches when default unknown',
+    () {
+      final samples = ActivityService.ciRunSamplesFromGithubRuns(
+        {
+          'workflow_runs': [
+            {
+              'id': 1,
+              'name': 'CI',
+              'status': 'completed',
+              'conclusion': 'success',
+              'head_branch': 'main',
+              'updated_at': '2026-03-01T10:00:00Z',
+            },
+            {
+              'id': 2,
+              'name': 'CI',
+              'status': 'completed',
+              'conclusion': 'failure',
+              'head_branch': 'feature/x',
+              'updated_at': '2026-03-01T09:00:00Z',
+            },
+          ],
+        },
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      );
+      expect(samples, hasLength(2));
+    },
+  );
+
   test('githubRunOutcome buckets conclusions; cancelled is not a failure', () {
     expect(
       ActivityService.githubRunOutcome({'conclusion': 'success'}),
@@ -234,6 +300,24 @@ void main() {
     },
   );
 
+  test('defaultBranchFromGithubRuns reads the default branch from a run', () {
+    expect(
+      ActivityService.defaultBranchFromGithubRuns({
+        'workflow_runs': [
+          {
+            'id': 1,
+            'repository': {'default_branch': 'trunk'},
+          },
+        ],
+      }),
+      'trunk',
+    );
+    expect(
+      ActivityService.defaultBranchFromGithubRuns({'workflow_runs': []}),
+      isNull,
+    );
+  });
+
   test('ciRunSamplesFromAdoBuilds parses builds, skips id-less', () {
     final samples = ActivityService.ciRunSamplesFromAdoBuilds(
       {
@@ -263,6 +347,44 @@ void main() {
     expect(samples.single.workflowId, '3');
     expect(samples.single.outcome, CiOutcome.success);
     expect(samples.single.url, contains('buildId=55'));
+  });
+
+  test('ciRunSamplesFromAdoBuilds filters to the default branch', () {
+    final json = {
+      'value': [
+        {
+          'id': 55,
+          'definition': {'id': 3, 'name': 'Pipeline'},
+          'status': 'completed',
+          'result': 'succeeded',
+          'sourceBranch': 'refs/heads/main',
+          'finishTime': '2026-03-01T10:00:00Z',
+        },
+        {
+          'id': 56,
+          'definition': {'id': 3, 'name': 'Pipeline'},
+          'status': 'completed',
+          'result': 'failed',
+          'sourceBranch': 'refs/heads/topic',
+          'finishTime': '2026-03-01T09:00:00Z',
+        },
+      ],
+    };
+    final scoped = ActivityService.ciRunSamplesFromAdoBuilds(
+      json,
+      repoKey: 'ado:o/p/r',
+      repoDisplay: 'o/p/r',
+      defaultBranch: 'refs/heads/main',
+    );
+    expect(scoped, hasLength(1));
+    expect(scoped.single.runKey, 'ado:o/p/r:55');
+    // No default supplied -> keep both branches.
+    final all = ActivityService.ciRunSamplesFromAdoBuilds(
+      json,
+      repoKey: 'ado:o/p/r',
+      repoDisplay: 'o/p/r',
+    );
+    expect(all, hasLength(2));
   });
 
   test('ADO PR helpers parse authors review needs and age', () {
@@ -346,7 +468,7 @@ void main() {
       }
 
       if (request.url.path == '/repos/acme/kode/actions/runs') {
-        expect(request.url.queryParameters['per_page'], '20');
+        expect(request.url.queryParameters['per_page'], '50');
         return http.Response(
           jsonEncode({
             'workflow_runs': [
@@ -383,6 +505,161 @@ void main() {
     expect(activity.recentRuns.single.runKey, 'github:acme/kode:1:1');
     expect(activity.error, isNull);
   });
+
+  test('computeForGithub does a branch-scoped follow-up when the page has no '
+      'completed default-branch run', () async {
+    var scopedCalls = 0;
+    final client = MockClient((request) async {
+      if (request.url.path == '/repos/acme/kode/pulls') {
+        return http.Response(jsonEncode([]), 200);
+      }
+      if (request.url.path == '/repos/acme/kode/actions/runs') {
+        final branch = request.url.queryParameters['branch'];
+        if (branch == null) {
+          // A full (50) page: 49 PR-branch failures (dropped from trends) plus
+          // one IN-PROGRESS default-branch run. recentRuns is therefore
+          // non-empty but has no completed/persistable run, which must still
+          // trigger the follow-up (the old `recentRuns.isEmpty` trigger would
+          // have wrongly skipped it). Newest run drives ciStatus = failure.
+          return http.Response(
+            jsonEncode({
+              'workflow_runs': [
+                for (var i = 0; i < 49; i++)
+                  {
+                    'id': 100 + i,
+                    'name': 'CI',
+                    'status': 'completed',
+                    'conclusion': 'failure',
+                    'head_branch': 'feature/x',
+                    'updated_at': '2026-03-01T10:00:00Z',
+                    'repository': {'default_branch': 'main'},
+                  },
+                {
+                  'id': 149,
+                  'name': 'CI',
+                  'status': 'in_progress',
+                  'conclusion': null,
+                  'head_branch': 'main',
+                  'updated_at': '2026-03-01T10:30:00Z',
+                  'repository': {'default_branch': 'main'},
+                },
+              ],
+            }),
+            200,
+          );
+        }
+        scopedCalls++;
+        expect(branch, 'main');
+        return http.Response(
+          jsonEncode({
+            'workflow_runs': [
+              {
+                'id': 10,
+                'name': 'CI',
+                'status': 'completed',
+                'conclusion': 'success',
+                'head_branch': 'main',
+                'updated_at': '2026-03-01T09:00:00Z',
+                'repository': {'default_branch': 'main'},
+              },
+            ],
+          }),
+          200,
+        );
+      }
+      return http.Response('not found', 404);
+    });
+
+    final activity = await ActivityService.computeForGithub(
+      owner: 'acme',
+      name: 'kode',
+      secret: 'secret',
+      repoKey: 'github:acme/kode',
+      client: client,
+    );
+
+    expect(scopedCalls, 1);
+    // ciStatus comes only from the first (all-branch) page...
+    expect(activity.ciStatus, 'failure');
+    // ...while the trend sample comes from the scoped default-branch page.
+    expect(activity.recentRuns.single.runKey, 'github:acme/kode:10:1');
+    expect(activity.recentRuns.single.branch, 'main');
+  });
+
+  test(
+    'computeForAdo scopes the trend follow-up to the default branch',
+    () async {
+      var scopedBuildCalls = 0;
+      final client = MockClient((request) async {
+        final path = request.url.path;
+        if (path.endsWith('/pullrequests')) {
+          return http.Response(jsonEncode({'value': []}), 200);
+        }
+        if (path.endsWith('/git/repositories/kode')) {
+          return http.Response(
+            jsonEncode({'id': 'guid-1', 'defaultBranch': 'refs/heads/main'}),
+            200,
+          );
+        }
+        if (path.endsWith('/build/builds')) {
+          final branchName = request.url.queryParameters['branchName'];
+          if (branchName == null) {
+            // Full (50) all-branch page, all PR-branch failures.
+            return http.Response(
+              jsonEncode({
+                'value': [
+                  for (var i = 0; i < 50; i++)
+                    {
+                      'id': 200 + i,
+                      'definition': {'id': 1, 'name': 'Pipeline'},
+                      'status': 'completed',
+                      'result': 'failed',
+                      'sourceBranch': 'refs/heads/topic',
+                      'finishTime': '2026-03-01T10:00:00Z',
+                    },
+                ],
+              }),
+              200,
+            );
+          }
+          scopedBuildCalls++;
+          expect(branchName, 'refs/heads/main');
+          return http.Response(
+            jsonEncode({
+              'value': [
+                {
+                  'id': 300,
+                  'definition': {'id': 1, 'name': 'Pipeline'},
+                  'status': 'completed',
+                  'result': 'succeeded',
+                  'sourceBranch': 'refs/heads/main',
+                  'finishTime': '2026-03-01T09:00:00Z',
+                },
+              ],
+            }),
+            200,
+          );
+        }
+        return http.Response('not found', 404);
+      });
+
+      final activity = await ActivityService.computeForAdo(
+        organization: 'org',
+        project: 'proj',
+        name: 'kode',
+        secret: 'secret',
+        repoKey: 'ado:org/proj/kode',
+        client: client,
+      );
+
+      expect(scopedBuildCalls, 1);
+      // ciStatus from the all-branch page (failed); trend sample from the scoped
+      // default-branch page (succeeded).
+      expect(activity.ciStatus, 'failure');
+      expect(activity.recentRuns.single.runKey, 'ado:org/proj/kode:300');
+      expect(activity.recentRuns.single.outcome, CiOutcome.success);
+    },
+  );
 
   group('computeAll onlyRepoKeys', () {
     setUp(() {

--- a/test/ci_run_history_store_test.dart
+++ b/test/ci_run_history_store_test.dart
@@ -219,4 +219,60 @@ void main() {
       await upgraded.close();
     },
   );
+
+  test('allSamples returns every stored run', () async {
+    final now = DateTime.utc(2026, 1, 11);
+    await CiRunHistoryStore.record([
+      _sample('build', runKey: 'github:owner/name:1'),
+      _sample(
+        'build',
+        runKey: 'github:owner/name:2',
+        outcome: CiOutcome.failure,
+        conclusion: 'failure',
+      ),
+    ], now: now);
+    final samples = await CiRunHistoryStore.allSamples();
+    expect(samples, hasLength(2));
+    expect(samples.map((s) => s.runKey).toSet(), {
+      'github:owner/name:1',
+      'github:owner/name:2',
+    });
+  });
+
+  test('v10 -> v11 upgrade clears the derived CI history cache', () async {
+    // A v10 database with an existing (all-branch) row: opening AppDatabase
+    // (now v11) must run onUpgrade(10 -> 11) and clear the derived cache so the
+    // new default-branch-only semantics start clean.
+    final native = sqlite3.openInMemory();
+    native.execute('''
+      CREATE TABLE ci_run_history (
+        id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        provider TEXT NOT NULL,
+        repo_key TEXT NOT NULL,
+        repo_display TEXT NOT NULL,
+        workflow TEXT NOT NULL,
+        workflow_id TEXT,
+        run_key TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        conclusion TEXT NOT NULL,
+        branch TEXT,
+        finished_at INTEGER,
+        url TEXT
+      );
+    ''');
+    native.execute(
+      "INSERT INTO ci_run_history "
+      "(provider, repo_key, repo_display, workflow, run_key, outcome, conclusion, finished_at) "
+      "VALUES ('github','github:o/r','o/r','CI','github:o/r:1:1','success','success',1000);",
+    );
+    native.execute('PRAGMA user_version = 10;');
+    final upgraded = AppDatabase.forExecutor(
+      NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+    );
+    CiRunHistoryStore.debugUseDatabase(upgraded);
+
+    final samples = await CiRunHistoryStore.allSamples();
+    expect(samples, isEmpty, reason: 'the pre-v11 all-branch cache is cleared');
+    await upgraded.close();
+  });
 }

--- a/test/ci_run_history_test.dart
+++ b/test/ci_run_history_test.dart
@@ -129,6 +129,36 @@ void main() {
       expect(trends.firstWhere((t) => t.total == 1).successes, 1);
     });
 
+    test('a workflow id does not collide with an id-less same-string name', () {
+      final trends = CiWorkflowTrend.aggregate([
+        // workflowId "5" ...
+        CiRunSample(
+          provider: 'github',
+          repoKey: 'github:o/r',
+          repoDisplay: 'o/r',
+          workflow: 'Deploy',
+          workflowId: '5',
+          runKey: 'github:o/r:a',
+          outcome: CiOutcome.success,
+          conclusion: 'success',
+          finishedAt: ago(1),
+        ),
+        // ... vs an id-less workflow literally named "5".
+        CiRunSample(
+          provider: 'github',
+          repoKey: 'github:o/r',
+          repoDisplay: 'o/r',
+          workflow: '5',
+          runKey: 'github:o/r:b',
+          outcome: CiOutcome.failure,
+          conclusion: 'failure',
+          finishedAt: ago(2),
+        ),
+      ], now: base);
+      // Namespaced group keys keep them separate.
+      expect(trends, hasLength(2));
+    });
+
     test('small samples rank below a confident chronic failure', () {
       final trends = CiWorkflowTrend.aggregate([
         // 2-run 100% fail: high rate but low confidence.

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -124,10 +124,12 @@ InsightsData _sampleData() {
           runKey: 'github:acme/kode:$i',
           outcome: i.isEven ? CiOutcome.success : CiOutcome.failure,
           conclusion: i.isEven ? 'success' : 'failure',
-          finishedAt: DateTime.now().subtract(Duration(days: i)),
+          // Within the default 30-day window of the fixed loadedAt below, so
+          // the view renders populated deterministically (no wall-clock).
+          finishedAt: DateTime.utc(2026, 3, 1, 12).subtract(Duration(days: i)),
         ),
     ],
-    loadedAt: DateTime.now(),
+    loadedAt: DateTime.utc(2026, 3, 1, 13),
   );
 }
 

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -113,19 +113,20 @@ InsightsData _sampleData() {
         reviewRequests: 2,
       ),
     ],
-    ciTrends: CiWorkflowTrend.aggregate([
+    ciRunSamples: [
       for (var i = 0; i < 4; i++)
         CiRunSample(
           provider: 'github',
           repoKey: 'github:acme/kode',
           repoDisplay: 'acme/kode',
           workflow: 'CI',
+          workflowId: '1',
           runKey: 'github:acme/kode:$i',
           outcome: i.isEven ? CiOutcome.success : CiOutcome.failure,
           conclusion: i.isEven ? 'success' : 'failure',
-          finishedAt: DateTime.utc(2026, 3, 1, 12 - i),
+          finishedAt: DateTime.now().subtract(Duration(days: i)),
         ),
-    ], now: DateTime.utc(2026, 3, 1, 13)),
+    ],
     loadedAt: DateTime.now(),
   );
 }


### PR DESCRIPTION
## What

Three follow-ups to the CI-trends insight (PR #43):

1. **Default-branch scoping** — trends now reflect only the repo's **default branch**, so PR/feature-branch runs (which legitimately fail) no longer inflate a workflow's failure rate / flakiness.
2. **History window selector** — the CI trends view has a **7 / 30 / 90-day** toggle.
3. **Workflow drill-down** — tapping a workflow opens a page listing its individual runs.

## How

- **Default-branch scoping** (`lib/activity_service.dart`): the run parsers keep only default-branch runs.
  - GitHub: default branch read from each run's `repository.default_branch` in the `/actions/runs` payload (no extra call in the common case).
  - ADO: default branch read from the repository GET already performed (`defaultBranch`).
  - `ciStatus` (the CI health board) is **unchanged** — still all-branch, newest-run based, sourced only from the first (unscoped) response.
  - **Anti-starvation:** the run page is widened (`per_page`/`$top` 20→50); if that page has **no completed default-branch run** *and* was full (≥50, i.e. truncated), one **branch-scoped follow-up** fetch runs *just for trend samples* (`/actions/runs?branch=…` / `builds?branchName=…`). So a main-branch run pushed past the window by a PR-run burst is still captured. Normal repos do a single call.
- **Retention + window** (`lib/ci_run_history_store.dart`, `lib/database/app_database.dart`): retention 45→90 days, per-repo cap 400→600 (default-branch-only volume is far lower). New `allSamples()`. The view holds the raw samples and re-aggregates client-side via the pure `CiWorkflowTrend.aggregate(samples, window:)` for the selected window (single `loadedAt` anchor shared with the drill-down). **schemaVersion 10→11** clears the now-differently-scoped derived cache (`DELETE FROM ci_run_history`; it re-populates from the API).
- **Drill-down** (`lib/views/ci_trends_view.dart` now stateful, new `lib/views/ci_workflow_detail_page.dart`): tapping a trend filters the raw samples by `repoKey` + `groupKey` within the window and pushes a run list (outcome/branch/time, tappable to the run URL) with stats. `CiWorkflowTrend` gained `workflowId` + a **namespaced** `groupKey` (`id:` vs `name:`) so an id can't collide with another workflow's name.

## Review gate

code-review (no significant issues) + rubber-duck pre-open. Rubber-duck drove several fixes: the anti-starvation follow-up (page-widening alone wasn't enough), the follow-up trigger keying off *completed persistable* runs (not just `recentRuns.isEmpty`, so an in-progress default-branch run still triggers it) gated on a full page, a single `loadedAt` time anchor for aggregation + drill-down, and the namespaced group keys.

## Tests

Parser default-branch filtering (both providers), `defaultBranchFromGithubRuns`, GitHub **and** ADO integration tests for the branch-scoped follow-up (asserts it fires once, `ciStatus` stays all-branch, trend sample = the default-branch run) including the in-progress-default-branch regression case, `allSamples`, the v10→v11 cache-clear migration, group-key collision, and the view smoke test. `dart format` clean, `flutter analyze --fatal-infos` clean, all 384 tests pass.
