### PR TITLE
Add CI run-duration trends (slowing pipeline detection)

### DIFF
--- a/lib/activity_service.dart
+++ b/lib/activity_service.dart
@@ -369,6 +369,7 @@ class ActivityService {
           conclusion: _stringValue(run, 'conclusion') ?? '',
           branch: headBranch,
           finishedAt: _parseDate(run['updated_at']),
+          durationMs: _durationMs(run['run_started_at'], run['updated_at']),
           url: _stringValue(run, 'html_url'),
         ),
       );
@@ -426,11 +427,23 @@ class ActivityService {
           conclusion: _stringValue(build, 'result') ?? '',
           branch: sourceBranch,
           finishedAt: _parseDate(build['finishTime']),
+          durationMs: _durationMs(build['startTime'], build['finishTime']),
           url: url,
         ),
       );
     }
     return result;
+  }
+
+  /// The elapsed milliseconds between two ISO-8601 timestamps ([startIso] to
+  /// [endIso]), or null when either is missing/unparseable or the result is not
+  /// positive (guards against clock skew / mislabeled fields).
+  static int? _durationMs(dynamic startIso, dynamic endIso) {
+    final start = _parseDate(startIso);
+    final end = _parseDate(endIso);
+    if (start == null || end == null) return null;
+    final ms = end.difference(start).inMilliseconds;
+    return ms > 0 ? ms : null;
   }
 
   /// Whether [runs] contains a run that counts toward trend rates — a completed

--- a/lib/ci_run_history.dart
+++ b/lib/ci_run_history.dart
@@ -34,6 +34,7 @@ class CiRunSample {
     this.workflowId,
     this.branch,
     this.finishedAt,
+    this.durationMs,
     this.url,
   });
 
@@ -62,6 +63,11 @@ class CiRunSample {
 
   final String? branch;
   final DateTime? finishedAt;
+
+  /// The run's execution duration in milliseconds, when known (GitHub
+  /// `run_started_at`→`updated_at`, ADO `startTime`→`finishTime`). Powers the
+  /// typical-duration and slowdown signals.
+  final int? durationMs;
   final String? url;
 
   /// The key runs are grouped by for trends: the stable id when known, else the
@@ -88,6 +94,9 @@ class CiWorkflowTrend {
     required this.recentOutcomes,
     required this.lastRunAt,
     required this.url,
+    this.medianDurationMs,
+    this.slowdownRatio,
+    this.isSlowing = false,
   });
 
   final String repoKey;
