### PR TITLE
Add daily digest notification mode

### DIFF
--- a/lib/notification_seen_store.dart
+++ b/lib/notification_seen_store.dart
@@ -180,11 +180,54 @@ class NotificationSeenStore {
     return row != null;
   }
 
+  static Future<String?> _getMeta(AppDatabase db, String key) async {
+    final row = await (db.select(
+      db.appMeta,
+    )..where((t) => t.key.equals(key))).getSingleOrNull();
+    return row?.value;
+  }
+
   static Future<void> _setMeta(AppDatabase db, String key, String value) {
     return db
         .into(db.appMeta)
         .insertOnConflictUpdate(
           AppMetaCompanion.insert(key: key, value: value),
         );
+  }
+
+  /// `app_meta` key holding the local date (`yyyy-M-d`) the daily digest was
+  /// last shown, used as an atomic once-per-day claim.
+  static const String _digestShownKey = 'digest_last_shown';
+
+  /// Atomically claims the daily digest for [date] (a `yyyy-M-d` key): returns
+  /// true if this run won the claim (the digest hasn't been shown for [date]
+  /// yet), false if another run already claimed it. The check-and-set runs in a
+  /// single write transaction, which SQLite serializes, so the foreground and
+  /// background-sync isolates can't both claim — and show — the same day.
+  static Future<bool> claimDailyDigest(String date) {
+    final db = _database;
+    return _runLocked(
+      () => db.transaction(() async {
+        if (await _getMeta(db, _digestShownKey) == date) return false;
+        await _setMeta(db, _digestShownKey, date);
+        return true;
+      }),
+    );
+  }
+
+  /// Releases a same-day digest claim (e.g. when showing the notification
+  /// failed) so a later sync can retry. Only clears the marker if it still
+  /// holds [date], to avoid clobbering a newer day's claim.
+  static Future<void> releaseDailyDigest(String date) {
+    final db = _database;
+    return _runLocked(
+      () => db.transaction(() async {
+        if (await _getMeta(db, _digestShownKey) == date) {
+          await (db.delete(
+            db.appMeta,
+          )..where((t) => t.key.equals(_digestShownKey))).go();
+        }
+      }),
+    );
   }
 }

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -152,6 +152,9 @@ class NotificationService {
           inQuietHours: false,
         );
         await NotificationSeenStore.recordBaseline(baselineIds, monitoredRepos);
