### PR TITLE
Smarter notifications: per-category & mine-only control + approved category

### DIFF
--- a/lib/attention_inbox_page.dart
+++ b/lib/attention_inbox_page.dart
@@ -548,6 +548,8 @@ class _AttentionInboxPageState extends State<AttentionInboxPage> {
         return (icon: Icons.rate_review, color: Colors.orange);
       case 'changesRequested':
         return (icon: Icons.edit_note, color: Colors.red);
+      case 'approved':
+        return (icon: Icons.check_circle, color: Colors.green);
       case 'oldOpenPr':
         return (icon: Icons.schedule, color: Colors.blueGrey);
       case 'error':

--- a/lib/attention_service.dart
+++ b/lib/attention_service.dart
@@ -202,9 +202,9 @@ class AttentionService {
       final changesRequested =
           decision == 'CHANGES_REQUESTED' ||
           _hasChangesRequestedReview(pr['latestOpinionatedReviews']);
-      // Approved & ready to merge: the required review decision is APPROVED, or
-      // (on repos without required reviews, where decision is null) an author
-      // left an approving review and none requested changes.
+      // Approved: the required review decision is APPROVED, or (on repos
+      // without required reviews, where decision is null) at least one
+      // approving review exists and none requested changes.
       final approved =
           decision == 'APPROVED' ||
           (decision == null &&
@@ -314,7 +314,7 @@ class AttentionService {
     return false;
   }
 
-  /// True when any author's latest opinionated review is APPROVED — used to
+  /// True when any reviewer's latest opinionated review is APPROVED — used to
   /// detect an approved PR on repos without required reviews (null decision).
   static bool _hasApprovingReview(dynamic latestOpinionatedReviews) {
     final nodes = latestOpinionatedReviews is Map

--- a/lib/attention_service.dart
+++ b/lib/attention_service.dart
@@ -204,11 +204,13 @@ class AttentionService {
           _hasChangesRequestedReview(pr['latestOpinionatedReviews']);
       // Approved: the required review decision is APPROVED, or (on repos
       // without required reviews, where decision is null) at least one
-      // approving review exists and none requested changes.
+      // approving review exists — and, in either case, no changes are
+      // requested (folded in so the flag stands on its own).
       final approved =
-          decision == 'APPROVED' ||
-          (decision == null &&
-              _hasApprovingReview(pr['latestOpinionatedReviews']));
+          !changesRequested &&
+          (decision == 'APPROVED' ||
+              (decision == null &&
+                  _hasApprovingReview(pr['latestOpinionatedReviews'])));
 
       final reviewRequests = pr['reviewRequests'];
       final pendingCount =

--- a/lib/attention_service.dart
+++ b/lib/attention_service.dart
@@ -25,7 +25,8 @@ class AttentionItem {
   /// Stable identity for the item (enables list keys and future snooze).
   final String id;
 
-  /// One of: `reviewRequested`, `changesRequested`, `oldOpenPr`, `error`.
+  /// One of: `reviewRequested`, `changesRequested`, `approved`, `oldOpenPr`,
+  /// `error`.
   final String category;
 
   /// Higher = more urgent (used for ranking). Category dominates age.
@@ -108,8 +109,9 @@ class AttentionService {
 
   // Category tiers; severity = tier * 1000 + age, so category always dominates
   // age in ranking while older items still sort first within a category.
-  static const int _tierReviewRequested = 3;
-  static const int _tierChangesRequested = 2;
+  static const int _tierReviewRequested = 4;
+  static const int _tierChangesRequested = 3;
+  static const int _tierApproved = 2;
   static const int _tierOldOpen = 1;
   static const int _tierError = 0;
 
@@ -122,14 +124,26 @@ class AttentionService {
   static const List<String> categories = [
     'reviewRequested',
     'changesRequested',
+    'approved',
     'oldOpenPr',
     'error',
+  ];
+
+  /// Categories that can actually raise a notification, for the notification
+  /// settings UI. Excludes `error`: error items appear in the inbox but are
+  /// stripped before the notification gate, so a toggle for them would be inert.
+  static const List<String> notifiableCategories = [
+    'reviewRequested',
+    'changesRequested',
+    'approved',
+    'oldOpenPr',
   ];
 
   /// A short, human-readable label for an attention [category].
   static String categoryLabel(String category) => switch (category) {
     'reviewRequested' => 'Review requested',
     'changesRequested' => 'Changes requested',
+    'approved' => 'Approved',
     'oldOpenPr' => 'Old open',
     'error' => 'Errors',
     _ => category,
@@ -188,6 +202,13 @@ class AttentionService {
       final changesRequested =
           decision == 'CHANGES_REQUESTED' ||
           _hasChangesRequestedReview(pr['latestOpinionatedReviews']);
+      // Approved & ready to merge: the required review decision is APPROVED, or
+      // (on repos without required reviews, where decision is null) an author
+      // left an approving review and none requested changes.
+      final approved =
+          decision == 'APPROVED' ||
+          (decision == null &&
+              _hasApprovingReview(pr['latestOpinionatedReviews']));
 
       final reviewRequests = pr['reviewRequests'];
       final pendingCount =
@@ -195,10 +216,11 @@ class AttentionService {
           ? reviewRequests['totalCount'] as int
           : 0;
       final reviewerLogins = _requestedReviewerLogins(reviewRequests);
+      final authoredByMe =
+          self.isNotEmpty && self.contains(author.trim().toLowerCase());
       final mine =
-          self.isNotEmpty &&
-          (self.contains(author.trim().toLowerCase()) ||
-              reviewerLogins.any(self.contains));
+          authoredByMe ||
+          (self.isNotEmpty && reviewerLogins.any(self.contains));
 
       final label = 'PR #$number';
       if (changesRequested) {
@@ -212,6 +234,21 @@ class AttentionService {
             url,
             createdAt: createdAt,
             isMine: mine,
+          ),
+        );
+      } else if (authoredByMe && approved) {
+        // Only surface "approved" for the user's OWN PRs — merging is the
+        // author's action. (A satisfied required decision wins even if an
+        // optional reviewer is still pending.)
+        items.add(
+          _approved(
+            repoDisplay,
+            label,
+            title,
+            author,
+            age,
+            url,
+            createdAt: createdAt,
           ),
         );
       } else if (decision == 'REVIEW_REQUIRED' || pendingCount > 0) {
@@ -277,6 +314,19 @@ class AttentionService {
     return false;
   }
 
+  /// True when any author's latest opinionated review is APPROVED — used to
+  /// detect an approved PR on repos without required reviews (null decision).
+  static bool _hasApprovingReview(dynamic latestOpinionatedReviews) {
+    final nodes = latestOpinionatedReviews is Map
+        ? latestOpinionatedReviews['nodes']
+        : null;
+    if (nodes is! List) return false;
+    for (final n in nodes) {
+      if (n is Map && n['state'] == 'APPROVED') return true;
+    }
+    return false;
+  }
+
   /// Builds attention items for an Azure DevOps repo from its active PR list.
   static List<AttentionItem> adoItems({
     required String repoDisplay,
@@ -317,10 +367,11 @@ class AttentionService {
       }
       final changesRequested = votes.any((v) => v is int && v < 0);
       final waitingOnReview = votes.any((v) => v == 0);
+      final approved = votes.any((v) => v is int && v > 0);
+      final authoredByMe =
+          self.isNotEmpty && self.contains(author.trim().toLowerCase());
       final mine =
-          self.isNotEmpty &&
-          (self.contains(author.trim().toLowerCase()) ||
-              reviewerNames.any(self.contains));
+          authoredByMe || (self.isNotEmpty && reviewerNames.any(self.contains));
 
       if (changesRequested) {
         items.add(
@@ -346,6 +397,19 @@ class AttentionService {
             url,
             createdAt: createdAt,
             isMine: mine,
+          ),
+        );
+      } else if (authoredByMe && approved) {
+        // My own PR has an approval and nothing pending/rejected.
+        items.add(
+          _approved(
+            repoDisplay,
+            'PR #$id',
+            title,
+            author,
+            age,
+            url,
+            createdAt: createdAt,
           ),
         );
       } else if ((age ?? 0) > oldOpenPrDays) {
@@ -413,6 +477,31 @@ class AttentionService {
       ageDays: ageDays,
       createdAt: createdAt,
       isMine: isMine,
+    );
+  }
+
+  static AttentionItem _approved(
+    String repoDisplay,
+    String prLabel,
+    String title,
+    String author,
+    int? ageDays,
+    String? url, {
+    DateTime? createdAt,
+  }) {
+    return AttentionItem(
+      id: 'approved:$repoDisplay:$prLabel',
+      category: 'approved',
+      severity: _severity(_tierApproved, ageDays),
+      titleTemplate: '$prLabel approved',
+      subtitleTemplate:
+          '$repoDisplay · $title · opened ${AttentionItem.ageToken} by $author',
+      repoDisplay: repoDisplay,
+      url: url,
+      ageDays: ageDays,
+      createdAt: createdAt,
+      // Only surfaced for the user's own PRs.
+      isMine: true,
     );
   }
 

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -126,12 +126,20 @@ class NotificationService {
       // Read the muted repos once: used both to filter notifications and to
       // still advance the baseline for muted items during quiet hours (below).
       final muted = await MuteStore.mutedDisplays();
+      final silenced = appPrefs.silencedNotifyCategories;
+      final mineOnly = appPrefs.notifyMineOnly;
 
       if (newIds.isNotEmpty &&
           PreferencesStore.notificationsAllowed(appPrefs, now)) {
-        // Exclude items from muted repos (their items still appear in the
-        // inbox; muting only suppresses the notification).
-        final newItems = notifiableItems(attention, newIds, muted);
+        // Exclude muted repos, silenced categories, and (when mine-only) items
+        // that aren't the user's — they still appear in the inbox.
+        final newItems = notifiableItems(
+          attention,
+          newIds,
+          mutedDisplays: muted,
+          silencedCategories: silenced,
+          mineOnly: mineOnly,
+        );
         await _showSummaryNotification(newItems);
       }
 
@@ -148,6 +156,9 @@ class NotificationService {
         currentIds: currentIds,
         items: attention,
         mutedDisplays: muted,
+        silencedCategories: silenced,
+        mineOnly: mineOnly,
+        notificationsEnabled: appPrefs.notificationsEnabled,
         firstRun: firstRun,
         inQuietHours: inQuietHours,
       );
@@ -166,45 +177,85 @@ class NotificationService {
     }
   }
 
-  /// The item ids to record into the seen baseline this cycle. Normally (first
-  /// run or outside quiet hours) that's every id in [currentIds]. During quiet
-  /// hours we defer unmuted items (hold their baseline so they notify after
-  /// quiet hours end) but still record muted items, so unmuting can't replay a
-  /// backlog that accrued while muted.
+  /// The item ids to record into the seen baseline this cycle.
+  ///
+  /// - Notifications fully off: drop the whole backlog (record every id) — never
+  ///   defer, or re-enabling notifications would replay everything held.
+  /// - Muted repos / silenced categories **drop**: record their baseline so
+  ///   un-muting or re-enabling the category never replays a backlog. (They also
+  ///   won't notify on becoming the user's — correct, they were silenced.)
+  /// - Mine-only **defers** a not-mine item — including on the first run — by
+  ///   NOT recording it, so if it later becomes the user's (e.g. they're added
+  ///   as a reviewer, same id) it's still unseen and can notify.
+  /// - Otherwise a would-notify item is seeded on the first run (so the existing
+  ///   backlog isn't announced on install) and recorded whenever it's actually
+  ///   notified; during quiet hours it's held to notify once quiet hours end.
   @visibleForTesting
   static Set<String> baselineIdsToRecord({
     required Set<String> currentIds,
     required List<AttentionItem> items,
     required Set<String> mutedDisplays,
+    required Set<String> silencedCategories,
+    required bool mineOnly,
+    required bool notificationsEnabled,
     required bool firstRun,
     required bool inQuietHours,
   }) {
-    if (firstRun || !inQuietHours) return currentIds;
-    return items
-        .where((item) => mutedDisplays.contains(item.repoDisplay))
-        .map((item) => item.id)
-        .toSet();
+    if (!notificationsEnabled) return currentIds;
+    final ids = <String>{};
+    for (final item in items) {
+      if (mutedDisplays.contains(item.repoDisplay) ||
+          silencedCategories.contains(item.category)) {
+        ids.add(item.id); // dropped: record so re-enabling can't replay
+        continue;
+      }
+      if (mineOnly && !item.isMine) continue; // deferred by audience
+      if (firstRun || !inQuietHours) ids.add(item.id); // seeded / notified
+    }
+    return ids;
   }
 
   static Set<String> diffNew(Set<String> seen, Iterable<String> current) =>
       current.toSet().difference(seen);
 
-  /// The items to actually notify about: those whose id is in [newIds] and whose
-  /// repo isn't in [mutedDisplays]. Muting suppresses only the notification —
-  /// the items still show in the inbox, and the seen baseline still advances.
+  /// The items to actually notify about: those whose id is in [newIds] and that
+  /// pass the notification filters ([notifiesFor]). Suppressed items still show
+  /// in the inbox, and the seen baseline still advances for them.
   @visibleForTesting
   static List<AttentionItem> notifiableItems(
     List<AttentionItem> items,
-    Set<String> newIds,
-    Set<String> mutedDisplays,
-  ) {
+    Set<String> newIds, {
+    required Set<String> mutedDisplays,
+    required Set<String> silencedCategories,
+    required bool mineOnly,
+  }) {
     return items
         .where(
           (item) =>
               newIds.contains(item.id) &&
-              !mutedDisplays.contains(item.repoDisplay),
+              notifiesFor(
+                item,
+                mutedDisplays: mutedDisplays,
+                silencedCategories: silencedCategories,
+                mineOnly: mineOnly,
+              ),
         )
         .toList(growable: false);
+  }
+
+  /// Whether [item] should raise a notification given the user's filters: its
+  /// repo isn't muted, its category isn't silenced, and — when [mineOnly] — it
+  /// concerns the user. Pure; the inbox is unaffected by any of these.
+  @visibleForTesting
+  static bool notifiesFor(
+    AttentionItem item, {
+    required Set<String> mutedDisplays,
+    required Set<String> silencedCategories,
+    required bool mineOnly,
+  }) {
+    return !mutedDisplays.contains(item.repoDisplay) &&
+        !silencedCategories.contains(item.category) &&
+        (!mineOnly || item.isMine);
   }
 
   /// The payload for a summary notification. When exactly one new item is being

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -220,7 +220,9 @@ class NotificationService {
 
   /// The items to actually notify about: those whose id is in [newIds] and that
   /// pass the notification filters ([notifiesFor]). Suppressed items still show
-  /// in the inbox, and the seen baseline still advances for them.
+  /// in the inbox; their seen baseline advances when they're dropped (muted /
+  /// silenced), but a not-mine item under mine-only is instead deferred so it
+  /// can still notify if it later becomes the user's (see [baselineIdsToRecord]).
   @visibleForTesting
   static List<AttentionItem> notifiableItems(
     List<AttentionItem> items,

--- a/lib/preferences_page.dart
+++ b/lib/preferences_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import 'attention_service.dart';
 import 'background_sync.dart';
 import 'background_sync_status_store.dart';
 import 'preferences_store.dart';
@@ -128,6 +129,59 @@ class _PreferencesPageState extends State<PreferencesPage>
                     },
                   ),
                 ],
+                SwitchListTile(
+                  title: const Text('Only my PRs & reviews'),
+                  subtitle: const Text(
+                    'Notify only for items you authored or were asked to '
+                    'review',
+                  ),
+                  value: _prefs.notifyMineOnly,
+                  onChanged: _prefs.notificationsEnabled
+                      ? (value) async {
+                          await PreferencesStore.setNotifyMineOnly(value);
+                          if (!mounted) return;
+                          setState(
+                            () =>
+                                _prefs = _prefs.copyWith(notifyMineOnly: value),
+                          );
+                        }
+                      : null,
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                  child: Text(
+                    'Notify me about',
+                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+                for (final category in AttentionService.notifiableCategories)
+                  SwitchListTile(
+                    dense: true,
+                    title: Text(AttentionService.categoryLabel(category)),
+                    value: !_prefs.silencedNotifyCategories.contains(category),
+                    onChanged: _prefs.notificationsEnabled
+                        ? (enabled) async {
+                            await PreferencesStore.setCategorySilenced(
+                              category,
+                              !enabled,
+                            );
+                            if (!mounted) return;
+                            setState(() {
+                              final next = {..._prefs.silencedNotifyCategories};
+                              if (enabled) {
+                                next.remove(category);
+                              } else {
+                                next.add(category);
+                              }
+                              _prefs = _prefs.copyWith(
+                                silencedNotifyCategories: next,
+                              );
+                            });
+                          }
+                        : null,
+                  ),
                 const Divider(),
                 _sectionHeader('Activity Feed'),
                 ListTile(

--- a/lib/preferences_store.dart
+++ b/lib/preferences_store.dart
@@ -11,6 +11,8 @@ class AppPreferences {
     this.quietEndHour = 8,
     this.feedLookbackDays = 14,
     this.backgroundSyncEnabled = true,
+    this.notifyMineOnly = false,
+    this.silencedNotifyCategories = const {},
   });
 
   final bool notificationsEnabled;
@@ -28,6 +30,15 @@ class AppPreferences {
   /// on iOS). Desktop keeps polling while running regardless.
   final bool backgroundSyncEnabled;
 
+  /// When true, only notify for attention items that concern the user (a PR
+  /// they authored or are a requested reviewer on). The inbox still shows all.
+  final bool notifyMineOnly;
+
+  /// Attention categories whose notifications are turned OFF (the empty default
+  /// notifies for every category — matching the prior behavior). Storing the
+  /// *silenced* set means a newly-added category notifies by default.
+  final Set<String> silencedNotifyCategories;
+
   AppPreferences copyWith({
     bool? notificationsEnabled,
     bool? quietHoursEnabled,
@@ -35,6 +46,8 @@ class AppPreferences {
     int? quietEndHour,
     int? feedLookbackDays,
     bool? backgroundSyncEnabled,
+    bool? notifyMineOnly,
+    Set<String>? silencedNotifyCategories,
   }) {
     return AppPreferences(
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
@@ -44,6 +57,9 @@ class AppPreferences {
       feedLookbackDays: feedLookbackDays ?? this.feedLookbackDays,
       backgroundSyncEnabled:
           backgroundSyncEnabled ?? this.backgroundSyncEnabled,
+      notifyMineOnly: notifyMineOnly ?? this.notifyMineOnly,
+      silencedNotifyCategories:
+          silencedNotifyCategories ?? this.silencedNotifyCategories,
     );
   }
 }
@@ -59,6 +75,9 @@ class PreferencesStore {
   static const String _quietEndHour = 'pref_quiet_end_hour';
   static const String _feedLookbackDays = 'pref_feed_lookback_days';
   static const String _backgroundSyncEnabled = 'pref_background_sync_enabled';
+  static const String _notifyMineOnly = 'pref_notify_mine_only';
+  static const String _silencedNotifyCategories =
+      'pref_notify_silenced_categories';
 
   /// Allowed lookback options shown in the UI.
   static const List<int> lookbackOptions = [7, 14, 30, 60];
@@ -91,6 +110,10 @@ class PreferencesStore {
       backgroundSyncEnabled:
           prefs.getBool(_backgroundSyncEnabled) ??
           defaults.backgroundSyncEnabled,
+      notifyMineOnly: prefs.getBool(_notifyMineOnly) ?? defaults.notifyMineOnly,
+      silencedNotifyCategories:
+          prefs.getStringList(_silencedNotifyCategories)?.toSet() ??
+          defaults.silencedNotifyCategories,
     );
   }
 
@@ -133,6 +156,32 @@ class PreferencesStore {
     return _runLocked(() async {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setInt(_feedLookbackDays, _sanitizeLookback(days));
+    });
+  }
+
+  static Future<void> setNotifyMineOnly(bool value) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_notifyMineOnly, value);
+    });
+  }
+
+  /// Turns notifications for [category] on ([silenced] false) or off (true),
+  /// persisting the updated silenced set.
+  static Future<void> setCategorySilenced(String category, bool silenced) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      final current =
+          prefs.getStringList(_silencedNotifyCategories)?.toSet() ?? <String>{};
+      if (silenced) {
+        current.add(category);
+      } else {
+        current.remove(category);
+      }
+      await prefs.setStringList(
+        _silencedNotifyCategories,
+        current.toList(growable: false),
+      );
     });
   }
 

--- a/lib/preferences_store.dart
+++ b/lib/preferences_store.dart
@@ -58,8 +58,9 @@ class AppPreferences {
       backgroundSyncEnabled:
           backgroundSyncEnabled ?? this.backgroundSyncEnabled,
       notifyMineOnly: notifyMineOnly ?? this.notifyMineOnly,
-      silencedNotifyCategories:
-          silencedNotifyCategories ?? this.silencedNotifyCategories,
+      silencedNotifyCategories: Set.unmodifiable(
+        silencedNotifyCategories ?? this.silencedNotifyCategories,
+      ),
     );
   }
 }
@@ -111,9 +112,10 @@ class PreferencesStore {
           prefs.getBool(_backgroundSyncEnabled) ??
           defaults.backgroundSyncEnabled,
       notifyMineOnly: prefs.getBool(_notifyMineOnly) ?? defaults.notifyMineOnly,
-      silencedNotifyCategories:
-          prefs.getStringList(_silencedNotifyCategories)?.toSet() ??
-          defaults.silencedNotifyCategories,
+      silencedNotifyCategories: Set.unmodifiable(
+        prefs.getStringList(_silencedNotifyCategories)?.toSet() ??
+            defaults.silencedNotifyCategories,
+      ),
     );
   }
 

--- a/test/attention_service_test.dart
+++ b/test/attention_service_test.dart
@@ -106,7 +106,7 @@ void main() {
     expect(approvedAged(40).single.category, 'oldOpenPr');
   });
 
-  test('GitHub: my APPROVED PR -> approved (ready to merge)', () {
+  test('GitHub: my APPROVED PR -> approved', () {
     final items = AttentionService.githubItems(
       repoDisplay: 'acme/api',
       now: now,

--- a/test/attention_service_test.dart
+++ b/test/attention_service_test.dart
@@ -106,6 +106,130 @@ void main() {
     expect(approvedAged(40).single.category, 'oldOpenPr');
   });
 
+  test('GitHub: my APPROVED PR -> approved (ready to merge)', () {
+    final items = AttentionService.githubItems(
+      repoDisplay: 'acme/api',
+      now: now,
+      selfGithubLogins: {'alice'},
+      prs: [
+        {
+          'number': 44,
+          'title': 'Ready',
+          'author': {'login': 'alice'},
+          'createdAt': daysAgo(2).toIso8601String(),
+          'url': 'https://github.com/acme/api/pull/44',
+          'reviewDecision': 'APPROVED',
+          'reviewRequests': {'totalCount': 0, 'nodes': []},
+        },
+      ],
+    );
+    expect(items.single.category, 'approved');
+    expect(items.single.isMine, isTrue);
+    expect(items.single.title, 'PR #44 approved');
+  });
+
+  test(
+    'GitHub: my PR approved via review on a null-decision repo -> approved',
+    () {
+      final items = AttentionService.githubItems(
+        repoDisplay: 'acme/api',
+        now: now,
+        selfGithubLogins: {'alice'},
+        prs: [
+          {
+            'number': 45,
+            'title': 'Ready',
+            'author': {'login': 'alice'},
+            'createdAt': daysAgo(1).toIso8601String(),
+            'reviewDecision': null,
+            'latestOpinionatedReviews': {
+              'nodes': [
+                {'state': 'APPROVED'},
+              ],
+            },
+            'reviewRequests': {'totalCount': 0, 'nodes': []},
+          },
+        ],
+      );
+      expect(items.single.category, 'approved');
+    },
+  );
+
+  test('ADO: my approved PR -> approved', () {
+    final items = AttentionService.adoItems(
+      repoDisplay: 'org/proj/repo',
+      organization: 'org',
+      project: 'proj',
+      name: 'repo',
+      now: now,
+      selfAdoNames: {'Ada'},
+      prs: [
+        {
+          'pullRequestId': 7,
+          'title': 'Ready',
+          'createdBy': {'displayName': 'Ada'},
+          'creationDate': daysAgo(1).toIso8601String(),
+          'reviewers': [
+            {'vote': 10, 'displayName': 'Reviewer'},
+          ],
+        },
+      ],
+    );
+    expect(items.single.category, 'approved');
+    expect(items.single.isMine, isTrue);
+  });
+
+  test('GitHub: a reviewer (not author) does not get approved', () {
+    final items = AttentionService.githubItems(
+      repoDisplay: 'acme/api',
+      now: now,
+      selfGithubLogins: {'bob'},
+      prs: [
+        {
+          'number': 46,
+          'title': 'Ready',
+          'author': {'login': 'alice'},
+          'createdAt': daysAgo(1).toIso8601String(),
+          'reviewDecision': 'APPROVED',
+          'reviewRequests': {
+            'totalCount': 1,
+            'nodes': [
+              {
+                'requestedReviewer': {'login': 'bob'},
+              },
+            ],
+          },
+        },
+      ],
+    );
+    // Bob is a requested reviewer, not the author -> not "approved".
+    expect(items.single.category, isNot('approved'));
+  });
+
+  test('ADO: a reviewer (not author) does not get approved', () {
+    final items = AttentionService.adoItems(
+      repoDisplay: 'org/proj/repo',
+      organization: 'org',
+      project: 'proj',
+      name: 'repo',
+      now: now,
+      selfAdoNames: {'Bob'},
+      prs: [
+        {
+          'pullRequestId': 8,
+          'title': 'Ready',
+          'createdBy': {'displayName': 'Ada'},
+          'creationDate': daysAgo(1).toIso8601String(),
+          'reviewers': [
+            {'vote': 10, 'displayName': 'Bob'},
+          ],
+        },
+      ],
+    );
+    // Bob reviewed (approved) Ada's PR, but isn't the author -> no item.
+    expect(items.where((i) => i.category == 'approved'), isEmpty);
+  });
+
   test('GitHub: REVIEW_REQUIRED decision -> reviewRequested', () {
     final items = AttentionService.githubItems(
       repoDisplay: 'acme/api',

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -250,13 +250,19 @@ void main() {
   });
 
   group('notifiableItems', () {
-    AttentionItem item(String id, String repo) => AttentionItem(
+    AttentionItem item(
+      String id,
+      String repo, {
+      String category = 'reviewRequested',
+      bool isMine = false,
+    }) => AttentionItem(
       id: id,
-      category: 'reviewRequested',
+      category: category,
       severity: 3000,
       titleTemplate: id,
       subtitleTemplate: '',
       repoDisplay: repo,
+      isMine: isMine,
     );
 
     test('excludes items from muted repos', () {
@@ -268,28 +274,70 @@ void main() {
       final result = NotificationService.notifiableItems(
         items,
         {'a', 'b', 'c'},
-        {'acme/api'},
+        mutedDisplays: {'acme/api'},
+        silencedCategories: const {},
+        mineOnly: false,
       );
       expect(result.map((i) => i.id), ['b']);
     });
 
-    test('keeps only new ids when nothing is muted', () {
+    test('keeps only new ids when nothing is filtered', () {
       final items = [item('a', 'acme/api'), item('b', 'acme/web')];
-      final result = NotificationService.notifiableItems(items, {
-        'a',
-      }, const {});
+      final result = NotificationService.notifiableItems(
+        items,
+        {'a'},
+        mutedDisplays: const {},
+        silencedCategories: const {},
+        mineOnly: false,
+      );
+      expect(result.map((i) => i.id), ['a']);
+    });
+
+    test('excludes items in silenced categories', () {
+      final items = [
+        item('a', 'acme/api', category: 'reviewRequested'),
+        item('b', 'acme/web', category: 'oldOpenPr'),
+      ];
+      final result = NotificationService.notifiableItems(
+        items,
+        {'a', 'b'},
+        mutedDisplays: const {},
+        silencedCategories: {'oldOpenPr'},
+        mineOnly: false,
+      );
+      expect(result.map((i) => i.id), ['a']);
+    });
+
+    test('mineOnly excludes items that are not the user\'s', () {
+      final items = [
+        item('a', 'acme/api', isMine: true),
+        item('b', 'acme/web', isMine: false),
+      ];
+      final result = NotificationService.notifiableItems(
+        items,
+        {'a', 'b'},
+        mutedDisplays: const {},
+        silencedCategories: const {},
+        mineOnly: true,
+      );
       expect(result.map((i) => i.id), ['a']);
     });
   });
 
   group('baselineIdsToRecord', () {
-    AttentionItem item(String id, String repo) => AttentionItem(
+    AttentionItem item(
+      String id,
+      String repo, {
+      String category = 'reviewRequested',
+      bool isMine = false,
+    }) => AttentionItem(
       id: id,
-      category: 'reviewRequested',
+      category: category,
       severity: 3000,
       titleTemplate: id,
       subtitleTemplate: '',
       repoDisplay: repo,
+      isMine: isMine,
     );
 
     final items = [item('a', 'acme/api'), item('b', 'acme/web')];
@@ -300,6 +348,9 @@ void main() {
           currentIds: {'a', 'b'},
           items: items,
           mutedDisplays: {'acme/api'},
+          silencedCategories: const {},
+          mineOnly: false,
+          notificationsEnabled: true,
           firstRun: false,
           inQuietHours: false,
         ),
@@ -313,10 +364,35 @@ void main() {
           currentIds: {'a', 'b'},
           items: items,
           mutedDisplays: const {},
+          silencedCategories: const {},
+          mineOnly: false,
+          notificationsEnabled: true,
           firstRun: true,
           inQuietHours: true,
         ),
         {'a', 'b'},
+      );
+    });
+
+    test('records all ids when notifications are disabled (drops backlog)', () {
+      // Master off: never defer, or re-enabling would replay the backlog — even
+      // the not-mine item under mine-only is recorded.
+      final mixed = [
+        item('mine', 'acme/api', isMine: true),
+        item('other', 'acme/web', isMine: false),
+      ];
+      expect(
+        NotificationService.baselineIdsToRecord(
+          currentIds: {'mine', 'other'},
+          items: mixed,
+          mutedDisplays: const {},
+          silencedCategories: const {},
+          mineOnly: true,
+          notificationsEnabled: false,
+          firstRun: false,
+          inQuietHours: false,
+        ),
+        {'mine', 'other'},
       );
     });
 
@@ -327,10 +403,89 @@ void main() {
           currentIds: {'a', 'b'},
           items: items,
           mutedDisplays: {'acme/api'},
+          silencedCategories: const {},
+          mineOnly: false,
+          notificationsEnabled: true,
           firstRun: false,
           inQuietHours: true,
         ),
         {'a'},
+      );
+    });
+
+    test(
+      'quiet hours: silenced drops (records); would-notify & not-mine defer',
+      () {
+        final mixed = [
+          item('rev', 'acme/api', category: 'reviewRequested', isMine: true),
+          item('old', 'acme/web', category: 'oldOpenPr', isMine: true),
+          item('other', 'acme/db', category: 'reviewRequested', isMine: false),
+        ];
+        // 'old' (silenced category) never notifies -> its baseline advances.
+        // 'rev' (would-notify) is deferred by quiet hours; 'other' (not mine,
+        // mine-only) is deferred by audience so it can notify if it becomes mine.
+        expect(
+          NotificationService.baselineIdsToRecord(
+            currentIds: {'rev', 'old', 'other'},
+            items: mixed,
+            mutedDisplays: const {},
+            silencedCategories: {'oldOpenPr'},
+            mineOnly: true,
+            notificationsEnabled: true,
+            firstRun: false,
+            inQuietHours: true,
+          ),
+          {'old'},
+        );
+      },
+    );
+
+    test(
+      'mine-only defers a not-mine item outside quiet hours (records rest)',
+      () {
+        // Regression for the "becomes mine later" miss: a not-mine item must NOT
+        // be recorded (dropped) under mine-only, or it could never notify once it
+        // becomes the user's.
+        final mixed = [
+          item('mine', 'acme/api', isMine: true),
+          item('other', 'acme/web', isMine: false),
+        ];
+        expect(
+          NotificationService.baselineIdsToRecord(
+            currentIds: {'mine', 'other'},
+            items: mixed,
+            mutedDisplays: const {},
+            silencedCategories: const {},
+            mineOnly: true,
+            notificationsEnabled: true,
+            firstRun: false,
+            inQuietHours: false,
+          ),
+          {'mine'},
+        );
+      },
+    );
+
+    test('first run seeds all but defers not-mine under mine-only', () {
+      // The pre-existing backlog is seeded (so it isn't announced on install),
+      // except a not-mine item under mine-only, which stays unseen so it can
+      // notify if it later becomes the user's.
+      final mixed = [
+        item('mine', 'acme/api', isMine: true),
+        item('other', 'acme/web', isMine: false),
+      ];
+      expect(
+        NotificationService.baselineIdsToRecord(
+          currentIds: {'mine', 'other'},
+          items: mixed,
+          mutedDisplays: const {},
+          silencedCategories: const {},
+          mineOnly: true,
+          notificationsEnabled: true,
+          firstRun: true,
+          inQuietHours: false,
+        ),
+        {'mine'},
       );
     });
   });

--- a/test/preferences_store_test.dart
+++ b/test/preferences_store_test.dart
@@ -15,6 +15,30 @@ void main() {
     expect(prefs.quietHoursEnabled, isFalse);
     expect(prefs.feedLookbackDays, 14);
     expect(prefs.backgroundSyncEnabled, isTrue);
+    expect(prefs.notifyMineOnly, isFalse);
+    expect(prefs.silencedNotifyCategories, isEmpty);
+  });
+
+  test('notify mine-only setting round-trips through load()', () async {
+    await PreferencesStore.setNotifyMineOnly(true);
+    expect((await PreferencesStore.load()).notifyMineOnly, isTrue);
+    await PreferencesStore.setNotifyMineOnly(false);
+    expect((await PreferencesStore.load()).notifyMineOnly, isFalse);
+  });
+
+  test('silenced notify categories round-trip and toggle', () async {
+    await PreferencesStore.setCategorySilenced('oldOpenPr', true);
+    await PreferencesStore.setCategorySilenced('error', true);
+    expect((await PreferencesStore.load()).silencedNotifyCategories, {
+      'oldOpenPr',
+      'error',
+    });
+    // Idempotent add + independent remove.
+    await PreferencesStore.setCategorySilenced('oldOpenPr', true);
+    await PreferencesStore.setCategorySilenced('error', false);
+    expect((await PreferencesStore.load()).silencedNotifyCategories, {
+      'oldOpenPr',
+    });
   });
 
   test('background sync setting round-trips through load()', () async {


### PR DESCRIPTION
## What

"Smarter notifications" — control which attention notifications fire, and notify on positive events that target you.

1. **New "Approved" attention category** — a PR **you authored** that's approved (ready to merge) now surfaces in the inbox and can notify. Only for your own PRs (a requested reviewer doesn't get it).
2. **Per-category notification toggles** + an **"Only my PRs & reviews"** switch in Settings.

## How

- **`approved` category** (`lib/attention_service.dart`): GitHub — `reviewDecision == 'APPROVED'`, or an approving `latestOpinionatedReviews` on a null-decision repo, with no changes-requested; ADO — a positive reviewer vote with no pending (0) or negative vote. Gated on a new **`authoredByMe`** (self is the PR author), not the broader `mine` (author *or* reviewer). New `_approved` builder + `_hasApprovingReview`; tiers renumbered (reviewRequested 4 > changesRequested 3 > approved 2 > oldOpenPr 1 > error 0); inbox icon/color + `categoryLabel`.
- **Preferences** (`lib/preferences_store.dart`): `notifyMineOnly` (default false) and `silencedNotifyCategories` (default `{}` = notify for everything; a newly-added category notifies by default). New setters; persisted as bool + StringList.
- **Notification gate** (`lib/notification_service.dart`): pure `notifiesFor(item, {mutedDisplays, silencedCategories, mineOnly})`. `baselineIdsToRecord` reworked with an explicit precedence so a filter change never replays a backlog *and* an item that becomes yours still notifies:
  1. notifications **off** → record all (drop the backlog),
  2. **muted / silenced** → record (drop; re-enabling can't replay),
  3. **mine-only & not-mine** → **defer** (don't record, incl. first run) so a not-mine item that later becomes yours is still unseen and notifies,
  4. otherwise **seed** on first run / record when notified (would-notify items held during quiet hours).
- **Settings UI** (`lib/preferences_page.dart`): "Only my PRs & reviews" switch + a per-category switch list (excludes Errors, which are never notified via a new `notifiableCategories`).

## Review gate

code-review + rubber-duck pre-open. Rubber-duck drove several fixes: **approved is author-only** (not author-or-reviewer); the **mine-only baseline** now *defers* not-mine items rather than dropping them (so "review requested of me" on a PR I'm later added to still fires) — including at first run — and is overridden when notifications are globally off (so disabling can't accumulate a replay backlog). Softened the title to "PR #N approved" (no merge-readiness overclaim) and removed the inert Errors toggle. Accepted, documented limitations: the one-time post-upgrade surfacing of already-approved PRs (a single bundled summary), and no re-notification for a repeated approve→changes→approve cycle (consistent with the existing per-PR-lifetime id model).

## Tests

New coverage for the `approved` category (GitHub + ADO, incl. reviewer-not-author negatives and a null-decision approving review), PreferencesStore round-trips (mine-only + silenced set toggle), and the full `notifiesFor` / `baselineIdsToRecord` precedence matrix (muted/silenced drop, mine-only defer incl. first run, quiet-hours defer, notifications-off drop-all). `dart format` clean, `flutter analyze --fatal-infos` clean, all 397 tests pass.