@@ -120,6 +129,19 @@ class CiWorkflowTrend {
   final DateTime? lastRunAt;
   final String? url;
 
+  /// Median duration (ms) of successful runs in the window, or null until there
+  /// are at least [minRunsForTypical] timed successes — the "typical" run time.
+  final int? medianDurationMs;
+
+  /// Ratio of the recent-half median duration to the older-half median (of
+  /// successful runs), or null without enough timed runs. > 1 means slower.
+  final double? slowdownRatio;
+
+  /// Whether the workflow's recent successful runs are meaningfully slower than
+  /// its earlier ones (both a relative [slowdownThreshold] and an absolute
+  /// [minSlowdownDeltaMs] increase), computed over a sufficient sample.
+  final bool isSlowing;
+
   /// The key its runs are grouped by (matches [CiRunSample.groupKey]).
   String get groupKey =>
       workflowId != null ? 'id:$workflowId' : 'name:$workflow';
@@ -150,22 +172,40 @@ class CiWorkflowTrend {
       flakeRate < flakyThreshold &&
       lastCompletedOutcome == CiOutcome.failure;
 
-  bool get hasProblem => isFlaky || isChronicallyFailing;
+  /// A workflow whose recent runs are meaningfully slower than its earlier ones
+  /// (a regressing pipeline), even if it's still passing.
+  bool get hasProblem => isFlaky || isChronicallyFailing || isSlowing;
 
   /// Shrinks a small sample's weight so a 1-fail / 1-pass workflow can't rank
   /// alongside a 20-run one with the same rate.
   double get _confidence => total == 0 ? 0 : total / (total + 3);
 
-  /// Worst-first ranking weight: failing dominates, flakiness adds to it, both
-  /// damped by sample confidence.
+  /// Worst-first ranking weight from failure + flakiness only (a slowdown is a
+  /// separate, lower-priority sort tier so it never outranks a real failure or
+  /// flake — see [aggregate]'s sort). Damped by sample confidence.
   double get severity => _confidence * (failureRate + 0.5 * flakeRate);
 
   /// Minimum flip rate for a mixed workflow to read as flaky (~1 in 3).
   static const double flakyThreshold = 0.34;
 
+  /// Recent runs must be at least this much slower than older runs (relative)
+  /// AND at least [minSlowdownDeltaMs] slower (absolute) to count as "slowing".
+  static const double slowdownThreshold = 1.3;
+
+  /// Absolute floor (ms) on the recent-vs-older median increase, so trivial
+  /// jitter on short jobs (e.g. 2s → 3s) isn't flagged as a slowdown.
+  static const int minSlowdownDeltaMs = 10000;
+
   /// Minimum completed runs before a workflow can be labeled flaky / failing.
   static const int minRunsForFlaky = 4;
   static const int minRunsForChronic = 3;
+
+  /// Minimum timed successful runs before a "typical" duration is shown.
+  static const int minRunsForTypical = 3;
+
+  /// Minimum timed successful runs before a slowdown is assessed (split into
+  /// two halves of at least 4 each).
+  static const int minRunsForSlowdown = 8;
 
   /// Newest-first outcomes kept in [recentOutcomes] / persisted strips.
   static const int recentCap = 16;
@@ -205,11 +245,15 @@ class CiWorkflowTrend {
       var failures = 0;
       final completed = <String>[]; // newest-first pass/fail sequence
       final recent = <String>[];
+      final successDurations = <int>[]; // newest-first success run durations
       for (final s in group) {
         if (recent.length < recentCap) recent.add(s.outcome);
         if (s.outcome == CiOutcome.success) {
           successes++;
           completed.add(CiOutcome.success);
+          if (s.durationMs != null && s.durationMs! > 0) {
+            successDurations.add(s.durationMs!);
+          }
         } else if (s.outcome == CiOutcome.failure) {
           failures++;
           completed.add(CiOutcome.failure);
@@ -219,6 +263,10 @@ class CiWorkflowTrend {
       for (var i = 1; i < completed.length; i++) {
         if (completed[i] != completed[i - 1]) flips++;
       }
+      final medianDuration = successDurations.length >= minRunsForTypical
+          ? _median(successDurations)
+          : null;
+      final (slowdown, slowing) = _slowdown(successDurations);
       final newest = group.first;
       trends.add(
         CiWorkflowTrend(
@@ -234,6 +282,9 @@ class CiWorkflowTrend {
           recentOutcomes: recent,
           lastRunAt: newest.finishedAt,
           url: newest.url,
+          medianDurationMs: medianDuration,
+          slowdownRatio: slowdown,
+          isSlowing: slowing,
         ),
       );
     }
@@ -241,6 +292,10 @@ class CiWorkflowTrend {
     trends.sort((a, b) {
       final bySeverity = b.severity.compareTo(a.severity);
       if (bySeverity != 0) return bySeverity;
+      // Slowing is a lower-priority tier: at equal failure/flake severity, a
+      // slowing workflow surfaces above a healthy one, but never above a
+      // genuinely failing/flaky one.
+      if (a.isSlowing != b.isSlowing) return a.isSlowing ? -1 : 1;
       final byTotal = b.total.compareTo(a.total);
       if (byTotal != 0) return byTotal;
       final byRepo = a.repoDisplay.toLowerCase().compareTo(
@@ -250,5 +305,32 @@ class CiWorkflowTrend {
       return a.workflow.toLowerCase().compareTo(b.workflow.toLowerCase());
     });
     return trends;
+  }
+
+  /// The median of [values] (average of the two middle elements for an even
+  /// count), or null when empty. Does not mutate [values].
+  static int? _median(List<int> values) {
+    if (values.isEmpty) return null;
+    final sorted = [...values]..sort();
+    final mid = sorted.length ~/ 2;
+    if (sorted.length.isOdd) return sorted[mid];
+    return ((sorted[mid - 1] + sorted[mid]) / 2).round();
+  }
+
+  /// The (ratio, isSlowing) of the recent-half vs older-half median durations of
+  /// [newestFirstDurations] (newest first). Ratio is null without at least
+  /// [minRunsForSlowdown] timed runs; isSlowing additionally requires the
+  /// increase to clear both the relative [slowdownThreshold] and the absolute
+  /// [minSlowdownDeltaMs] floor.
+  static (double?, bool) _slowdown(List<int> newestFirstDurations) {
+    if (newestFirstDurations.length < minRunsForSlowdown) return (null, false);
+    final half = newestFirstDurations.length ~/ 2;
+    final recent = _median(newestFirstDurations.sublist(0, half));
+    final older = _median(newestFirstDurations.sublist(half));
+    if (recent == null || older == null || older == 0) return (null, false);
+    final ratio = recent / older;
+    final slowing =
+        ratio >= slowdownThreshold && (recent - older) >= minSlowdownDeltaMs;
+    return (ratio, slowing);
   }
 }

--- a/lib/ci_run_history_store.dart
+++ b/lib/ci_run_history_store.dart
@@ -174,6 +174,7 @@ class CiRunHistoryStore {
     finishedAt: row.finishedAt == null
         ? null
         : DateTime.fromMillisecondsSinceEpoch(row.finishedAt!, isUtc: true),
+    durationMs: row.durationMs,
     url: row.url,
   );
 
@@ -189,6 +190,7 @@ class CiRunHistoryStore {
         conclusion: s.conclusion,
         branch: Value(s.branch),
         finishedAt: Value(s.finishedAt?.toUtc().millisecondsSinceEpoch),
+        durationMs: Value(s.durationMs),
         url: Value(s.url),
       );
 }

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -153,6 +153,7 @@ class CiRunHistory extends Table {
   TextColumn get conclusion => text()();
   TextColumn get branch => text().nullable()();
   IntColumn get finishedAt => integer().nullable()();
+  IntColumn get durationMs => integer().nullable()();
   TextColumn get url => text().nullable()();
 }
 
@@ -239,7 +240,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 11;
+  int get schemaVersion => 12;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -420,6 +421,23 @@ class AppDatabase extends _$AppDatabase {
       // heals, so no serialization/marker is warranted here.
       if (from < 11) {
         await customStatement('DELETE FROM ci_run_history');
+      }
+      // v12 adds `duration_ms` to ci_run_history (run-duration trends). Ensure
+      // the table exists, then add the column with a single idempotent
+      // `ALTER TABLE ADD COLUMN`, tolerating "duplicate column" from a
+      // concurrent migrator or a jump from <10 where createTable already built
+      // the current schema.
+      if (from < 12) {
+        await m.createTable(ciRunHistory);
+        try {
+          await customStatement(
+            'ALTER TABLE ci_run_history ADD COLUMN duration_ms INTEGER',
+          );
+        } on Exception catch (e) {
+          if (!e.toString().toLowerCase().contains('duplicate column')) {
+            rethrow;
+          }
+        }
       }
     },
   );

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -4487,6 +4487,17 @@ class $CiRunHistoryTable extends CiRunHistory
     type: DriftSqlType.int,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _durationMsMeta = const VerificationMeta(
+    'durationMs',
+  );
+  @override
+  late final GeneratedColumn<int> durationMs = GeneratedColumn<int>(
+    'duration_ms',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _urlMeta = const VerificationMeta('url');
   @override
   late final GeneratedColumn<String> url = GeneratedColumn<String>(
@@ -4509,6 +4520,7 @@ class $CiRunHistoryTable extends CiRunHistory
     conclusion,
     branch,
     finishedAt,
+    durationMs,
     url,
   ];
   @override
@@ -4603,6 +4615,12 @@ class $CiRunHistoryTable extends CiRunHistory
         finishedAt.isAcceptableOrUnknown(data['finished_at']!, _finishedAtMeta),
       );
     }
+    if (data.containsKey('duration_ms')) {
+      context.handle(
+        _durationMsMeta,
+        durationMs.isAcceptableOrUnknown(data['duration_ms']!, _durationMsMeta),
+      );
+    }
     if (data.containsKey('url')) {
       context.handle(
         _urlMeta,
@@ -4662,6 +4680,10 @@ class $CiRunHistoryTable extends CiRunHistory
         DriftSqlType.int,
         data['${effectivePrefix}finished_at'],
       ),
+      durationMs: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}duration_ms'],
+      ),
       url: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}url'],
@@ -4687,6 +4709,7 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
   final String conclusion;
   final String? branch;
   final int? finishedAt;
+  final int? durationMs;
   final String? url;
   const CiRunHistoryRow({
     required this.id,
@@ -4700,6 +4723,7 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
     required this.conclusion,
     this.branch,
     this.finishedAt,
+    this.durationMs,
     this.url,
   });
   @override
@@ -4721,6 +4745,9 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
     }
     if (!nullToAbsent || finishedAt != null) {
       map['finished_at'] = Variable<int>(finishedAt);
+    }
+    if (!nullToAbsent || durationMs != null) {
+      map['duration_ms'] = Variable<int>(durationMs);
     }
     if (!nullToAbsent || url != null) {
       map['url'] = Variable<String>(url);
@@ -4747,6 +4774,9 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
       finishedAt: finishedAt == null && nullToAbsent
           ? const Value.absent()
           : Value(finishedAt),
+      durationMs: durationMs == null && nullToAbsent
+          ? const Value.absent()
+          : Value(durationMs),
       url: url == null && nullToAbsent ? const Value.absent() : Value(url),
     );
   }