+        // `attention` already excludes error items (filtered at the top of this
+        // method), so the digest's count and per-category breakdown stay
+        // consistent; here we only apply the notification filters.
         final digestItems = attention
             .where(
               (item) => notifiesFor(

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -14,6 +14,7 @@ class NotificationService {
   NotificationService._();
 
   static const int _summaryNotificationId = 42001;
+  static const int _digestNotificationId = 42002;
   static const String _channelId = 'attention_inbox';
   static const String _channelName = 'Attention Inbox';
   static const String _channelDescription =
@@ -128,9 +129,63 @@ class NotificationService {
       final muted = await MuteStore.mutedDisplays();
       final silenced = appPrefs.silencedNotifyCategories;
       final mineOnly = appPrefs.notifyMineOnly;
+      final notificationsAllowed = PreferencesStore.notificationsAllowed(
+        appPrefs,
+        now,
+      );
 
-      if (newIds.isNotEmpty &&
-          PreferencesStore.notificationsAllowed(appPrefs, now)) {
+      // Digest mode: suppress per-change alerts and instead show at most one
+      // summary a day. Advance the baseline as in per-item mode but WITHOUT
+      // quiet-hours deferral (the digest owns its own timing) — muted/silenced
+      // still drop and mine-only not-mine items still defer (preserving the
+      // becomes-mine invariant), so switching back to per-item alerts can't
+      // replay yet a not-mine item can still notify if it becomes the user's.
+      if (appPrefs.digestModeEnabled) {
+        final baselineIds = baselineIdsToRecord(
+          currentIds: currentIds,
+          items: attention,
+          mutedDisplays: muted,
+          silencedCategories: silenced,
+          mineOnly: mineOnly,
+          notificationsEnabled: appPrefs.notificationsEnabled,
+          firstRun: firstRun,
+          inQuietHours: false,
+        );
+        await NotificationSeenStore.recordBaseline(baselineIds, monitoredRepos);
+        final digestItems = attention
+            .where(
+              (item) => notifiesFor(
+                item,
+                mutedDisplays: muted,
+                silencedCategories: silenced,
+                mineOnly: mineOnly,
+              ),
+            )
+            .toList(growable: false);
+        if (digestItems.isNotEmpty &&
+            _isSupportedPlatform &&
+            shouldShowDigest(
+              now: now,
+              digestHour: appPrefs.digestHour,
+              notificationsEnabled: appPrefs.notificationsEnabled,
+              quietHoursEnabled: appPrefs.quietHoursEnabled,
+              quietStartHour: appPrefs.quietStartHour,
+              quietEndHour: appPrefs.quietEndHour,
+            )) {
+          // Atomic once-per-day claim (serialized across isolates in the DB);
+          // release it if the notification fails so a later sync retries.
+          final date = PreferencesStore.localDateString(now);
+          if (await NotificationSeenStore.claimDailyDigest(date)) {
+            final shown = await _showDigestNotification(digestItems);
+            if (!shown) {
+              await NotificationSeenStore.releaseDailyDigest(date);
+            }
+          }
+        }
+        return;
+      }
+
+      if (newIds.isNotEmpty && notificationsAllowed) {
         // Exclude muted repos, silenced categories, and (when mine-only) items
         // that aren't the user's — they still appear in the inbox.
         final newItems = notifiableItems(
@@ -477,5 +532,82 @@ class NotificationService {
       titles.add('+$remaining more');
     }
     return titles.join('\n');
+  }
+
+  /// Whether the once-daily digest should be shown now, by timing alone (the
+  /// once-per-day guarantee is a separate atomic claim). True when notifications
+  /// are enabled, it's not currently quiet hours, and either we've reached the
+  /// digest hour today OR the digest hour falls inside an overnight (wrapping)
+  /// quiet window — in which case it can never be reached while allowed, so we
+  /// fire it once quiet hours lift. Pure.
+  @visibleForTesting
+  static bool shouldShowDigest({
+    required DateTime now,
+    required int digestHour,
+    required bool notificationsEnabled,
+    required bool quietHoursEnabled,
+    required int quietStartHour,
+    required int quietEndHour,
+  }) {
+    if (!notificationsEnabled) return false;
+    final inQuiet =
+        quietHoursEnabled &&
+        PreferencesStore.isWithinQuietHours(now, quietStartHour, quietEndHour);
+    if (inQuiet) return false;
+    if (now.hour >= digestHour) return true;
+    // Overnight quiet window (start > end) that contains the digest hour: the
+    // digest hour is unreachable while notifications are allowed, so deliver at
+    // the first allowed moment after the window lifts.
+    final quietWraps = quietHoursEnabled && quietStartHour > quietEndHour;
+    return quietWraps &&
+        digestHour >= quietStartHour &&
+        now.hour >= quietEndHour;
+  }
+
+  /// The digest notification's title (the total count). Pure.
+  @visibleForTesting
+  static String digestTitle(int count) => count == 1
+      ? '1 item needs your attention'
+      : '$count items need your attention';
+
+  /// The digest notification's body: a per-category breakdown of [items] in
+  /// priority order (e.g. "3 review requested · 1 changes requested"). Pure.
+  @visibleForTesting
+  static String digestBody(List<AttentionItem> items) {
+    final counts = <String, int>{};
+    for (final item in items) {
+      counts[item.category] = (counts[item.category] ?? 0) + 1;
+    }
+    final parts = <String>[];
+    for (final category in AttentionService.notifiableCategories) {
+      final n = counts[category] ?? 0;
+      if (n > 0) {
+        parts.add(
+          '$n ${AttentionService.categoryLabel(category).toLowerCase()}',
+        );
+      }
+    }
+    return parts.join(' · ');
+  }
+
+  static Future<bool> _showDigestNotification(List<AttentionItem> items) async {
+    try {
+      if (items.isEmpty || !_isSupportedPlatform) return false;
+      await init();
+      if (!_initialized) return false;
+      final details = _notificationDetails();
+      if (details == null) return false;
+      await _plugin.show(
+        id: _digestNotificationId,
+        title: digestTitle(items.length),
+        body: digestBody(items),
+        notificationDetails: details,
+        payload: attentionPayload,
+      );
+      return true;
+    } catch (e) {
+      debugPrint('Failed to show digest notification: $e');
+      return false;
+    }
   }
 }

--- a/lib/preferences_page.dart
+++ b/lib/preferences_page.dart
@@ -130,6 +130,36 @@ class _PreferencesPageState extends State<PreferencesPage>
                   ),
                 ],
                 SwitchListTile(
+                  title: const Text('Daily digest'),
+                  subtitle: const Text(
+                    'One summary a day instead of per-change alerts',
+                  ),
+                  value: _prefs.digestModeEnabled,
+                  onChanged: _prefs.notificationsEnabled
+                      ? (value) async {
+                          await PreferencesStore.setDigestModeEnabled(value);
+                          if (!mounted) return;
+                          setState(
+                            () => _prefs = _prefs.copyWith(
+                              digestModeEnabled: value,
+                            ),
+                          );
+                        }
+                      : null,
+                ),
+                if (_prefs.notificationsEnabled && _prefs.digestModeEnabled)
+                  _hourTile(
+                    label: 'Digest time',
+                    hour: _prefs.digestHour,
+                    onChanged: (hour) async {
+                      await PreferencesStore.setDigestHour(hour);
+                      if (!mounted) return;
+                      setState(
+                        () => _prefs = _prefs.copyWith(digestHour: hour),
+                      );
+                    },
+                  ),
+                SwitchListTile(
                   title: const Text('Only my PRs & reviews'),
                   subtitle: const Text(
                     'Notify only for items you authored or were asked to '

--- a/lib/preferences_store.dart
+++ b/lib/preferences_store.dart
@@ -13,6 +13,8 @@ class AppPreferences {
     this.backgroundSyncEnabled = true,
     this.notifyMineOnly = false,
     this.silencedNotifyCategories = const {},
+    this.digestModeEnabled = false,
+    this.digestHour = 9,
   });
 
   final bool notificationsEnabled;
@@ -39,6 +41,13 @@ class AppPreferences {
   /// *silenced* set means a newly-added category notifies by default.
   final Set<String> silencedNotifyCategories;
 
+  /// When true, replace per-change attention notifications with a single daily
+  /// digest summary (shown on the first sync at/after [digestHour] each day).
+  final bool digestModeEnabled;
+
+  /// Local hour [0, 23] at/after which the daily digest is shown.
+  final int digestHour;
+
   AppPreferences copyWith({
     bool? notificationsEnabled,
     bool? quietHoursEnabled,
@@ -48,6 +57,8 @@ class AppPreferences {
     bool? backgroundSyncEnabled,
     bool? notifyMineOnly,
     Set<String>? silencedNotifyCategories,
+    bool? digestModeEnabled,
+    int? digestHour,
   }) {
     return AppPreferences(
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
@@ -61,6 +72,8 @@ class AppPreferences {
       silencedNotifyCategories: Set.unmodifiable(
         silencedNotifyCategories ?? this.silencedNotifyCategories,
       ),
+      digestModeEnabled: digestModeEnabled ?? this.digestModeEnabled,
+      digestHour: digestHour ?? this.digestHour,
     );
   }
 }
@@ -79,6 +92,8 @@ class PreferencesStore {
   static const String _notifyMineOnly = 'pref_notify_mine_only';
   static const String _silencedNotifyCategories =
       'pref_notify_silenced_categories';
+  static const String _digestModeEnabled = 'pref_digest_mode_enabled';
+  static const String _digestHour = 'pref_digest_hour';
 
   /// Allowed lookback options shown in the UI.
   static const List<int> lookbackOptions = [7, 14, 30, 60];
@@ -116,6 +131,9 @@ class PreferencesStore {
         prefs.getStringList(_silencedNotifyCategories)?.toSet() ??
             defaults.silencedNotifyCategories,
       ),
+      digestModeEnabled:
+          prefs.getBool(_digestModeEnabled) ?? defaults.digestModeEnabled,
+      digestHour: _clampHour(prefs.getInt(_digestHour) ?? defaults.digestHour),
     );
   }
 
@@ -186,6 +204,24 @@ class PreferencesStore {
       );
     });
   }
+
+  static Future<void> setDigestModeEnabled(bool value) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_digestModeEnabled, value);
+    });
+  }
+
+  static Future<void> setDigestHour(int hour) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_digestHour, _clampHour(hour));
+    });
+  }
+
+  /// A local calendar-date key (`yyyy-M-d`) for the once-per-day digest claim.
+  static String localDateString(DateTime now) =>
+      '${now.year}-${now.month}-${now.day}';
 
   /// Whether notifications should be shown right now given [prefs] and [now].
   static bool notificationsAllowed(AppPreferences prefs, DateTime now) {

--- a/test/notification_seen_store_test.dart
+++ b/test/notification_seen_store_test.dart
@@ -111,4 +111,19 @@ void main() {
 
     await upgraded.close();
   });