@@ -4768,6 +4798,7 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
       conclusion: serializer.fromJson<String>(json['conclusion']),
       branch: serializer.fromJson<String?>(json['branch']),
       finishedAt: serializer.fromJson<int?>(json['finishedAt']),
+      durationMs: serializer.fromJson<int?>(json['durationMs']),
       url: serializer.fromJson<String?>(json['url']),
     );
   }
@@ -4786,6 +4817,7 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
       'conclusion': serializer.toJson<String>(conclusion),
       'branch': serializer.toJson<String?>(branch),
       'finishedAt': serializer.toJson<int?>(finishedAt),
+      'durationMs': serializer.toJson<int?>(durationMs),
       'url': serializer.toJson<String?>(url),
     };
   }
@@ -4802,6 +4834,7 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
     String? conclusion,
     Value<String?> branch = const Value.absent(),
     Value<int?> finishedAt = const Value.absent(),
+    Value<int?> durationMs = const Value.absent(),
     Value<String?> url = const Value.absent(),
   }) => CiRunHistoryRow(
     id: id ?? this.id,
@@ -4815,6 +4848,7 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
     conclusion: conclusion ?? this.conclusion,
     branch: branch.present ? branch.value : this.branch,
     finishedAt: finishedAt.present ? finishedAt.value : this.finishedAt,
+    durationMs: durationMs.present ? durationMs.value : this.durationMs,
     url: url.present ? url.value : this.url,
   );
   CiRunHistoryRow copyWithCompanion(CiRunHistoryCompanion data) {
@@ -4838,6 +4872,9 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
       finishedAt: data.finishedAt.present
           ? data.finishedAt.value
           : this.finishedAt,
+      durationMs: data.durationMs.present
+          ? data.durationMs.value
+          : this.durationMs,
       url: data.url.present ? data.url.value : this.url,
     );
   }