+
+  test('claimDailyDigest is once-per-day and release allows a retry', () async {
+    // First claim for a date wins; a second (e.g. the other isolate) loses.
+    expect(await NotificationSeenStore.claimDailyDigest('2026-7-23'), isTrue);
+    expect(await NotificationSeenStore.claimDailyDigest('2026-7-23'), isFalse);
+    // Releasing the ACTIVE claim (e.g. after a failed show) lets the SAME day
+    // be re-claimed so a later sync retries.
+    await NotificationSeenStore.releaseDailyDigest('2026-7-23');
+    expect(await NotificationSeenStore.claimDailyDigest('2026-7-23'), isTrue);
+    // A different date is its own claim.
+    expect(await NotificationSeenStore.claimDailyDigest('2026-7-24'), isTrue);
+    // A stale release (the marker has moved on) is a no-op — today stays held.
+    await NotificationSeenStore.releaseDailyDigest('2026-7-23');
+    expect(await NotificationSeenStore.claimDailyDigest('2026-7-24'), isFalse);
+  });
 }

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -489,4 +489,105 @@ void main() {
       );
     });
   });
+
+  group('daily digest', () {
+    AttentionItem item(String id, String category) => AttentionItem(
+      id: id,
+      category: category,
+      severity: 1000,
+      titleTemplate: id,
+      subtitleTemplate: '',
+      repoDisplay: 'acme/api',
+    );
+
+    test('shouldShowDigest only at/after the hour, respecting quiet hours', () {
+      bool show({
+        required int hour,
+        int digestHour = 9,
+        bool notificationsEnabled = true,
+        bool quietHoursEnabled = false,
+        int quietStartHour = 22,
+        int quietEndHour = 8,
+      }) => NotificationService.shouldShowDigest(
+        now: DateTime(2026, 7, 23, hour),
+        digestHour: digestHour,
+        notificationsEnabled: notificationsEnabled,
+        quietHoursEnabled: quietHoursEnabled,
+        quietStartHour: quietStartHour,
+        quietEndHour: quietEndHour,
+      );
+
+      // Before / at / after the digest hour.
+      expect(show(hour: 8), isFalse);
+      expect(show(hour: 9), isTrue);
+      expect(show(hour: 14), isTrue);
+      // Notifications disabled.
+      expect(show(hour: 10, notificationsEnabled: false), isFalse);
+      // Digest hour inside a normal (non-wrapping) quiet window: blocked during
+      // it, fires once it lifts.
+      expect(
+        show(
+          hour: 9,
+          quietHoursEnabled: true,
+          quietStartHour: 8,
+          quietEndHour: 10,
+        ),
+        isFalse,
+      );
+      expect(
+        show(
+          hour: 10,
+          quietHoursEnabled: true,
+          quietStartHour: 8,
+          quietEndHour: 10,
+        ),
+        isTrue,
+      );
+      // Not premature before the digest hour when quiet doesn't cover it.
+      expect(
+        show(
+          hour: 7,
+          quietHoursEnabled: true,
+          quietStartHour: 8,
+          quietEndHour: 10,
+        ),
+        isFalse,
+      );
+    });
+
+    test('shouldShowDigest is not starved by an overnight quiet window', () {
+      // Regression: digest hour 23 with quiet hours 22->8 has no allowed hour
+      // >= 23, so it must fire once quiet lifts (from 08:00) rather than never.
+      bool show(int hour) => NotificationService.shouldShowDigest(
+        now: DateTime(2026, 7, 23, hour),
+        digestHour: 23,
+        notificationsEnabled: true,
+        quietHoursEnabled: true,
+        quietStartHour: 22,
+        quietEndHour: 8,
+      );
+      expect(show(3), isFalse, reason: 'quiet hours (night)');
+      expect(show(22), isFalse, reason: 'quiet hours (evening)');
+      expect(show(8), isTrue, reason: 'fires when quiet lifts');
+      expect(show(15), isTrue);
+    });
+
+    test('digestTitle counts items', () {
+      expect(NotificationService.digestTitle(1), '1 item needs your attention');
+      expect(NotificationService.digestTitle(4), '4 items need your attention');
+    });
+
+    test('digestBody breaks down by category in priority order', () {
+      final items = [
+        item('r1', 'reviewRequested'),
+        item('r2', 'reviewRequested'),
+        item('c1', 'changesRequested'),
+        item('a1', 'approved'),
+      ];
+      expect(
+        NotificationService.digestBody(items),
+        '2 review requested · 1 changes requested · 1 approved',
+      );
+    });
+  });
 }

--- a/test/preferences_store_test.dart
+++ b/test/preferences_store_test.dart
@@ -48,6 +48,27 @@ void main() {
     expect((await PreferencesStore.load()).backgroundSyncEnabled, isTrue);
   });
 
+  test('digest settings round-trip through load()', () async {
+    expect((await PreferencesStore.load()).digestModeEnabled, isFalse);
+    expect((await PreferencesStore.load()).digestHour, 9);
+    await PreferencesStore.setDigestModeEnabled(true);
+    await PreferencesStore.setDigestHour(7);
+    final loaded = await PreferencesStore.load();
+    expect(loaded.digestModeEnabled, isTrue);
+    expect(loaded.digestHour, 7);
+    // Out-of-range hour is clamped.
+    await PreferencesStore.setDigestHour(99);
+    expect((await PreferencesStore.load()).digestHour, 23);
+  });
+
+  test('last-digest local date key formats correctly', () {
+    expect(PreferencesStore.localDateString(DateTime(2026, 1, 5)), '2026-1-5');
+    expect(
+      PreferencesStore.localDateString(DateTime(2026, 7, 23, 14)),
+      '2026-7-23',
+    );
+  });
+
   test('setters round-trip through load()', () async {
     await PreferencesStore.setNotificationsEnabled(false);
     await PreferencesStore.setQuietHoursEnabled(true);


### PR DESCRIPTION
## What

An opt-in **daily digest** notification mode: instead of a per-change alert each time new items need attention, get **one summary notification a day** at/after a chosen hour. Complements the per-category / mine-only controls already shipped.

## How

- **`PreferencesStore`**: `digestModeEnabled` (default off) + `digestHour` (default 9, clamped). A **"Daily digest"** switch + **"Digest time"** hour picker in Settings (shown when the mode is on).
- **`NotificationService`** — in digest mode, `_notifyNewAttention` suppresses the per-item summary and instead shows, at most once/day, a digest of the currently **filtered** attention (respects mute / silenced categories / mine-only): title = total count, body = per-category breakdown (e.g. "3 review requested · 1 changes requested").
  - **`shouldShowDigest(...)`** (pure) gates by timing only: notifications enabled, not currently quiet hours, and either past the digest hour today **or** — when the digest hour falls inside an **overnight (wrapping) quiet window** where it could never be reached while allowed — the first allowed moment once quiet lifts (so a digest at 23:00 with quiet 22→08 fires at 08:00 rather than never).
  - **Once-per-day is an atomic DB claim** — `NotificationSeenStore.claimDailyDigest(date)` does a check-and-set in a single serialized write transaction, so the foreground and background isolates can't both fire. If the show fails (unsupported/uninitialized/exception), the claim is **released** so a later sync retries.
  - The digest **baseline** advances via `baselineIdsToRecord(..., inQuietHours: false)`, so muted/silenced items still drop and a not-mine item under mine-only still **defers** — preserving the "becomes mine notifies" invariant across a mode switch (no per-item replay when you turn digest mode off).

## Review gate

code-review (clean) + rubber-duck pre-open. Rubber-duck caught 3 blocking issues, all fixed: (1) a digest hour inside overnight quiet hours **starved forever** → now fires when quiet lifts; (2) the SharedPreferences once-per-day marker **wasn't cross-isolate atomic** → moved to a serialized DB claim; (3) a **failed `show()` still marked the day done** → now `show` returns success and the claim is released on failure. Plus preserving the mine-only deferral in digest mode.

Accepted best-effort tradeoffs (documented): a partial-repo-failure day yields a slightly-low count that self-corrects next day; repeated unchanged digests are an intentional daily reminder (not a "new since last digest" feed); iOS BG throttling makes delivery best-effort.

## Tests

`shouldShowDigest` timing incl. the **overnight-quiet regression**; `claimDailyDigest`/`releaseDailyDigest` once-per-day + release-then-retry; `digestTitle`/`digestBody`; PreferencesStore digest round-trips + `localDateString`. `dart format` clean, `flutter analyze --fatal-infos` clean, all 404 tests pass.