@@ -4856,6 +4893,7 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
           ..write('conclusion: $conclusion, ')
           ..write('branch: $branch, ')
           ..write('finishedAt: $finishedAt, ')
+          ..write('durationMs: $durationMs, ')
           ..write('url: $url')
           ..write(')'))
         .toString();
@@ -4874,6 +4912,7 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
     conclusion,
     branch,
     finishedAt,
+    durationMs,
     url,
   );
   @override
@@ -4891,6 +4930,7 @@ class CiRunHistoryRow extends DataClass implements Insertable<CiRunHistoryRow> {
           other.conclusion == this.conclusion &&
           other.branch == this.branch &&
           other.finishedAt == this.finishedAt &&
+          other.durationMs == this.durationMs &&
           other.url == this.url);
 }
 
@@ -4906,6 +4946,7 @@ class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
   final Value<String> conclusion;
   final Value<String?> branch;
   final Value<int?> finishedAt;
+  final Value<int?> durationMs;
   final Value<String?> url;
   const CiRunHistoryCompanion({
     this.id = const Value.absent(),
@@ -4919,6 +4960,7 @@ class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
     this.conclusion = const Value.absent(),
     this.branch = const Value.absent(),
     this.finishedAt = const Value.absent(),
+    this.durationMs = const Value.absent(),
     this.url = const Value.absent(),
   });
   CiRunHistoryCompanion.insert({
@@ -4933,6 +4975,7 @@ class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
     required String conclusion,
     this.branch = const Value.absent(),
     this.finishedAt = const Value.absent(),
+    this.durationMs = const Value.absent(),
     this.url = const Value.absent(),
   }) : provider = Value(provider),
        repoKey = Value(repoKey),
@@ -4953,6 +4996,7 @@ class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
     Expression<String>? conclusion,
     Expression<String>? branch,
     Expression<int>? finishedAt,
+    Expression<int>? durationMs,
     Expression<String>? url,
   }) {
     return RawValuesInsertable({
@@ -4967,6 +5011,7 @@ class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
       if (conclusion != null) 'conclusion': conclusion,
       if (branch != null) 'branch': branch,
       if (finishedAt != null) 'finished_at': finishedAt,
+      if (durationMs != null) 'duration_ms': durationMs,
       if (url != null) 'url': url,
     });
   }
@@ -4983,6 +5028,7 @@ class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
     Value<String>? conclusion,
     Value<String?>? branch,
     Value<int?>? finishedAt,
+    Value<int?>? durationMs,
     Value<String?>? url,
   }) {
     return CiRunHistoryCompanion(
@@ -4997,6 +5043,7 @@ class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
       conclusion: conclusion ?? this.conclusion,
       branch: branch ?? this.branch,
       finishedAt: finishedAt ?? this.finishedAt,
+      durationMs: durationMs ?? this.durationMs,
       url: url ?? this.url,
     );
   }
@@ -5037,6 +5084,9 @@ class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
     if (finishedAt.present) {
       map['finished_at'] = Variable<int>(finishedAt.value);
     }
+    if (durationMs.present) {
+      map['duration_ms'] = Variable<int>(durationMs.value);
+    }
     if (url.present) {
       map['url'] = Variable<String>(url.value);
     }
@@ -5057,6 +5107,7 @@ class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
           ..write('conclusion: $conclusion, ')
           ..write('branch: $branch, ')
           ..write('finishedAt: $finishedAt, ')
+          ..write('durationMs: $durationMs, ')
           ..write('url: $url')
           ..write(')'))
         .toString();
@@ -7487,6 +7538,7 @@ typedef $$CiRunHistoryTableCreateCompanionBuilder =
       required String conclusion,
       Value<String?> branch,
       Value<int?> finishedAt,
+      Value<int?> durationMs,
       Value<String?> url,
     });
 typedef $$CiRunHistoryTableUpdateCompanionBuilder =
@@ -7502,6 +7554,7 @@ typedef $$CiRunHistoryTableUpdateCompanionBuilder =
       Value<String> conclusion,
       Value<String?> branch,
       Value<int?> finishedAt,
+      Value<int?> durationMs,
       Value<String?> url,
     });
 
@@ -7566,6 +7619,11 @@ class $$CiRunHistoryTableFilterComposer
 
   ColumnFilters<int> get finishedAt => $composableBuilder(
     column: $table.finishedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -7639,6 +7697,11 @@ class $$CiRunHistoryTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get url => $composableBuilder(
     column: $table.url,
     builder: (column) => ColumnOrderings(column),
@@ -7695,6 +7758,11 @@ class $$CiRunHistoryTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<String> get url =>
       $composableBuilder(column: $table.url, builder: (column) => column);
 }
@@ -7741,6 +7809,7 @@ class $$CiRunHistoryTableTableManager
                 Value<String> conclusion = const Value.absent(),
                 Value<String?> branch = const Value.absent(),
                 Value<int?> finishedAt = const Value.absent(),
+                Value<int?> durationMs = const Value.absent(),
                 Value<String?> url = const Value.absent(),
               }) => CiRunHistoryCompanion(
                 id: id,
@@ -7754,6 +7823,7 @@ class $$CiRunHistoryTableTableManager
                 conclusion: conclusion,
                 branch: branch,
                 finishedAt: finishedAt,
+                durationMs: durationMs,
                 url: url,
               ),
           createCompanionCallback:
@@ -7769,6 +7839,7 @@ class $$CiRunHistoryTableTableManager
                 required String conclusion,
                 Value<String?> branch = const Value.absent(),
                 Value<int?> finishedAt = const Value.absent(),
+                Value<int?> durationMs = const Value.absent(),
                 Value<String?> url = const Value.absent(),
               }) => CiRunHistoryCompanion.insert(
                 id: id,
@@ -7782,6 +7853,7 @@ class $$CiRunHistoryTableTableManager
                 conclusion: conclusion,
                 branch: branch,
                 finishedAt: finishedAt,
+                durationMs: durationMs,
                 url: url,
               ),
           withReferenceMapper: (p0) => p0

--- a/lib/views/ci_trends_view.dart
+++ b/lib/views/ci_trends_view.dart
@@ -139,7 +139,7 @@ class _TrendTile extends StatelessWidget {
   final CiWorkflowTrend trend;
   final VoidCallback onTap;
 
-  ({String label, Color color})? _badge() {
+  ({String label, Color color})? _statusBadge() {
     if (trend.isChronicallyFailing) {
       return (label: 'Failing', color: ciColor('failure'));
     }
@@ -150,8 +150,9 @@ class _TrendTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final badge = _badge();
+    final badge = _statusBadge();
     final ratePct = (trend.failureRate * 100).round();
+    final typical = formatDurationMs(trend.medianDurationMs);
 
     return Card(
       clipBehavior: Clip.antiAlias,
@@ -180,8 +181,16 @@ class _TrendTile extends StatelessWidget {
                       ),
                     ),
                   ),
+                  if (trend.isSlowing)
+                    const Padding(
+                      padding: EdgeInsets.only(left: 4),
+                      child: _Badge(label: 'Slowing', color: Color(0xFF8E24AA)),
+                    ),
                   if (badge != null)
-                    _Badge(label: badge.label, color: badge.color),
+                    Padding(
+                      padding: const EdgeInsets.only(left: 4),
+                      child: _Badge(label: badge.label, color: badge.color),
+                    ),
                   const SizedBox(width: 4),
                   Icon(
                     Icons.chevron_right,
@@ -203,10 +212,11 @@ class _TrendTile extends StatelessWidget {
               _Sparkline(outcomes: trend.recentOutcomes),
               const SizedBox(height: 6),
               Text(
-                trend.total == 0
-                    ? 'No completed runs in range'
-                    : '$ratePct% failed · ${trend.failures}/${trend.total} runs'
-                          '${trend.flips > 0 ? ' · ${trend.flips} flips' : ''}',
+                (trend.total == 0
+                        ? 'No completed runs in range'
+                        : '$ratePct% failed · ${trend.failures}/${trend.total} runs'
+                              '${trend.flips > 0 ? ' · ${trend.flips} flips' : ''}') +
+                    (typical != null ? ' · ~$typical' : ''),
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),

--- a/lib/views/ci_workflow_detail_page.dart
+++ b/lib/views/ci_workflow_detail_page.dart
@@ -61,11 +61,16 @@ class CiWorkflowDetailPage extends StatelessWidget {
               children: [
                 _Stat(label: 'Failure rate', value: '$ratePct%'),
                 _Stat(label: 'Completed', value: '${trend.total}'),
-                _Stat(label: 'Flips', value: '${trend.flips}'),
+                _Stat(
+                  label: trend.isSlowing ? 'Typical ↑' : 'Typical',
+                  value: formatDurationMs(trend.medianDurationMs) ?? '—',
+                ),
                 if (trend.isFlaky)
                   const _Stat(label: 'Verdict', value: 'Flaky')
                 else if (trend.isChronicallyFailing)
                   const _Stat(label: 'Verdict', value: 'Failing')
+                else if (trend.isSlowing)
+                  const _Stat(label: 'Verdict', value: 'Slowing')
                 else
                   const _Stat(label: 'Verdict', value: 'OK'),
               ],
@@ -128,9 +133,11 @@ class _RunTile extends StatelessWidget {
     final theme = Theme.of(context);
     final url = run.url;
     final when = run.finishedAt;
+    final duration = formatDurationMs(run.durationMs);
     final subtitleParts = <String>[
       if (run.conclusion.isNotEmpty) run.conclusion,
       if (when != null) relativeTime(when),
+      ?duration,
       if (run.branch != null && run.branch!.isNotEmpty) run.branch!,
     ];
     return ListTile(

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -143,6 +143,19 @@ String relativeTime(DateTime? value, {DateTime? now}) {
   return '${diff.inDays ~/ 365}y ago';
 }
 
+/// Formats a duration in milliseconds compactly (e.g. "45s", "2m 30s",
+/// "1h 5m"), or null when [ms] is null/non-positive.
+String? formatDurationMs(int? ms) {
+  if (ms == null || ms <= 0) return null;
+  final totalSeconds = ms ~/ 1000;
+  final h = totalSeconds ~/ 3600;
+  final m = (totalSeconds % 3600) ~/ 60;
+  final s = totalSeconds % 60;
+  if (h > 0) return m > 0 ? '${h}h ${m}m' : '${h}h';
+  if (m > 0) return s > 0 ? '${m}m ${s}s' : '${m}m';
+  return '${s}s';
+}
+
 // ---- Freshness / heat scale -------------------------------------------------
 
 /// Maps a repo's last activity to a freshness color: green (fresh) → amber

--- a/test/activity_service_test.dart
+++ b/test/activity_service_test.dart
@@ -123,6 +123,53 @@ void main() {
     expect(ActivityService.ciStatusFromAdoBuilds({'value': []}), 'unknown');
   });
 
+  test('CI run parsers capture run duration from start/finish timestamps', () {
+    final gh = ActivityService.ciRunSamplesFromGithubRuns(
+      {
+        'workflow_runs': [
+          {
+            'id': 1,
+            'name': 'CI',
+            'status': 'completed',
+            'conclusion': 'success',
+            'run_started_at': '2026-03-01T10:00:00Z',
+            'updated_at': '2026-03-01T10:02:30Z',
+          },
+          // No start time -> null duration (not negative/zero).
+          {
+            'id': 2,
+            'name': 'CI',
+            'status': 'completed',
+            'conclusion': 'success',
+            'updated_at': '2026-03-01T09:00:00Z',
+          },
+        ],
+      },
+      repoKey: 'github:o/r',
+      repoDisplay: 'o/r',
+    );
+    expect(gh[0].durationMs, 150000); // 2m30s
+    expect(gh[1].durationMs, isNull);
+
+    final ado = ActivityService.ciRunSamplesFromAdoBuilds(
+      {
+        'value': [
+          {
+            'id': 55,
+            'definition': {'id': 3, 'name': 'Pipeline'},
+            'status': 'completed',
+            'result': 'succeeded',
+            'startTime': '2026-03-01T10:00:00Z',
+            'finishTime': '2026-03-01T10:05:00Z',
+          },
+        ],
+      },
+      repoKey: 'ado:o/p/r',
+      repoDisplay: 'o/p/r',
+    );
+    expect(ado.single.durationMs, 300000); // 5m
+  });
+
   test(
     'ciRunSamplesFromGithubRuns keys by run id + attempt, groups by workflow id',
     () {

--- a/test/ci_run_history_store_test.dart
+++ b/test/ci_run_history_store_test.dart
@@ -14,6 +14,7 @@ CiRunSample _sample(
   String conclusion = 'success',
   String? workflowId,
   DateTime? finishedAt,
+  int? durationMs,
   String? url,
 }) => CiRunSample(
   provider: 'github',
@@ -25,6 +26,7 @@ CiRunSample _sample(
   outcome: outcome,
   conclusion: conclusion,
   finishedAt: finishedAt ?? DateTime.utc(2026, 1, 10),
+  durationMs: durationMs,
   url: url ?? 'https://example.com/$runKey',
 );
 
@@ -273,6 +275,64 @@ void main() {
 
     final samples = await CiRunHistoryStore.allSamples();
     expect(samples, isEmpty, reason: 'the pre-v11 all-branch cache is cleared');
+    await upgraded.close();
+  });
+
+  test('durationMs round-trips through the store', () async {
+    final now = DateTime.utc(2026, 1, 11);
+    await CiRunHistoryStore.record([
+      _sample('build', runKey: 'github:owner/name:1', durationMs: 123456),
+      _sample('build', runKey: 'github:owner/name:2'),
+    ], now: now);
+    final byKey = {
+      for (final s in await CiRunHistoryStore.allSamples()) s.runKey: s,
+    };
+    expect(byKey['github:owner/name:1']!.durationMs, 123456);
+    expect(byKey['github:owner/name:2']!.durationMs, isNull);
+  });
+
+  test('v11 -> v12 upgrade adds duration_ms and keeps rows', () async {
+    // A v11 database (ci_run_history without duration_ms) with a row: opening
+    // AppDatabase (now v12) must ALTER TABLE to add duration_ms without loss.
+    final native = sqlite3.openInMemory();
+    native.execute('''
+      CREATE TABLE ci_run_history (
+        id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        provider TEXT NOT NULL,
+        repo_key TEXT NOT NULL,
+        repo_display TEXT NOT NULL,
+        workflow TEXT NOT NULL,
+        workflow_id TEXT,
+        run_key TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        conclusion TEXT NOT NULL,
+        branch TEXT,
+        finished_at INTEGER,
+        url TEXT
+      );
+    ''');
+    native.execute(
+      "INSERT INTO ci_run_history "
+      "(provider, repo_key, repo_display, workflow, run_key, outcome, conclusion, finished_at) "
+      "VALUES ('github','github:o/r','o/r','CI','github:o/r:9:1','success','success',1000);",
+    );
+    native.execute('PRAGMA user_version = 11;');
+    final upgraded = AppDatabase.forExecutor(
+      NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+    );
+    CiRunHistoryStore.debugUseDatabase(upgraded);
+
+    final samples = await CiRunHistoryStore.allSamples();
+    expect(samples, hasLength(1), reason: 'the pre-v12 row is preserved');
+    expect(samples.single.durationMs, isNull);
+    // The new column is writable after the migration.
+    await CiRunHistoryStore.record([
+      _sample('build', runKey: 'github:o/r:10:1', durationMs: 5000),
+    ], now: DateTime.utc(2026, 1, 11));
+    final withDuration = (await CiRunHistoryStore.allSamples()).firstWhere(
+      (s) => s.runKey == 'github:o/r:10:1',
+    );
+    expect(withDuration.durationMs, 5000);
     await upgraded.close();
   });
 }

--- a/test/ci_run_history_test.dart
+++ b/test/ci_run_history_test.dart
@@ -7,6 +7,7 @@ CiRunSample _s(
   DateTime finishedAt, {
   String repoKey = 'github:owner/name',
   String repoDisplay = 'owner/name',
+  int? durationMs,
 }) => CiRunSample(
   provider: 'github',
   repoKey: repoKey,
@@ -16,6 +17,7 @@ CiRunSample _s(
   outcome: outcome,
   conclusion: outcome,
   finishedAt: finishedAt,
+  durationMs: durationMs,
 );
 
 void main() {
@@ -237,6 +239,116 @@ void main() {
       ], now: base);
       expect(trends.first.workflow, 'red');
       expect(trends.last.workflow, 'green');
+    });
+
+    test('computes median duration over successful runs', () {
+      final trends = CiWorkflowTrend.aggregate([
+        _s('build', CiOutcome.success, ago(1), durationMs: 100),
+        _s('build', CiOutcome.success, ago(2), durationMs: 300),
+        _s('build', CiOutcome.success, ago(3), durationMs: 200),
+        // A failure's duration is ignored for the typical-duration signal.
+        _s('build', CiOutcome.failure, ago(4), durationMs: 9999),
+      ], now: base);
+      expect(trends.single.medianDurationMs, 200);
+    });
+
+    test('flags a slowing workflow (recent runs slower than older)', () {
+      // 8 timed successes, newest-first: recent half 500s, older half 200s —
+      // a 2.5x, +300s increase (clears both the ratio and absolute floors).
+      final trends = CiWorkflowTrend.aggregate([
+        for (var i = 0; i < 4; i++)
+          _s('build', CiOutcome.success, ago(i + 1), durationMs: 500000),
+        for (var i = 4; i < 8; i++)
+          _s('build', CiOutcome.success, ago(i + 1), durationMs: 200000),
+      ], now: base);
+      final t = trends.single;
+      expect(t.slowdownRatio, closeTo(2.5, 1e-9));
+      expect(t.isSlowing, isTrue);
+    });
+
+    test('a large relative but tiny absolute change is not slowing', () {
+      // 2s -> 3s is 1.5x but only +1s: below the absolute delta floor.
+      final trends = CiWorkflowTrend.aggregate([
+        for (var i = 0; i < 4; i++)
+          _s('build', CiOutcome.success, ago(i + 1), durationMs: 3000),
+        for (var i = 4; i < 8; i++)
+          _s('build', CiOutcome.success, ago(i + 1), durationMs: 2000),
+      ], now: base);
+      expect(trends.single.slowdownRatio, closeTo(1.5, 1e-9));
+      expect(trends.single.isSlowing, isFalse);
+    });
+
+    test('a steady workflow is not slowing', () {
+      final trends = CiWorkflowTrend.aggregate([
+        for (var i = 0; i < 8; i++)
+          _s('build', CiOutcome.success, ago(i + 1), durationMs: 300000),
+      ], now: base);
+      expect(trends.single.isSlowing, isFalse);
+      expect(trends.single.slowdownRatio, closeTo(1.0, 1e-9));
+    });
+
+    test('slowdown needs a minimum sample; typical needs 3 timed runs', () {
+      final trends = CiWorkflowTrend.aggregate([
+        _s('build', CiOutcome.success, ago(1), durationMs: 900000),
+        _s('build', CiOutcome.success, ago(2), durationMs: 100000),
+      ], now: base);
+      expect(trends.single.slowdownRatio, isNull);
+      expect(trends.single.isSlowing, isFalse);
+      // Only 2 timed runs -> no "typical" duration shown.
+      expect(trends.single.medianDurationMs, isNull);
+    });
+
+    test('slowing ranks above healthy but below flaky/failing', () {
+      CiRunSample s(
+        String wf,
+        String outcome,
+        int i, {
+        int? durationMs,
+        String repoKey = 'github:o/r',
+        String repoDisplay = 'o/r',
+      }) => _s(
+        wf,
+        outcome,
+        ago(i),
+        durationMs: durationMs,
+        repoKey: repoKey,
+        repoDisplay: repoDisplay,
+      );
+      final trends = CiWorkflowTrend.aggregate([
+        // healthy green (no duration)
+        for (var i = 1; i <= 3; i++) s('green', CiOutcome.success, i),
+        // slowing but green
+        for (var i = 1; i <= 4; i++)
+          s(
+            'slow',
+            CiOutcome.success,
+            i,
+            durationMs: 600000,
+            repoKey: 'github:o/s',
+            repoDisplay: 'o/s',
+          ),
+        for (var i = 5; i <= 8; i++)
+          s(
+            'slow',
+            CiOutcome.success,
+            i,
+            durationMs: 200000,
+            repoKey: 'github:o/s',
+            repoDisplay: 'o/s',
+          ),
+        // flaky (alternating), repo o/f
+        for (var i = 1; i <= 4; i++)
+          s(
+            'flaky',
+            i.isEven ? CiOutcome.success : CiOutcome.failure,
+            i,
+            repoKey: 'github:o/f',
+            repoDisplay: 'o/f',
+          ),
+      ], now: base);
+      final order = trends.map((t) => t.workflow).toList();
+      expect(order.indexOf('flaky'), lessThan(order.indexOf('slow')));
+      expect(order.indexOf('slow'), lessThan(order.indexOf('green')));
     });
   });
 }


### PR DESCRIPTION
## What

Extends the **CI trends** insight with **run duration** to surface pipelines that are **slowing down** — a regressing pipeline is worth knowing about even when it's still green.

## How

- **`CiRunSample.durationMs`** (nullable): GitHub `run_started_at`→`updated_at`, ADO `startTime`→`finishTime`, via `_durationMs(start, end)` which returns null when either is missing/unparseable or the delta is non-positive (clock skew). New nullable `duration_ms` column; **schemaVersion 11→12** with an idempotent `ALTER TABLE ADD COLUMN` migration (existing rows keep null).
- **`CiWorkflowTrend`** gains:
  - `medianDurationMs` — the workflow's "typical" run time (median of **successful** runs' durations in the window), shown **only once there are ≥3 timed successes** so a lone run can't masquerade as "typical".
  - `slowdownRatio` + `isSlowing` — recent-half vs older-half median of successful-run durations (needs **≥8 timed successes**, split 4/4). `isSlowing` requires **both** a ≥1.3× relative **and** a ≥10s absolute increase, so trivial jitter on short jobs (2s→3s) isn't flagged.
  - Slowing is a **separate, lower-priority sort tier** (not a severity bump): a genuinely failing/flaky workflow always outranks a slowing-but-green one, while slowing surfaces above healthy. It counts toward `hasProblem`.
- **Views**: a compact `formatDurationMs` helper; the trends tile shows a **"Slowing"** badge + `~<typical>`; the drill-down shows a **"Typical"** stat (rendered `Typical ↑` when slowing, **independent** of the flaky/failing verdict) and **per-run duration** in each run row.

## Review gate

code-review (clean) + rubber-duck pre-open. Rubber-duck caught a blocking issue — "Typical" could be based on a **single** run (misleading right after migration) → now gated on ≥3 timed successes. Non-blocking fixes applied: larger cohorts + an absolute-delta floor (robustness against short-job jitter), a sort **tier** instead of a `+0.3` severity nudge (so slowing never leapfrogs real flakiness), and independent slowdown/verdict rendering in the drill-down. Deferred (documented): timeout runs excluded from duration (a future timeout badge), and the per-repo row cap (a broader per-workflow-quota improvement affecting all trends).

## Tests

Aggregate: median over successes, slowdown flagged (relative+absolute), tiny-absolute-change **not** flagged, steady not slowing, min-sample gating for both typical & slowdown, and the **sort tier** (flaky > slowing-green > healthy). Parsers: GitHub/ADO duration incl. null-when-missing. Store: `durationMs` round-trip + the **v11→v12** migration preserving rows. `dart format` clean, `flutter analyze --fatal-infos` clean, all 413 tests pass.
