### PR TITLE
Add PR review-time / cycle-time trends insight

### DIFF
--- a/lib/cycle_time.dart
+++ b/lib/cycle_time.dart
@@ -1,0 +1,173 @@
+// Models for PR review-time / cycle-time trends: the merged-PR samples
+// accumulated across syncs and the per-repo / per-team summaries rolled up from
+// them (median time-to-first-review and median time-to-merge). Provider-
+// agnostic and pure so they're easy to persist and unit-test.
+
+/// A single merged pull request, keyed by [prKey] (`<repoKey>:<number>`) so
+/// repeated syncs that re-see the same PR don't double-count it.
+class MergedPrSample {
+  const MergedPrSample({
+    required this.provider,
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.prKey,
+    required this.createdAt,
+    required this.mergedAt,
+    this.firstReviewAt,
+    this.title,
+    this.author,
+    this.url,
+  });
+
+  final String provider;
+  final String repoKey;
+  final String repoDisplay;
+
+  /// Stable de-duplication key, e.g. `github:owner/name:1234`.
+  final String prKey;
+
+  final DateTime createdAt;
+  final DateTime mergedAt;
+
+  /// When the PR first received a review, if known (GitHub). Null for providers
+  /// or PRs where a first-review time isn't available.
+  final DateTime? firstReviewAt;
+
+  final String? title;
+  final String? author;
+  final String? url;
+
+  /// Milliseconds from open to first review, or null when unknown / negative.
+  int? get timeToFirstReviewMs {
+    final r = firstReviewAt;
+    if (r == null) return null;
+    final ms = r.difference(createdAt).inMilliseconds;
+    return ms >= 0 ? ms : null;
+  }
+
+  /// Milliseconds from open to merge, or null when the timestamps are invalid.
+  int? get timeToMergeMs {
+    final ms = mergedAt.difference(createdAt).inMilliseconds;
+    return ms >= 0 ? ms : null;
+  }
+}
+
+/// A rolled-up summary of merged-PR timings for a repo or a team.
+class CycleSummary {
+  const CycleSummary({
+    required this.mergedCount,
+    required this.medianTimeToFirstReviewMs,
+    required this.medianTimeToMergeMs,
+    required this.reviewedCount,
+  });
+
+  /// Merged PRs considered (within the window).
+  final int mergedCount;
+
+  /// Of those, how many had a known first-review time.
+  final int reviewedCount;
+
+  /// Median open→first-review, or null when no PR had a first-review time.
+  final int? medianTimeToFirstReviewMs;
+
+  /// Median open→merge, or null when there are no merged PRs.
+  final int? medianTimeToMergeMs;
+
+  bool get isEmpty => mergedCount == 0;
+}
+
+/// A per-repo cycle-time summary with identity, for the trends list.
+class RepoCycleStats {
+  const RepoCycleStats({
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.summary,
+  });
+
+  final String repoKey;
+  final String repoDisplay;
+  final CycleSummary summary;
+}
+
+/// Pure roll-ups over [MergedPrSample]s. No I/O.
+class CycleTimeStats {
+  const CycleTimeStats._();
+
+  /// Summarizes [samples] merged within [window] of [now] into medians.
+  static CycleSummary summarize(
+    Iterable<MergedPrSample> samples, {
+    DateTime? now,
+    Duration window = const Duration(days: 30),
+  }) {
+    final at = now ?? DateTime.now();
+    final cutoff = at.subtract(window);
+    final mergeTimes = <int>[];
+    final reviewTimes = <int>[];
+    var count = 0;
+    for (final s in samples) {
+      if (s.mergedAt.isBefore(cutoff)) continue;
+      count++;
+      final merge = s.timeToMergeMs;
+      if (merge != null) mergeTimes.add(merge);
+      final review = s.timeToFirstReviewMs;
+      if (review != null) reviewTimes.add(review);
+    }
+    return CycleSummary(
+      mergedCount: count,
+      reviewedCount: reviewTimes.length,
+      medianTimeToFirstReviewMs: median(reviewTimes),
+      medianTimeToMergeMs: median(mergeTimes),
+    );
+  }
+
+  /// Per-repo summaries, slowest median merge time first (nulls last).
+  static List<RepoCycleStats> perRepo(
+    Iterable<MergedPrSample> samples, {
+    DateTime? now,
+    Duration window = const Duration(days: 30),
+  }) {
+    final groups = <String, List<MergedPrSample>>{};
+    final display = <String, String>{};
+    for (final s in samples) {
+      groups.putIfAbsent(s.repoKey, () => []).add(s);
+      display[s.repoKey] = s.repoDisplay;
+    }
+    final result = <RepoCycleStats>[];
+    for (final entry in groups.entries) {
+      final summary = summarize(entry.value, now: now, window: window);
+      if (summary.isEmpty) continue;
+      result.add(
+        RepoCycleStats(
+          repoKey: entry.key,
+          repoDisplay: display[entry.key] ?? entry.key,
+          summary: summary,
+        ),
+      );
+    }
+    result.sort((a, b) {
+      final am = a.summary.medianTimeToMergeMs;
+      final bm = b.summary.medianTimeToMergeMs;
+      if (am == null && bm == null) {
+        return a.repoDisplay.toLowerCase().compareTo(
+          b.repoDisplay.toLowerCase(),
+        );
+      }
+      if (am == null) return 1;
+      if (bm == null) return -1;
+      final byMerge = bm.compareTo(am);
+      if (byMerge != 0) return byMerge;
+      return a.repoDisplay.toLowerCase().compareTo(b.repoDisplay.toLowerCase());
+    });
+    return result;
+  }
+
+  /// The median of [values] (average of the two middle elements for an even
+  /// count), or null when empty. Does not mutate [values].
+  static int? median(List<int> values) {
+    if (values.isEmpty) return null;
+    final sorted = [...values]..sort();
+    final mid = sorted.length ~/ 2;
+    if (sorted.length.isOdd) return sorted[mid];
+    return ((sorted[mid - 1] + sorted[mid]) / 2).round();
+  }
+}

--- a/lib/cycle_time.dart
+++ b/lib/cycle_time.dart
@@ -67,10 +67,13 @@ class CycleSummary {
   /// Of those, how many had a known first-review time.
   final int reviewedCount;
 
-  /// Median open→first-review, or null when no PR had a first-review time.
+  /// Median open→first-review, or null when no merged PR in range had a
+  /// (valid, non-author) first-review time.
   final int? medianTimeToFirstReviewMs;
 
-  /// Median open→merge, or null when there are no merged PRs.
+  /// Median open→merge, or null when no merged PR in range has a valid
+  /// (non-negative) merge span — which can happen even when [mergedCount] > 0
+  /// if every span was dropped as invalid.
   final int? medianTimeToMergeMs;
 
   bool get isEmpty => mergedCount == 0;

--- a/lib/cycle_time.dart
+++ b/lib/cycle_time.dart
@@ -161,8 +161,10 @@ class CycleTimeStats {
     return result;
   }
 
-  /// The median of [values] (average of the two middle elements for an even
-  /// count), or null when empty. Does not mutate [values].
+  /// The median of [values], or null when empty. For an even count this is the
+  /// average of the two middle elements, rounded to the nearest int (values are
+  /// millisecond durations, so sub-millisecond rounding is immaterial). Does
+  /// not mutate [values].
   static int? median(List<int> values) {
     if (values.isEmpty) return null;
     final sorted = [...values]..sort();

--- a/lib/cycle_time_service.dart
+++ b/lib/cycle_time_service.dart
@@ -1,0 +1,372 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'cycle_time.dart';
+import 'repo_discovery_service.dart';
+import 'repo_store.dart';
+import 'token_store.dart';
+
+/// Fetches recently-merged pull requests for the monitored repos and normalizes
+/// them into [MergedPrSample]s, so the review-time / cycle-time trends can
+/// accumulate how long PRs take to get a first review and to merge.
+///
+/// This is a separate pass from the activity fetch (which only sees open PRs).
+/// The parsers are pure static methods for unit-testing; [computeAll] wires the
+/// network fetch + monitored-repo iteration, mirroring [ActivityService].
+class CycleTimeService {
+  CycleTimeService._();
+
+  static const Duration _requestTimeout = Duration(seconds: 20);
+
+  /// How many recently-merged PRs to request per repo per sync. Merged PRs are
+  /// accumulated across syncs (deduped by `prKey`), so history fills in over
+  /// time: this is a per-sync sample, not the complete merge log.
+  ///
+  /// KNOWN LIMITATION: a single page ordered by `UPDATED_AT` can undersample a
+  /// repo that merges more than [_pageSize] PRs between syncs (or whose old PRs
+  /// get freshly commented). The medians are then computed over an incomplete
+  /// (but not incorrect) sample. A merged-date-ranged, high-water-mark backfill
+  /// that paginates to completion is a planned follow-up; for now the
+  /// accumulate-across-syncs model keeps each sync cheap while coverage grows.
+  static const int _pageSize = 50;
+
+  /// The GraphQL query for a repo's most-recently-updated merged PRs, with each
+  /// PR's reviews (submission time + state + author) so we can derive the time
+  /// of the first *submitted* review.
+  static const String mergedPullsQuery =
+      r'query($owner:String!,$name:String!,$first:Int!){'
+      r'repository(owner:$owner,name:$name){'
+      r'pullRequests(states:MERGED,first:$first,orderBy:{field:UPDATED_AT,direction:DESC}){'
+      r'nodes{number title url createdAt mergedAt author{login} '
+      r'reviews(first:50){nodes{submittedAt state author{login}}}}'
+      r'}}}';
+
+  // ---- Pure parsers --------------------------------------------------------
+
+  /// Normalizes a GitHub GraphQL merged-PR response into [MergedPrSample]s.
+  /// `firstReviewAt` is the earliest *submitted* review (excluding pending
+  /// drafts, the PR author's own reviews, and any review submitted after the
+  /// merge) so a PR author's own comment-review or a post-merge review doesn't
+  /// count as the first review. PRs missing a number or either timestamp are
+  /// skipped.
+  static List<MergedPrSample> parseGithubGraphqlMergedPulls(
+    dynamic body, {
+    required String repoKey,
+    required String repoDisplay,
+  }) {
+    final nodes = _graphqlPullNodes(body);
+    if (nodes == null) return const [];
+    final result = <MergedPrSample>[];
+    for (final pr in nodes) {
+      if (pr is! Map) continue;
+      final number = pr['number'];
+      if (number is! int) continue;
+      final createdAt = _parseDate(pr['createdAt']);
+      final mergedAt = _parseDate(pr['mergedAt']);
+      if (createdAt == null || mergedAt == null) continue;
+      final prAuthor = _nested(pr['author'], 'login');
+      result.add(
+        MergedPrSample(
+          provider: TokenStore.providerGithub,
+          repoKey: repoKey,
+          repoDisplay: repoDisplay,
+          prKey: '$repoKey:$number',
+          createdAt: createdAt,
+          mergedAt: mergedAt,
+          firstReviewAt: _firstReviewAt(
+            pr['reviews'],
+            excludeLogin: prAuthor,
+            notAfter: mergedAt,
+          ),
+          title: _str(pr, 'title'),
+          author: prAuthor,
+          url: _str(pr, 'url'),
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// Normalizes an Azure DevOps completed-PR list into [MergedPrSample]s. ADO's
+  /// PR API doesn't cheaply expose a first-review timestamp, so `firstReviewAt`
+  /// is left null (time-to-merge only) for the MVP. Only PRs whose merge status
+  /// is `completed` with both a creation and close date are kept.
+  static List<MergedPrSample> parseAdoMergedPulls(
+    dynamic body, {
+    required String repoKey,
+    required String repoDisplay,
+    required String organization,
+    required String project,
+    required String name,
+  }) {
+    final value = body is Map ? body['value'] : body;
+    if (value is! List) return const [];
+    final result = <MergedPrSample>[];
+    for (final pr in value) {
+      if (pr is! Map) continue;
+      final status = pr['status'];
+      if (status is String && status.toLowerCase() != 'completed') continue;
+      final id = pr['pullRequestId'];
+      if (id == null) continue;
+      final createdAt = _parseDate(pr['creationDate']);
+      final mergedAt = _parseDate(pr['closedDate']);
+      if (createdAt == null || mergedAt == null) continue;
+      final author = _nested(pr['createdBy'], 'displayName');
+      result.add(
+        MergedPrSample(
+          provider: TokenStore.providerAdo,
+          repoKey: repoKey,
+          repoDisplay: repoDisplay,
+          prKey: '$repoKey:$id',
+          createdAt: createdAt,
+          mergedAt: mergedAt,
+          title: _str(pr, 'title'),
+          author: author,
+          url:
+              'https://dev.azure.com/$organization/$project/_git/$name/'
+              'pullrequest/$id',
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// The earliest *submitted* review time in a GraphQL `reviews` connection,
+  /// ignoring pending drafts (null `submittedAt` / `state == PENDING`), reviews
+  /// authored by [excludeLogin] (typically the PR author), and — when
+  /// [notAfter] is given — reviews submitted after that instant (e.g. after the
+  /// merge). Null when there are no qualifying reviews.
+  static DateTime? _firstReviewAt(
+    dynamic reviews, {
+    String? excludeLogin,
+    DateTime? notAfter,
+  }) {
+    final nodes = reviews is Map ? reviews['nodes'] : null;
+    if (nodes is! List) return null;
+    DateTime? earliest;
+    for (final review in nodes) {
+      if (review is! Map) continue;
+      final state = review['state'];
+      if (state is String && state.toUpperCase() == 'PENDING') continue;
+      final login = _nested(review['author'], 'login');
+      if (excludeLogin != null && login == excludeLogin) continue;
+      final at = _parseDate(review['submittedAt']);
+      if (at == null) continue;
+      if (notAfter != null && at.isAfter(notAfter)) continue;
+      if (earliest == null || at.isBefore(earliest)) earliest = at;
+    }
+    return earliest;
+  }
+
+  static List<dynamic>? _graphqlPullNodes(dynamic body) {
+    final data = body is Map ? body['data'] : null;
+    final repository = data is Map ? data['repository'] : null;
+    final pullRequests = repository is Map ? repository['pullRequests'] : null;
+    final nodes = pullRequests is Map ? pullRequests['nodes'] : null;
+    return nodes is List ? nodes : null;
+  }
+
+  static DateTime? _parseDate(dynamic value) {
+    if (value is! String || value.isEmpty) return null;
+    return DateTime.tryParse(value);
+  }
+
+  static String? _str(Map map, String key) {
+    final v = map[key];
+    return v is String && v.isNotEmpty ? v : null;
+  }
+
+  static String? _nested(dynamic map, String key) {
+    if (map is! Map) return null;
+    final v = map[key];
+    return v is String && v.isNotEmpty ? v : null;
+  }
+
+  // ---- Network -------------------------------------------------------------
+
+  /// Fetches recently-merged PRs for every monitored repo, returning all
+  /// samples. Never throws — a failed repo contributes no samples. Bounded to
+  /// [concurrency] in-flight requests.
+  static Future<List<MergedPrSample>> computeAll({
+    http.Client? client,
+    int concurrency = 5,
+    Set<String>? onlyRepoKeys,
+  }) async {
+    final httpClient = client ?? http.Client();
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final githubRepos =
+          prefs.getStringList(RepoStore.githubKey) ?? const <String>[];
+      final adoRepos =
+          prefs.getStringList(RepoStore.adoKey) ?? const <String>[];
+
+      final tasks = <Future<List<MergedPrSample>> Function()>[];
+
+      for (final raw in githubRepos) {
+        try {
+          final decoded = jsonDecode(raw);
+          if (decoded is! Map) continue;
+          final owner = _str(decoded, 'owner');
+          final name = _str(decoded, 'repoName');
+          if (owner == null || name == null) continue;
+          final repoKey = RepoDiscoveryService.githubKey(owner, name);
+          if (onlyRepoKeys != null && !onlyRepoKeys.contains(repoKey)) continue;
+          final tokenId = _str(decoded, 'tokenId');
+          tasks.add(
+            () => _fetchGithub(
+              httpClient,
+              owner: owner,
+              name: name,
+              repoKey: repoKey,
+              tokenId: tokenId,
+            ),
+          );
+        } catch (_) {
+          // Skip malformed entries.
+        }
+      }
+
+      for (final raw in adoRepos) {
+        try {
+          final decoded = jsonDecode(raw);
+          if (decoded is! Map) continue;
+          final organization = _str(decoded, 'organization');
+          final project = _str(decoded, 'project');
+          final name = _str(decoded, 'repoName');
+          if (organization == null || project == null || name == null) {
+            continue;
+          }
+          final repoKey = RepoDiscoveryService.adoKey(
+            organization,
+            project,
+            name,
+          );
+          if (onlyRepoKeys != null && !onlyRepoKeys.contains(repoKey)) continue;
+          final tokenId = _str(decoded, 'tokenId');
+          tasks.add(
+            () => _fetchAdo(
+              httpClient,
+              organization: organization,
+              project: project,
+              name: name,
+              repoKey: repoKey,
+              tokenId: tokenId,
+            ),
+          );
+        } catch (_) {
+          // Skip malformed entries.
+        }
+      }
+
+      final batches = await _runBounded(tasks, concurrency);
+      return batches.expand((b) => b).toList();
+    } finally {
+      if (client == null) httpClient.close();
+    }
+  }
+
+  static Future<List<MergedPrSample>> _fetchGithub(
+    http.Client httpClient, {
+    required String owner,
+    required String name,
+    required String repoKey,
+    String? tokenId,
+  }) async {
+    try {
+      final secret = (await TokenStore.resolveGithubSecret(
+        owner,
+        tokenId: tokenId,
+      ))?.trim();
+      if (secret == null || secret.isEmpty) return const [];
+      final response = await httpClient
+          .post(
+            Uri.https('api.github.com', '/graphql'),
+            headers: {
+              'Authorization': 'Bearer $secret',
+              'Content-Type': 'application/json',
+            },
+            body: jsonEncode({
+              'query': mergedPullsQuery,
+              'variables': {'owner': owner, 'name': name, 'first': _pageSize},
+            }),
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode != 200) return const [];
+      final body = jsonDecode(response.body);
+      if (body is Map && body['errors'] != null) return const [];
+      return parseGithubGraphqlMergedPulls(
+        body,
+        repoKey: repoKey,
+        repoDisplay: '$owner/$name',
+      );
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  static Future<List<MergedPrSample>> _fetchAdo(
+    http.Client httpClient, {
+    required String organization,
+    required String project,
+    required String name,
+    required String repoKey,
+    String? tokenId,
+  }) async {
+    try {
+      final secret = (await TokenStore.resolveAdoSecret(
+        organization,
+        tokenId: tokenId,
+      ))?.trim();
+      if (secret == null || secret.isEmpty) return const [];
+      final response = await httpClient
+          .get(
+            Uri.https(
+              'dev.azure.com',
+              '/$organization/$project/_apis/git/repositories/$name/pullrequests',
+              {
+                'searchCriteria.status': 'completed',
+                r'$top': '$_pageSize',
+                'api-version': '6.0',
+              },
+            ),
+            headers: {
+              'Authorization': 'Basic ${base64Encode(utf8.encode(':$secret'))}',
+            },
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode != 200) return const [];
+      return parseAdoMergedPulls(
+        jsonDecode(response.body),
+        repoKey: repoKey,
+        repoDisplay: '$organization/$project/$name',
+        organization: organization,
+        project: project,
+        name: name,
+      );
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  static Future<List<T>> _runBounded<T>(
+    List<Future<T> Function()> tasks,
+    int concurrency,
+  ) async {
+    if (tasks.isEmpty) return <T>[];
+    final results = <T>[];
+    var next = 0;
+    Future<void> worker() async {
+      while (true) {
+        final i = next++;
+        if (i >= tasks.length) break;
+        results.add(await tasks[i]());
+      }
+    }
+
+    final workerCount = concurrency.clamp(1, tasks.length);
+    await Future.wait(List.generate(workerCount, (_) => worker()));
+    return results;
+  }
+}

--- a/lib/cycle_time_service.dart
+++ b/lib/cycle_time_service.dart
@@ -145,13 +145,16 @@ class CycleTimeService {
   }) {
     final nodes = reviews is Map ? reviews['nodes'] : null;
     if (nodes is! List) return null;
+    // GitHub logins are case-insensitive; normalize both sides so the PR
+    // author's own review is excluded regardless of casing/whitespace.
+    final exclude = excludeLogin?.trim().toLowerCase();
     DateTime? earliest;
     for (final review in nodes) {
       if (review is! Map) continue;
       final state = review['state'];
       if (state is String && state.toUpperCase() == 'PENDING') continue;
-      final login = _nested(review['author'], 'login');
-      if (excludeLogin != null && login == excludeLogin) continue;
+      final login = _nested(review['author'], 'login')?.trim().toLowerCase();
+      if (exclude != null && login == exclude) continue;
       final at = _parseDate(review['submittedAt']);
       if (at == null) continue;
       if (notAfter != null && at.isAfter(notAfter)) continue;

--- a/lib/cycle_time_service.dart
+++ b/lib/cycle_time_service.dart
@@ -107,7 +107,7 @@ class CycleTimeService {
     for (final pr in value) {
       if (pr is! Map) continue;
       final status = pr['status'];
-      if (status is String && status.toLowerCase() != 'completed') continue;
+      if (status is! String || status.toLowerCase() != 'completed') continue;
       final id = pr['pullRequestId'];
       if (id == null) continue;
       final createdAt = _parseDate(pr['creationDate']);

--- a/lib/cycle_time_store.dart
+++ b/lib/cycle_time_store.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+
+import 'cycle_time.dart';
+import 'database/app_database.dart';
+
+/// Persists merged pull requests on the local SQLite database (drift) so the
+/// review-time / cycle-time trends can surface how long PRs take to review and
+/// merge, across syncs.
+///
+/// Rows are de-duplicated by `prKey` via an `INSERT OR REPLACE` on its UNIQUE
+/// index, so repeated syncs that re-see the same merged PRs union rather than
+/// double-count. After each write the table is pruned to stay bounded: rows
+/// merged before [retention] ago are dropped, and each repo is capped at
+/// [perRepoCap] newest rows.
+///
+/// Like the other local-DB stores, this owns its own [AppDatabase] singleton
+/// and serializes its writes through a static lock chain.
+class CycleTimeStore {
+  CycleTimeStore._();
+
+  static AppDatabase? _db;
+
+  static Future<void> _lock = SynchronousFuture<void>(null);
+
+  static Future<T> _runLocked<T>(Future<T> Function() action) {
+    final result = _lock.then((_) => action());
+    _lock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  static AppDatabase get _database => _db ??= AppDatabase();
+
+  /// How long a merged PR stays in history before it's pruned.
+  static const Duration retention = Duration(days: 120);
+
+  /// Cap on rows kept per repo so a very active repo can't grow unbounded.
+  /// Sized to comfortably exceed [retention]'s worth of merges for an active
+  /// repo (~10 merged PRs/day over 120 days), so the advertised windows (up to
+  /// 90 days) aren't silently clipped for busy repos.
+  static const int perRepoCap = 1200;
+
+  @visibleForTesting
+  static void debugUseDatabase(AppDatabase db) {
+    _db = db;
+    _lock = SynchronousFuture<void>(null);
+  }
+
+  /// Records [samples] (skipping any without a `prKey`), de-duplicating by
+  /// `prKey`, then prunes by age and the per-repo cap. A no-op for empty input.
+  static Future<void> record(
+    Iterable<MergedPrSample> samples, {
+    DateTime? now,
+  }) {
+    final rows = samples.where((s) => s.prKey.isNotEmpty).toList();
+    if (rows.isEmpty) return Future<void>.value();
+    final at = now ?? DateTime.now();
+    return _runLocked(() async {
+      final db = _database;
+      await db.transaction(() async {
+        await db.batch((b) {
+          b.insertAll(
+            db.mergedPrs,
+            rows.map(_companion).toList(),
+            mode: InsertMode.insertOrReplace,
+          );
+        });
+        final cutoff = at.subtract(retention).millisecondsSinceEpoch;
+        await (db.delete(
+          db.mergedPrs,
+        )..where((t) => t.mergedAt.isSmallerThanValue(cutoff))).go();
+        for (final repoKey in rows.map((s) => s.repoKey).toSet()) {
+          await _capRepo(db, repoKey);
+        }
+      });
+    });
+  }
+
+  /// Like [record] but never throws — logs and swallows — for UI load paths.
+  static Future<void> recordSafely(
+    Iterable<MergedPrSample> samples, {
+    DateTime? now,
+  }) async {
+    try {
+      await record(samples, now: now);
+    } catch (e, st) {
+      debugPrint('CycleTimeStore.record failed: $e\n$st');
+    }
+  }
+
+  static Future<void> _capRepo(AppDatabase db, String repoKey) async {
+    final ids =
+        await (db.selectOnly(db.mergedPrs)
+              ..addColumns([db.mergedPrs.id])
+              ..where(db.mergedPrs.repoKey.equals(repoKey))
+              ..orderBy([
+                OrderingTerm.desc(db.mergedPrs.mergedAt),
+                OrderingTerm.desc(db.mergedPrs.id),
+              ]))
+            .map((row) => row.read(db.mergedPrs.id)!)
+            .get();
+    if (ids.length <= perRepoCap) return;
+    final toDrop = ids.sublist(perRepoCap);
+    await (db.delete(db.mergedPrs)..where((t) => t.id.isIn(toDrop))).go();
+  }
+
+  /// All stored merged-PR samples (bounded by [retention] and the per-repo
+  /// cap), so a caller can aggregate client-side for any window.
+  static Future<List<MergedPrSample>> allSamples() {
+    return _runLocked(() async {
+      final db = _database;
+      final rows = await db.select(db.mergedPrs).get();
+      return rows.map(_toSample).toList();
+    });
+  }
+
+  /// Drops all history for [repoKey] (e.g. after the repo is removed).
+  static Future<void> removeRepo(String repoKey) async {
+    final key = repoKey.trim();
+    if (key.isEmpty) return;
+    await _runLocked(() async {
+      final db = _database;
+      await (db.delete(db.mergedPrs)..where((t) => t.repoKey.equals(key))).go();
+    });
+  }
+
+  static DateTime _fromMs(int ms) =>
+      DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true);
+
+  static MergedPrSample _toSample(MergedPrRow row) => MergedPrSample(
+    provider: row.provider,
+    repoKey: row.repoKey,
+    repoDisplay: row.repoDisplay,
+    prKey: row.prKey,
+    createdAt: _fromMs(row.createdAt),
+    mergedAt: _fromMs(row.mergedAt),
+    firstReviewAt: row.firstReviewAt == null
+        ? null
+        : _fromMs(row.firstReviewAt!),
+    title: row.title,
+    author: row.author,
+    url: row.url,
+  );
+
+  static MergedPrsCompanion _companion(MergedPrSample s) =>
+      MergedPrsCompanion.insert(
+        provider: s.provider,
+        repoKey: s.repoKey,
+        repoDisplay: s.repoDisplay,
+        prKey: s.prKey,
+        createdAt: s.createdAt.toUtc().millisecondsSinceEpoch,
+        mergedAt: s.mergedAt.toUtc().millisecondsSinceEpoch,
+        firstReviewAt: Value(s.firstReviewAt?.toUtc().millisecondsSinceEpoch),
+        title: Value(s.title),
+        author: Value(s.author),
+        url: Value(s.url),
+      );
+}

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -157,6 +157,28 @@ class CiRunHistory extends Table {
   TextColumn get url => text().nullable()();
 }
 
+/// Accumulated merged-PR history (Phase 6): one row per merged pull request,
+/// de-duplicated by [prKey], powering the review-time / cycle-time trends
+/// (median open→first-review and open→merge per repo/team). Pruned by age and a
+/// per-repo cap so the table stays bounded.
+@DataClassName('MergedPrRow')
+@TableIndex(name: 'idx_merged_prs_pr_key', columns: {#prKey}, unique: true)
+@TableIndex(name: 'idx_merged_prs_repo_key', columns: {#repoKey})
+@TableIndex(name: 'idx_merged_prs_merged_at', columns: {#mergedAt})
+class MergedPrs extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get provider => text()();
+  TextColumn get repoKey => text()();
+  TextColumn get repoDisplay => text()();
+  TextColumn get prKey => text()();
+  IntColumn get createdAt => integer()();
+  IntColumn get mergedAt => integer()();
+  IntColumn get firstReviewAt => integer().nullable()();
+  TextColumn get title => text().nullable()();
+  TextColumn get author => text().nullable()();
+  TextColumn get url => text().nullable()();
+}
+
 /// Per-scope sync provenance (Phase 3): when a cache scope was last refreshed
 /// successfully from the network, so the UI can show an accurate "updated Xh
 /// ago" instead of "just now" when it's actually displaying stale cached data.
@@ -230,6 +252,7 @@ class AppMeta extends Table {
     NotificationSeen,
     NotificationKnownRepos,
     CiRunHistory,
+    MergedPrs,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -240,7 +263,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forExecutor(super.executor);
 
   @override
-  int get schemaVersion => 12;
+  int get schemaVersion => 13;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -438,6 +461,27 @@ class AppDatabase extends _$AppDatabase {
             rethrow;
           }
         }
+      }
+      // v13 adds the merged-PR history table (Phase 6, cycle-time trends). Same
+      // idempotent-DDL reasoning as the CI-history table: `createTable` emits
+      // only `CREATE TABLE IF NOT EXISTS`, so create each @TableIndex explicitly
+      // with `CREATE [UNIQUE] INDEX IF NOT EXISTS` — the unique pr_key index the
+      // upsert relies on especially — so a concurrent background-isolate open
+      // can't crash on an already-existing object.
+      if (from < 13) {
+        await m.createTable(mergedPrs);
+        await customStatement(
+          'CREATE UNIQUE INDEX IF NOT EXISTS idx_merged_prs_pr_key '
+          'ON merged_prs (pr_key)',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_merged_prs_repo_key '
+          'ON merged_prs (repo_key)',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_merged_prs_merged_at '
+          'ON merged_prs (merged_at)',
+        );
       }
     },
   );

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -5114,6 +5114,658 @@ class CiRunHistoryCompanion extends UpdateCompanion<CiRunHistoryRow> {
   }
 }
 
+class $MergedPrsTable extends MergedPrs
+    with TableInfo<$MergedPrsTable, MergedPrRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $MergedPrsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _providerMeta = const VerificationMeta(
+    'provider',
+  );
+  @override
+  late final GeneratedColumn<String> provider = GeneratedColumn<String>(
+    'provider',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _repoKeyMeta = const VerificationMeta(
+    'repoKey',
+  );
+  @override
+  late final GeneratedColumn<String> repoKey = GeneratedColumn<String>(
+    'repo_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _repoDisplayMeta = const VerificationMeta(
+    'repoDisplay',
+  );
+  @override
+  late final GeneratedColumn<String> repoDisplay = GeneratedColumn<String>(
+    'repo_display',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _prKeyMeta = const VerificationMeta('prKey');
+  @override
+  late final GeneratedColumn<String> prKey = GeneratedColumn<String>(
+    'pr_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<int> createdAt = GeneratedColumn<int>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _mergedAtMeta = const VerificationMeta(
+    'mergedAt',
+  );
+  @override
+  late final GeneratedColumn<int> mergedAt = GeneratedColumn<int>(
+    'merged_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _firstReviewAtMeta = const VerificationMeta(
+    'firstReviewAt',
+  );
+  @override
+  late final GeneratedColumn<int> firstReviewAt = GeneratedColumn<int>(
+    'first_review_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _authorMeta = const VerificationMeta('author');
+  @override
+  late final GeneratedColumn<String> author = GeneratedColumn<String>(
+    'author',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _urlMeta = const VerificationMeta('url');
+  @override
+  late final GeneratedColumn<String> url = GeneratedColumn<String>(
+    'url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    provider,
+    repoKey,
+    repoDisplay,
+    prKey,
+    createdAt,
+    mergedAt,
+    firstReviewAt,
+    title,
+    author,
+    url,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'merged_prs';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<MergedPrRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('provider')) {
+      context.handle(
+        _providerMeta,
+        provider.isAcceptableOrUnknown(data['provider']!, _providerMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_providerMeta);
+    }
+    if (data.containsKey('repo_key')) {
+      context.handle(
+        _repoKeyMeta,
+        repoKey.isAcceptableOrUnknown(data['repo_key']!, _repoKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_repoKeyMeta);
+    }
+    if (data.containsKey('repo_display')) {
+      context.handle(
+        _repoDisplayMeta,
+        repoDisplay.isAcceptableOrUnknown(
+          data['repo_display']!,
+          _repoDisplayMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_repoDisplayMeta);
+    }
+    if (data.containsKey('pr_key')) {
+      context.handle(
+        _prKeyMeta,
+        prKey.isAcceptableOrUnknown(data['pr_key']!, _prKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_prKeyMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('merged_at')) {
+      context.handle(
+        _mergedAtMeta,
+        mergedAt.isAcceptableOrUnknown(data['merged_at']!, _mergedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_mergedAtMeta);
+    }
+    if (data.containsKey('first_review_at')) {
+      context.handle(
+        _firstReviewAtMeta,
+        firstReviewAt.isAcceptableOrUnknown(
+          data['first_review_at']!,
+          _firstReviewAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    }
+    if (data.containsKey('author')) {
+      context.handle(
+        _authorMeta,
+        author.isAcceptableOrUnknown(data['author']!, _authorMeta),
+      );
+    }
+    if (data.containsKey('url')) {
+      context.handle(
+        _urlMeta,
+        url.isAcceptableOrUnknown(data['url']!, _urlMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  MergedPrRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return MergedPrRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      provider: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}provider'],
+      )!,
+      repoKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_key'],
+      )!,
+      repoDisplay: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}repo_display'],
+      )!,
+      prKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}pr_key'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}created_at'],
+      )!,
+      mergedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}merged_at'],
+      )!,
+      firstReviewAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}first_review_at'],
+      ),
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      ),
+      author: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}author'],
+      ),
+      url: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}url'],
+      ),
+    );
+  }
+
+  @override
+  $MergedPrsTable createAlias(String alias) {
+    return $MergedPrsTable(attachedDatabase, alias);
+  }
+}
+
+class MergedPrRow extends DataClass implements Insertable<MergedPrRow> {
+  final int id;
+  final String provider;
+  final String repoKey;
+  final String repoDisplay;
+  final String prKey;
+  final int createdAt;
+  final int mergedAt;
+  final int? firstReviewAt;
+  final String? title;
+  final String? author;
+  final String? url;
+  const MergedPrRow({
+    required this.id,
+    required this.provider,
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.prKey,
+    required this.createdAt,
+    required this.mergedAt,
+    this.firstReviewAt,
+    this.title,
+    this.author,
+    this.url,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['provider'] = Variable<String>(provider);
+    map['repo_key'] = Variable<String>(repoKey);
+    map['repo_display'] = Variable<String>(repoDisplay);
+    map['pr_key'] = Variable<String>(prKey);
+    map['created_at'] = Variable<int>(createdAt);
+    map['merged_at'] = Variable<int>(mergedAt);
+    if (!nullToAbsent || firstReviewAt != null) {
+      map['first_review_at'] = Variable<int>(firstReviewAt);
+    }
+    if (!nullToAbsent || title != null) {
+      map['title'] = Variable<String>(title);
+    }
+    if (!nullToAbsent || author != null) {
+      map['author'] = Variable<String>(author);
+    }
+    if (!nullToAbsent || url != null) {
+      map['url'] = Variable<String>(url);
+    }
+    return map;
+  }
+
+  MergedPrsCompanion toCompanion(bool nullToAbsent) {
+    return MergedPrsCompanion(
+      id: Value(id),
+      provider: Value(provider),
+      repoKey: Value(repoKey),
+      repoDisplay: Value(repoDisplay),
+      prKey: Value(prKey),
+      createdAt: Value(createdAt),
+      mergedAt: Value(mergedAt),
+      firstReviewAt: firstReviewAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(firstReviewAt),
+      title: title == null && nullToAbsent
+          ? const Value.absent()
+          : Value(title),
+      author: author == null && nullToAbsent
+          ? const Value.absent()
+          : Value(author),
+      url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+    );
+  }
+
+  factory MergedPrRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return MergedPrRow(
+      id: serializer.fromJson<int>(json['id']),
+      provider: serializer.fromJson<String>(json['provider']),
+      repoKey: serializer.fromJson<String>(json['repoKey']),
+      repoDisplay: serializer.fromJson<String>(json['repoDisplay']),
+      prKey: serializer.fromJson<String>(json['prKey']),
+      createdAt: serializer.fromJson<int>(json['createdAt']),
+      mergedAt: serializer.fromJson<int>(json['mergedAt']),
+      firstReviewAt: serializer.fromJson<int?>(json['firstReviewAt']),
+      title: serializer.fromJson<String?>(json['title']),
+      author: serializer.fromJson<String?>(json['author']),
+      url: serializer.fromJson<String?>(json['url']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'provider': serializer.toJson<String>(provider),
+      'repoKey': serializer.toJson<String>(repoKey),
+      'repoDisplay': serializer.toJson<String>(repoDisplay),
+      'prKey': serializer.toJson<String>(prKey),
+      'createdAt': serializer.toJson<int>(createdAt),
+      'mergedAt': serializer.toJson<int>(mergedAt),
+      'firstReviewAt': serializer.toJson<int?>(firstReviewAt),
+      'title': serializer.toJson<String?>(title),
+      'author': serializer.toJson<String?>(author),
+      'url': serializer.toJson<String?>(url),
+    };
+  }
+
+  MergedPrRow copyWith({
+    int? id,
+    String? provider,
+    String? repoKey,
+    String? repoDisplay,
+    String? prKey,
+    int? createdAt,
+    int? mergedAt,
+    Value<int?> firstReviewAt = const Value.absent(),
+    Value<String?> title = const Value.absent(),
+    Value<String?> author = const Value.absent(),
+    Value<String?> url = const Value.absent(),
+  }) => MergedPrRow(
+    id: id ?? this.id,
+    provider: provider ?? this.provider,
+    repoKey: repoKey ?? this.repoKey,
+    repoDisplay: repoDisplay ?? this.repoDisplay,
+    prKey: prKey ?? this.prKey,
+    createdAt: createdAt ?? this.createdAt,
+    mergedAt: mergedAt ?? this.mergedAt,
+    firstReviewAt: firstReviewAt.present
+        ? firstReviewAt.value
+        : this.firstReviewAt,
+    title: title.present ? title.value : this.title,
+    author: author.present ? author.value : this.author,
+    url: url.present ? url.value : this.url,
+  );
+  MergedPrRow copyWithCompanion(MergedPrsCompanion data) {
+    return MergedPrRow(
+      id: data.id.present ? data.id.value : this.id,
+      provider: data.provider.present ? data.provider.value : this.provider,
+      repoKey: data.repoKey.present ? data.repoKey.value : this.repoKey,
+      repoDisplay: data.repoDisplay.present
+          ? data.repoDisplay.value
+          : this.repoDisplay,
+      prKey: data.prKey.present ? data.prKey.value : this.prKey,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      mergedAt: data.mergedAt.present ? data.mergedAt.value : this.mergedAt,
+      firstReviewAt: data.firstReviewAt.present
+          ? data.firstReviewAt.value
+          : this.firstReviewAt,
+      title: data.title.present ? data.title.value : this.title,
+      author: data.author.present ? data.author.value : this.author,
+      url: data.url.present ? data.url.value : this.url,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('MergedPrRow(')
+          ..write('id: $id, ')
+          ..write('provider: $provider, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('repoDisplay: $repoDisplay, ')
+          ..write('prKey: $prKey, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('mergedAt: $mergedAt, ')
+          ..write('firstReviewAt: $firstReviewAt, ')
+          ..write('title: $title, ')
+          ..write('author: $author, ')
+          ..write('url: $url')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    provider,
+    repoKey,
+    repoDisplay,
+    prKey,
+    createdAt,
+    mergedAt,
+    firstReviewAt,
+    title,
+    author,
+    url,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is MergedPrRow &&
+          other.id == this.id &&
+          other.provider == this.provider &&
+          other.repoKey == this.repoKey &&
+          other.repoDisplay == this.repoDisplay &&
+          other.prKey == this.prKey &&
+          other.createdAt == this.createdAt &&
+          other.mergedAt == this.mergedAt &&
+          other.firstReviewAt == this.firstReviewAt &&
+          other.title == this.title &&
+          other.author == this.author &&
+          other.url == this.url);
+}
+
+class MergedPrsCompanion extends UpdateCompanion<MergedPrRow> {
+  final Value<int> id;
+  final Value<String> provider;
+  final Value<String> repoKey;
+  final Value<String> repoDisplay;
+  final Value<String> prKey;
+  final Value<int> createdAt;
+  final Value<int> mergedAt;
+  final Value<int?> firstReviewAt;
+  final Value<String?> title;
+  final Value<String?> author;
+  final Value<String?> url;
+  const MergedPrsCompanion({
+    this.id = const Value.absent(),
+    this.provider = const Value.absent(),
+    this.repoKey = const Value.absent(),
+    this.repoDisplay = const Value.absent(),
+    this.prKey = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.mergedAt = const Value.absent(),
+    this.firstReviewAt = const Value.absent(),
+    this.title = const Value.absent(),
+    this.author = const Value.absent(),
+    this.url = const Value.absent(),
+  });
+  MergedPrsCompanion.insert({
+    this.id = const Value.absent(),
+    required String provider,
+    required String repoKey,
+    required String repoDisplay,
+    required String prKey,
+    required int createdAt,
+    required int mergedAt,
+    this.firstReviewAt = const Value.absent(),
+    this.title = const Value.absent(),
+    this.author = const Value.absent(),
+    this.url = const Value.absent(),
+  }) : provider = Value(provider),
+       repoKey = Value(repoKey),
+       repoDisplay = Value(repoDisplay),
+       prKey = Value(prKey),
+       createdAt = Value(createdAt),
+       mergedAt = Value(mergedAt);
+  static Insertable<MergedPrRow> custom({
+    Expression<int>? id,
+    Expression<String>? provider,
+    Expression<String>? repoKey,
+    Expression<String>? repoDisplay,
+    Expression<String>? prKey,
+    Expression<int>? createdAt,
+    Expression<int>? mergedAt,
+    Expression<int>? firstReviewAt,
+    Expression<String>? title,
+    Expression<String>? author,
+    Expression<String>? url,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (provider != null) 'provider': provider,
+      if (repoKey != null) 'repo_key': repoKey,
+      if (repoDisplay != null) 'repo_display': repoDisplay,
+      if (prKey != null) 'pr_key': prKey,
+      if (createdAt != null) 'created_at': createdAt,
+      if (mergedAt != null) 'merged_at': mergedAt,
+      if (firstReviewAt != null) 'first_review_at': firstReviewAt,
+      if (title != null) 'title': title,
+      if (author != null) 'author': author,
+      if (url != null) 'url': url,
+    });
+  }
+
+  MergedPrsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? provider,
+    Value<String>? repoKey,
+    Value<String>? repoDisplay,
+    Value<String>? prKey,
+    Value<int>? createdAt,
+    Value<int>? mergedAt,
+    Value<int?>? firstReviewAt,
+    Value<String?>? title,
+    Value<String?>? author,
+    Value<String?>? url,
+  }) {
+    return MergedPrsCompanion(
+      id: id ?? this.id,
+      provider: provider ?? this.provider,
+      repoKey: repoKey ?? this.repoKey,
+      repoDisplay: repoDisplay ?? this.repoDisplay,
+      prKey: prKey ?? this.prKey,
+      createdAt: createdAt ?? this.createdAt,
+      mergedAt: mergedAt ?? this.mergedAt,
+      firstReviewAt: firstReviewAt ?? this.firstReviewAt,
+      title: title ?? this.title,
+      author: author ?? this.author,
+      url: url ?? this.url,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (provider.present) {
+      map['provider'] = Variable<String>(provider.value);
+    }
+    if (repoKey.present) {
+      map['repo_key'] = Variable<String>(repoKey.value);
+    }
+    if (repoDisplay.present) {
+      map['repo_display'] = Variable<String>(repoDisplay.value);
+    }
+    if (prKey.present) {
+      map['pr_key'] = Variable<String>(prKey.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<int>(createdAt.value);
+    }
+    if (mergedAt.present) {
+      map['merged_at'] = Variable<int>(mergedAt.value);
+    }
+    if (firstReviewAt.present) {
+      map['first_review_at'] = Variable<int>(firstReviewAt.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (author.present) {
+      map['author'] = Variable<String>(author.value);
+    }
+    if (url.present) {
+      map['url'] = Variable<String>(url.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('MergedPrsCompanion(')
+          ..write('id: $id, ')
+          ..write('provider: $provider, ')
+          ..write('repoKey: $repoKey, ')
+          ..write('repoDisplay: $repoDisplay, ')
+          ..write('prKey: $prKey, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('mergedAt: $mergedAt, ')
+          ..write('firstReviewAt: $firstReviewAt, ')
+          ..write('title: $title, ')
+          ..write('author: $author, ')
+          ..write('url: $url')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -5133,6 +5785,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $NotificationKnownReposTable notificationKnownRepos =
       $NotificationKnownReposTable(this);
   late final $CiRunHistoryTable ciRunHistory = $CiRunHistoryTable(this);
+  late final $MergedPrsTable mergedPrs = $MergedPrsTable(this);
   late final Index idxMetricSnapshotsRepoKey = Index(
     'idx_metric_snapshots_repo_key',
     'CREATE INDEX idx_metric_snapshots_repo_key ON metric_snapshots (repo_key)',
@@ -5181,6 +5834,18 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'idx_ci_run_history_finished_at',
     'CREATE INDEX idx_ci_run_history_finished_at ON ci_run_history (finished_at)',
   );
+  late final Index idxMergedPrsPrKey = Index(
+    'idx_merged_prs_pr_key',
+    'CREATE UNIQUE INDEX idx_merged_prs_pr_key ON merged_prs (pr_key)',
+  );
+  late final Index idxMergedPrsRepoKey = Index(
+    'idx_merged_prs_repo_key',
+    'CREATE INDEX idx_merged_prs_repo_key ON merged_prs (repo_key)',
+  );
+  late final Index idxMergedPrsMergedAt = Index(
+    'idx_merged_prs_merged_at',
+    'CREATE INDEX idx_merged_prs_merged_at ON merged_prs (merged_at)',
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -5197,6 +5862,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     notificationSeen,
     notificationKnownRepos,
     ciRunHistory,
+    mergedPrs,
     idxMetricSnapshotsRepoKey,
     idxActivityEventsRepoKey,
     idxActivityEventsOccurredAt,
@@ -5209,6 +5875,9 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     idxCiRunHistoryRunKey,
     idxCiRunHistoryRepoKey,
     idxCiRunHistoryFinishedAt,
+    idxMergedPrsPrKey,
+    idxMergedPrsRepoKey,
+    idxMergedPrsMergedAt,
   ];
 }
 
@@ -7881,6 +8550,318 @@ typedef $$CiRunHistoryTableProcessedTableManager =
       CiRunHistoryRow,
       PrefetchHooks Function()
     >;
+typedef $$MergedPrsTableCreateCompanionBuilder =
+    MergedPrsCompanion Function({
+      Value<int> id,
+      required String provider,
+      required String repoKey,
+      required String repoDisplay,
+      required String prKey,
+      required int createdAt,
+      required int mergedAt,
+      Value<int?> firstReviewAt,
+      Value<String?> title,
+      Value<String?> author,
+      Value<String?> url,
+    });
+typedef $$MergedPrsTableUpdateCompanionBuilder =
+    MergedPrsCompanion Function({
+      Value<int> id,
+      Value<String> provider,
+      Value<String> repoKey,
+      Value<String> repoDisplay,
+      Value<String> prKey,
+      Value<int> createdAt,
+      Value<int> mergedAt,
+      Value<int?> firstReviewAt,
+      Value<String?> title,
+      Value<String?> author,
+      Value<String?> url,
+    });
+
+class $$MergedPrsTableFilterComposer
+    extends Composer<_$AppDatabase, $MergedPrsTable> {
+  $$MergedPrsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get provider => $composableBuilder(
+    column: $table.provider,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get prKey => $composableBuilder(
+    column: $table.prKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get mergedAt => $composableBuilder(
+    column: $table.mergedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get firstReviewAt => $composableBuilder(
+    column: $table.firstReviewAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get author => $composableBuilder(
+    column: $table.author,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$MergedPrsTableOrderingComposer
+    extends Composer<_$AppDatabase, $MergedPrsTable> {
+  $$MergedPrsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get provider => $composableBuilder(
+    column: $table.provider,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get repoKey => $composableBuilder(
+    column: $table.repoKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get prKey => $composableBuilder(
+    column: $table.prKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get mergedAt => $composableBuilder(
+    column: $table.mergedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get firstReviewAt => $composableBuilder(
+    column: $table.firstReviewAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get author => $composableBuilder(
+    column: $table.author,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$MergedPrsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $MergedPrsTable> {
+  $$MergedPrsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get provider =>
+      $composableBuilder(column: $table.provider, builder: (column) => column);
+
+  GeneratedColumn<String> get repoKey =>
+      $composableBuilder(column: $table.repoKey, builder: (column) => column);
+
+  GeneratedColumn<String> get repoDisplay => $composableBuilder(
+    column: $table.repoDisplay,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get prKey =>
+      $composableBuilder(column: $table.prKey, builder: (column) => column);
+
+  GeneratedColumn<int> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<int> get mergedAt =>
+      $composableBuilder(column: $table.mergedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get firstReviewAt => $composableBuilder(
+    column: $table.firstReviewAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get author =>
+      $composableBuilder(column: $table.author, builder: (column) => column);
+
+  GeneratedColumn<String> get url =>
+      $composableBuilder(column: $table.url, builder: (column) => column);
+}
+
+class $$MergedPrsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $MergedPrsTable,
+          MergedPrRow,
+          $$MergedPrsTableFilterComposer,
+          $$MergedPrsTableOrderingComposer,
+          $$MergedPrsTableAnnotationComposer,
+          $$MergedPrsTableCreateCompanionBuilder,
+          $$MergedPrsTableUpdateCompanionBuilder,
+          (
+            MergedPrRow,
+            BaseReferences<_$AppDatabase, $MergedPrsTable, MergedPrRow>,
+          ),
+          MergedPrRow,
+          PrefetchHooks Function()
+        > {
+  $$MergedPrsTableTableManager(_$AppDatabase db, $MergedPrsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$MergedPrsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$MergedPrsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$MergedPrsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> provider = const Value.absent(),
+                Value<String> repoKey = const Value.absent(),
+                Value<String> repoDisplay = const Value.absent(),
+                Value<String> prKey = const Value.absent(),
+                Value<int> createdAt = const Value.absent(),
+                Value<int> mergedAt = const Value.absent(),
+                Value<int?> firstReviewAt = const Value.absent(),
+                Value<String?> title = const Value.absent(),
+                Value<String?> author = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+              }) => MergedPrsCompanion(
+                id: id,
+                provider: provider,
+                repoKey: repoKey,
+                repoDisplay: repoDisplay,
+                prKey: prKey,
+                createdAt: createdAt,
+                mergedAt: mergedAt,
+                firstReviewAt: firstReviewAt,
+                title: title,
+                author: author,
+                url: url,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String provider,
+                required String repoKey,
+                required String repoDisplay,
+                required String prKey,
+                required int createdAt,
+                required int mergedAt,
+                Value<int?> firstReviewAt = const Value.absent(),
+                Value<String?> title = const Value.absent(),
+                Value<String?> author = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+              }) => MergedPrsCompanion.insert(
+                id: id,
+                provider: provider,
+                repoKey: repoKey,
+                repoDisplay: repoDisplay,
+                prKey: prKey,
+                createdAt: createdAt,
+                mergedAt: mergedAt,
+                firstReviewAt: firstReviewAt,
+                title: title,
+                author: author,
+                url: url,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$MergedPrsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $MergedPrsTable,
+      MergedPrRow,
+      $$MergedPrsTableFilterComposer,
+      $$MergedPrsTableOrderingComposer,
+      $$MergedPrsTableAnnotationComposer,
+      $$MergedPrsTableCreateCompanionBuilder,
+      $$MergedPrsTableUpdateCompanionBuilder,
+      (
+        MergedPrRow,
+        BaseReferences<_$AppDatabase, $MergedPrsTable, MergedPrRow>,
+      ),
+      MergedPrRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -7910,4 +8891,6 @@ class $AppDatabaseManager {
       );
   $$CiRunHistoryTableTableManager get ciRunHistory =>
       $$CiRunHistoryTableTableManager(_db, _db.ciRunHistory);
+  $$MergedPrsTableTableManager get mergedPrs =>
+      $$MergedPrsTableTableManager(_db, _db.mergedPrs);
 }

--- a/lib/manage_repos_page.dart
+++ b/lib/manage_repos_page.dart
@@ -7,6 +7,7 @@ import 'register_github_repo.dart';
 import 'register_ado_repo.dart';
 import 'activity_event_store.dart';
 import 'ci_run_history_store.dart';
+import 'cycle_time_store.dart';
 import 'repo_detail_store.dart';
 import 'sync_state_store.dart';
 import 'ignore_store.dart';
@@ -259,6 +260,7 @@ class _ManageReposPageState extends State<ManageReposPage> {
         await SyncStateStore.remove(SyncStateStore.repoScope(repoKey));
         await TeamStore.removeRepoFromAll(repoKey);
         await CiRunHistoryStore.removeRepo(repoKey);
+        await CycleTimeStore.removeRepo(repoKey);
       }
     }
     // Mutes are keyed by display label, not repoKey, so prune independently:

--- a/lib/sync_service.dart
+++ b/lib/sync_service.dart
@@ -9,6 +9,8 @@ import 'app_http.dart';
 import 'attention_service.dart';
 import 'attention_store.dart';
 import 'ci_run_history_store.dart';
+import 'cycle_time_service.dart';
+import 'cycle_time_store.dart';
 import 'identity_store.dart';
 import 'metric_store.dart';
 import 'monitored_repos.dart';
@@ -159,6 +161,17 @@ class SyncService {
       }
     }
 
+    Future<void> cyclePhase() async {
+      try {
+        final samples = await withDeadline(
+          CycleTimeService.computeAll(client: httpClient),
+        );
+        await CycleTimeStore.recordSafely(samples);
+      } catch (e, st) {
+        debugPrint('SyncService: cycle-time capture failed: $e\n$st');
+      }
+    }
+
     if (background) {
       // Concurrent to fit the budget; each phase is independently deadlined and
       // its errors isolated.
@@ -167,6 +180,7 @@ class SyncService {
         activityPhase().then((r) => result = r),
         attentionPhase(),
         feedPhase(),
+        cyclePhase(),
       ]);
       return result;
     }
@@ -174,6 +188,7 @@ class SyncService {
     final result = await activityPhase();
     await attentionPhase();
     await feedPhase();
+    await cyclePhase();
     return result;
   }
 }

--- a/lib/views/cycle_time_view.dart
+++ b/lib/views/cycle_time_view.dart
@@ -50,7 +50,7 @@ class _CycleTimeViewState extends State<CycleTimeView> {
                 Expanded(
                   child: Text(
                     overall.isEmpty
-                        ? 'No merged PRs yet'
+                        ? 'No merged PRs in the last ${_windowDays}d'
                         : '${overall.mergedCount} merged · '
                               'review ${_fmt(overall.medianTimeToFirstReviewMs)} · '
                               'merge ${_fmt(overall.medianTimeToMergeMs)}',
@@ -132,12 +132,17 @@ class _CycleTimeViewState extends State<CycleTimeView> {
   List<_TeamCycle> _teamStats(List<MergedPrSample> samples, DateTime now) {
     final teams = widget.data.teams;
     if (teams.isEmpty) return const [];
+    // Index samples by repoKey once (O(samples)) instead of rescanning the full
+    // list per team (O(teams × samples)); each team then unions its repos' rows.
+    final byRepo = <String, List<MergedPrSample>>{};
+    for (final s in samples) {
+      byRepo.putIfAbsent(s.repoKey, () => []).add(s);
+    }
     final result = <_TeamCycle>[];
     for (final team in teams) {
       if (team.repoKeys.isEmpty) continue;
-      final teamSamples = samples
-          .where((s) => team.repoKeys.contains(s.repoKey))
-          .toList();
+      final teamSamples = [for (final key in team.repoKeys) ...?byRepo[key]];
+      if (teamSamples.isEmpty) continue;
       final summary = CycleTimeStats.summarize(
         teamSamples,
         now: now,

--- a/lib/views/cycle_time_view.dart
+++ b/lib/views/cycle_time_view.dart
@@ -1,0 +1,446 @@
+import 'package:flutter/material.dart';
+
+import '../cycle_time.dart';
+import '../team.dart';
+import 'views_common.dart';
+
+/// Surfaces how long pull requests take to get a first review and to merge,
+/// aggregated from the accumulated merged-PR history. Repos are ranked
+/// slowest-to-merge first so the cycle-time bottlenecks bubble up; an optional
+/// per-team section rolls the same medians up by team. A window selector
+/// re-aggregates the already-loaded samples client-side; tapping a repo drills
+/// into its individual merged PRs.
+class CycleTimeView extends StatefulWidget {
+  const CycleTimeView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  State<CycleTimeView> createState() => _CycleTimeViewState();
+}
+
+class _CycleTimeViewState extends State<CycleTimeView> {
+  static const List<int> _windowChoices = [7, 30, 90];
+  int _windowDays = 30;
+
+  Duration get _window => Duration(days: _windowDays);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final samples = widget.data.cycleSamples;
+    final now = widget.data.loadedAt;
+    final repos = CycleTimeStats.perRepo(samples, now: now, window: _window);
+    final overall = CycleTimeStats.summarize(
+      samples,
+      now: now,
+      window: _window,
+    );
+    final teamStats = _teamStats(samples, now);
+
+    return ViewScaffold(
+      title: 'Cycle time',
+      loadedAt: now,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    overall.isEmpty
+                        ? 'No merged PRs yet'
+                        : '${overall.mergedCount} merged · '
+                              'review ${_fmt(overall.medianTimeToFirstReviewMs)} · '
+                              'merge ${_fmt(overall.medianTimeToMergeMs)}',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                SegmentedButton<int>(
+                  showSelectedIcon: false,
+                  style: const ButtonStyle(
+                    visualDensity: VisualDensity.compact,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  segments: [
+                    for (final d in _windowChoices)
+                      ButtonSegment(value: d, label: Text('${d}d')),
+                  ],
+                  selected: {_windowDays},
+                  onSelectionChanged: (s) =>
+                      setState(() => _windowDays = s.first),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'Medians for PRs merged in the last $_windowDays days. '
+                'Review time is GitHub-only.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: repos.isEmpty
+                ? const ViewEmpty(
+                    message:
+                        'No merged PRs in range yet.\nMerged pull requests '
+                        'accumulate as syncs observe them — check back after a '
+                        'few refreshes.',
+                  )
+                : ListView(
+                    padding: const EdgeInsets.all(12),
+                    children: [
+                      if (teamStats.isNotEmpty) ...[
+                        _SectionLabel(label: 'By team'),
+                        for (final t in teamStats)
+                          _CycleTile(
+                            title: t.name,
+                            subtitle: null,
+                            summary: t.summary,
+                            leadingIcon: Icons.groups_2,
+                          ),
+                        const SizedBox(height: 16),
+                        _SectionLabel(label: 'By repo'),
+                      ],
+                      for (final r in repos)
+                        _CycleTile(
+                          title: r.repoDisplay,
+                          subtitle: null,
+                          summary: r.summary,
+                          leadingIcon: Icons.speed,
+                          onTap: () => _openDetail(r),
+                        ),
+                    ],
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<_TeamCycle> _teamStats(List<MergedPrSample> samples, DateTime now) {
+    final teams = widget.data.teams;
+    if (teams.isEmpty) return const [];
+    final result = <_TeamCycle>[];
+    for (final team in teams) {
+      if (team.repoKeys.isEmpty) continue;
+      final teamSamples = samples
+          .where((s) => team.repoKeys.contains(s.repoKey))
+          .toList();
+      final summary = CycleTimeStats.summarize(
+        teamSamples,
+        now: now,
+        window: _window,
+      );
+      if (summary.isEmpty) continue;
+      result.add(_TeamCycle(team: team, summary: summary));
+    }
+    result.sort((a, b) {
+      final am = a.summary.medianTimeToMergeMs;
+      final bm = b.summary.medianTimeToMergeMs;
+      if (am == null && bm == null) {
+        return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+      }
+      if (am == null) return 1;
+      if (bm == null) return -1;
+      final byMerge = bm.compareTo(am);
+      if (byMerge != 0) return byMerge;
+      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+    });
+    return result;
+  }
+
+  void _openDetail(RepoCycleStats repo) {
+    final cutoff = widget.data.loadedAt.subtract(_window);
+    final prs =
+        widget.data.cycleSamples
+            .where(
+              (s) => s.repoKey == repo.repoKey && !s.mergedAt.isBefore(cutoff),
+            )
+            .toList()
+          ..sort((a, b) => b.mergedAt.compareTo(a.mergedAt));
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => _RepoCycleDetailPage(
+          repoDisplay: repo.repoDisplay,
+          summary: repo.summary,
+          prs: prs,
+          windowDays: _windowDays,
+        ),
+      ),
+    );
+  }
+
+  static String _fmt(int? ms) => formatLongDurationMs(ms) ?? '—';
+}
+
+class _TeamCycle {
+  const _TeamCycle({required this.team, required this.summary});
+  final Team team;
+  final CycleSummary summary;
+  String get name => team.name;
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
+      child: Text(
+        label.toUpperCase(),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.6,
+        ),
+      ),
+    );
+  }
+}
+
+class _CycleTile extends StatelessWidget {
+  const _CycleTile({
+    required this.title,
+    required this.subtitle,
+    required this.summary,
+    required this.leadingIcon,
+    this.onTap,
+  });
+
+  final String title;
+  final String? subtitle;
+  final CycleSummary summary;
+  final IconData leadingIcon;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final review = formatLongDurationMs(summary.medianTimeToFirstReviewMs);
+    final merge = formatLongDurationMs(summary.medianTimeToMergeMs);
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      margin: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(leadingIcon, size: 18, color: theme.colorScheme.primary),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  if (onTap != null)
+                    Icon(
+                      Icons.chevron_right,
+                      size: 18,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Expanded(
+                    child: _Metric(
+                      label: 'First review',
+                      value: review ?? '—',
+                      hint: summary.reviewedCount < summary.mergedCount
+                          ? '${summary.reviewedCount}/${summary.mergedCount} with review time'
+                          : null,
+                    ),
+                  ),
+                  Expanded(
+                    child: _Metric(
+                      label: 'To merge',
+                      value: merge ?? '—',
+                      hint: '${summary.mergedCount} merged',
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  const _Metric({required this.label, required this.value, this.hint});
+
+  final String label;
+  final String value;
+  final String? hint;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label.toUpperCase(),
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+            letterSpacing: 0.5,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          value,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        if (hint != null)
+          Text(
+            hint!,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// Per-repo drill-down: the individual merged PRs behind the medians, newest
+/// merge first, each showing its own open→first-review and open→merge times.
+class _RepoCycleDetailPage extends StatelessWidget {
+  const _RepoCycleDetailPage({
+    required this.repoDisplay,
+    required this.summary,
+    required this.prs,
+    required this.windowDays,
+  });
+
+  final String repoDisplay;
+  final CycleSummary summary;
+  final List<MergedPrSample> prs;
+  final int windowDays;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(repoDisplay)),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                '${summary.mergedCount} merged in the last $windowDays days · '
+                'median review '
+                '${formatLongDurationMs(summary.medianTimeToFirstReviewMs) ?? '—'} · '
+                'median merge '
+                '${formatLongDurationMs(summary.medianTimeToMergeMs) ?? '—'}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: ListView.separated(
+              padding: const EdgeInsets.all(12),
+              itemCount: prs.length,
+              separatorBuilder: (_, _) => const SizedBox(height: 8),
+              itemBuilder: (context, i) => _PrTile(pr: prs[i]),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PrTile extends StatelessWidget {
+  const _PrTile({required this.pr});
+
+  final MergedPrSample pr;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final review = formatLongDurationMs(pr.timeToFirstReviewMs);
+    final merge = formatLongDurationMs(pr.timeToMergeMs);
+    final url = pr.url;
+    final number = pr.prKey.split(':').last;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: url == null ? null : () => openUrl(url),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      pr.title ?? 'PR #$number',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  if (url != null)
+                    Icon(
+                      Icons.open_in_new,
+                      size: 16,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '#$number'
+                '${pr.author != null ? ' · ${pr.author}' : ''}'
+                ' · review ${review ?? '—'} · merge ${merge ?? '—'}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import '../activity_service.dart';
 import '../app_http.dart';
 import '../ci_run_history_store.dart';
+import '../cycle_time_service.dart';
+import '../cycle_time_store.dart';
 import '../metric_store.dart';
 import '../people_service.dart';
 import '../team_service.dart';
@@ -12,6 +14,7 @@ import 'bubble_view.dart';
 import 'ci_grid_view.dart';
 import 'ci_trends_view.dart';
 import 'contributor_cloud_view.dart';
+import 'cycle_time_view.dart';
 import 'donut_view.dart';
 import 'freshness_view.dart';
 import 'health_gauge_view.dart';
@@ -85,6 +88,12 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       blurb: 'Flaky & chronically-failing workflows',
       icon: Icons.timeline,
       builder: (d) => CiTrendsView(data: d),
+    ),
+    ViewInfo(
+      title: 'Cycle time',
+      blurb: 'PR review & merge speed trends',
+      icon: Icons.speed,
+      builder: (d) => CycleTimeView(data: d),
     ),
     ViewInfo(
       title: 'Treemap',
@@ -169,9 +178,10 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
     try {
       // Run the two network passes concurrently so loading People doesn't
       // serialize behind the repo activity fetch.
-      final (activities, people) = await (
+      final (activities, people, cycleFetched) = await (
         ActivityService.computeAll(client: AppHttp.client),
         PeopleService.computeAll(client: AppHttp.client),
+        CycleTimeService.computeAll(client: AppHttp.client),
       ).wait;
       // Record a trend snapshot from this load too (deduped ~1/day), matching
       // Radar/Teams/Digest, so opening Insights also advances trend history.
@@ -182,6 +192,9 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
         activities.expand((a) => a.recentRuns),
       );
       final ciRunSamples = await CiRunHistoryStore.allSamples();
+      // Same accumulate-then-read pattern for merged-PR cycle-time history.
+      await CycleTimeStore.recordSafely(cycleFetched);
+      final cycleSamples = await CycleTimeStore.allSamples();
       final history = await MetricStore.all();
       final teams = await TeamStore.list();
       final rollups = TeamService.rollupAll(teams, activities);
@@ -194,6 +207,7 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
           rollups: rollups,
           people: people,
           ciRunSamples: ciRunSamples,
+          cycleSamples: cycleSamples,
           loadedAt: DateTime.now(),
         );
         _loading = false;

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -176,8 +176,8 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       _error = null;
     });
     try {
-      // Run the two network passes concurrently so loading People doesn't
-      // serialize behind the repo activity fetch.
+      // Run the three network passes concurrently (repo activity, People, and
+      // merged-PR cycle time) so none serializes behind the others.
       final (activities, people, cycleFetched) = await (
         ActivityService.computeAll(client: AppHttp.client),
         PeopleService.computeAll(client: AppHttp.client),

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -164,10 +164,11 @@ String? formatDurationMs(int? ms) {
 }
 
 /// Formats a longer span (up to days) for cycle-time durations, which routinely
-/// run to days rather than the minutes/hours of a CI run. Returns null for
-/// null/non-positive input. E.g. `2d 4h`, `5h 30m`, `12m`.
+/// run to days rather than the minutes/hours of a CI run. Returns null only for
+/// null or negative input; a zero span formats as `<1m` (it's a valid, if rare,
+/// instant span, distinct from "unknown"). E.g. `2d 4h`, `5h 30m`, `12m`.
 String? formatLongDurationMs(int? ms) {
-  if (ms == null || ms <= 0) return null;
+  if (ms == null || ms < 0) return null;
   final totalMinutes = ms ~/ 60000;
   final d = totalMinutes ~/ 1440;
   final h = (totalMinutes % 1440) ~/ 60;

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -3,6 +3,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../activity_service.dart';
 import '../ci_run_history.dart';
+import '../cycle_time.dart';
 import '../metric_snapshot.dart';
 import '../person.dart';
 import '../team.dart';
@@ -21,6 +22,7 @@ class InsightsData {
     required Map<String, TeamRollup> rollups,
     required List<Person> people,
     List<CiRunSample> ciRunSamples = const [],
+    List<MergedPrSample> cycleSamples = const [],
     required this.loadedAt,
   }) : activities = List.unmodifiable(activities),
        history = Map.unmodifiable({
@@ -32,7 +34,8 @@ class InsightsData {
          for (final e in rollups.entries) e.key: _readonlyRollup(e.value),
        }),
        people = List.unmodifiable(people),
-       ciRunSamples = List.unmodifiable(ciRunSamples);
+       ciRunSamples = List.unmodifiable(ciRunSamples),
+       cycleSamples = List.unmodifiable(cycleSamples);
 
   final List<RepoActivity> activities;
   final Map<String, List<MetricSnapshot>> history;
@@ -43,6 +46,10 @@ class InsightsData {
   /// Raw CI run history (default-branch, bounded by retention) from which the
   /// CI trends view aggregates per-workflow trends for a user-chosen window.
   final List<CiRunSample> ciRunSamples;
+
+  /// Raw merged-PR history (bounded by retention) from which the cycle-time
+  /// view aggregates per-repo / per-team review- and merge-time medians.
+  final List<MergedPrSample> cycleSamples;
   final DateTime loadedAt;
 
   /// Repos whose fetch succeeded (errored repos would read as healthy zeros).
@@ -154,6 +161,21 @@ String? formatDurationMs(int? ms) {
   if (h > 0) return m > 0 ? '${h}h ${m}m' : '${h}h';
   if (m > 0) return s > 0 ? '${m}m ${s}s' : '${m}m';
   return '${s}s';
+}
+
+/// Formats a longer span (up to days) for cycle-time durations, which routinely
+/// run to days rather than the minutes/hours of a CI run. Returns null for
+/// null/non-positive input. E.g. `2d 4h`, `5h 30m`, `12m`.
+String? formatLongDurationMs(int? ms) {
+  if (ms == null || ms <= 0) return null;
+  final totalMinutes = ms ~/ 60000;
+  final d = totalMinutes ~/ 1440;
+  final h = (totalMinutes % 1440) ~/ 60;
+  final m = totalMinutes % 60;
+  if (d > 0) return h > 0 ? '${d}d ${h}h' : '${d}d';
+  if (h > 0) return m > 0 ? '${h}h ${m}m' : '${h}h';
+  if (m > 0) return '${m}m';
+  return '<1m';
 }
 
 // ---- Freshness / heat scale -------------------------------------------------

--- a/test/cycle_time_service_test.dart
+++ b/test/cycle_time_service_test.dart
@@ -55,6 +55,28 @@ void main() {
       expect(s.firstReviewAt, DateTime.utc(2026, 1, 10, 5));
     });
 
+    test('excludes the PR author case-insensitively', () {
+      final body = jsonDecode('''
+      {"data":{"repository":{"pullRequests":{"nodes":[
+        {"number":16,"title":"Casing","url":"https://gh/pr/16",
+         "createdAt":"2026-01-10T00:00:00Z","mergedAt":"2026-01-10T06:00:00Z",
+         "author":{"login":"Alice"},
+         "reviews":{"nodes":[
+           {"submittedAt":"2026-01-10T01:00:00Z","state":"COMMENTED","author":{"login":"alice"}},
+           {"submittedAt":"2026-01-10T04:00:00Z","state":"APPROVED","author":{"login":"bob"}}
+         ]}}
+      ]}}}}
+      ''');
+      final s = CycleTimeService.parseGithubGraphqlMergedPulls(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      ).single;
+      // "alice" (lowercased) matches author "Alice"; first real review is
+      // bob's at 04:00.
+      expect(s.firstReviewAt, DateTime.utc(2026, 1, 10, 4));
+    });
+
     test('ignores pending drafts and reviews submitted after the merge', () {
       final body = jsonDecode('''
       {"data":{"repository":{"pullRequests":{"nodes":[

--- a/test/cycle_time_service_test.dart
+++ b/test/cycle_time_service_test.dart
@@ -173,5 +173,31 @@ void main() {
       );
       expect(samples.map((s) => s.prKey), ['ado:org/proj/repo:3']);
     });
+
+    test('skips PRs with a missing or non-string status', () {
+      final body = jsonDecode('''
+      {"value":[
+        {"pullRequestId":1,
+         "creationDate":"2026-01-10T00:00:00Z","closedDate":"2026-01-12T00:00:00Z"},
+        {"pullRequestId":2,"status":123,
+         "creationDate":"2026-01-10T00:00:00Z","closedDate":"2026-01-12T00:00:00Z"},
+        {"pullRequestId":3,"status":"completed",
+         "creationDate":"2026-01-10T00:00:00Z","closedDate":"2026-01-11T00:00:00Z"}
+      ]}
+      ''');
+      final samples = CycleTimeService.parseAdoMergedPulls(
+        body,
+        repoKey: 'ado:org/proj/repo',
+        repoDisplay: 'org/proj/repo',
+        organization: 'org',
+        project: 'proj',
+        name: 'repo',
+      );
+      expect(
+        samples.map((s) => s.prKey),
+        ['ado:org/proj/repo:3'],
+        reason: 'only an explicit "completed" status is eligible',
+      );
+    });
   });
 }

--- a/test/cycle_time_service_test.dart
+++ b/test/cycle_time_service_test.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/cycle_time_service.dart';
+
+void main() {
+  group('parseGithubGraphqlMergedPulls', () {
+    test('maps nodes and derives first-review from earliest submission', () {
+      final body = jsonDecode('''
+      {"data":{"repository":{"pullRequests":{"nodes":[
+        {"number":10,"title":"Add feature","url":"https://gh/pr/10",
+         "createdAt":"2026-01-10T00:00:00Z","mergedAt":"2026-01-10T06:00:00Z",
+         "author":{"login":"alice"},
+         "reviews":{"nodes":[
+           {"submittedAt":"2026-01-10T04:00:00Z","state":"COMMENTED","author":{"login":"bob"}},
+           {"submittedAt":"2026-01-10T02:00:00Z","state":"APPROVED","author":{"login":"carol"}}
+         ]}}
+      ]}}}}
+      ''');
+      final samples = CycleTimeService.parseGithubGraphqlMergedPulls(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      );
+      expect(samples, hasLength(1));
+      final s = samples.single;
+      expect(s.prKey, 'github:o/r:10');
+      expect(s.provider, 'github');
+      expect(s.createdAt, DateTime.utc(2026, 1, 10, 0));
+      expect(s.mergedAt, DateTime.utc(2026, 1, 10, 6));
+      expect(s.firstReviewAt, DateTime.utc(2026, 1, 10, 2));
+      expect(s.author, 'alice');
+      expect(s.title, 'Add feature');
+      expect(s.url, 'https://gh/pr/10');
+    });
+
+    test('ignores reviews authored by the PR author', () {
+      final body = jsonDecode('''
+      {"data":{"repository":{"pullRequests":{"nodes":[
+        {"number":11,"title":"Self","url":"https://gh/pr/11",
+         "createdAt":"2026-01-10T00:00:00Z","mergedAt":"2026-01-10T06:00:00Z",
+         "author":{"login":"alice"},
+         "reviews":{"nodes":[
+           {"submittedAt":"2026-01-10T01:00:00Z","state":"COMMENTED","author":{"login":"alice"}},
+           {"submittedAt":"2026-01-10T05:00:00Z","state":"APPROVED","author":{"login":"bob"}}
+         ]}}
+      ]}}}}
+      ''');
+      final s = CycleTimeService.parseGithubGraphqlMergedPulls(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      ).single;
+      // alice's own review is skipped; first real review is bob's at 05:00.
+      expect(s.firstReviewAt, DateTime.utc(2026, 1, 10, 5));
+    });
+
+    test('ignores pending drafts and reviews submitted after the merge', () {
+      final body = jsonDecode('''
+      {"data":{"repository":{"pullRequests":{"nodes":[
+        {"number":15,"title":"Late","url":"https://gh/pr/15",
+         "createdAt":"2026-01-10T00:00:00Z","mergedAt":"2026-01-10T06:00:00Z",
+         "author":{"login":"alice"},
+         "reviews":{"nodes":[
+           {"submittedAt":null,"state":"PENDING","author":{"login":"bob"}},
+           {"submittedAt":"2026-01-10T03:00:00Z","state":"PENDING","author":{"login":"carol"}},
+           {"submittedAt":"2026-01-10T09:00:00Z","state":"APPROVED","author":{"login":"dave"}},
+           {"submittedAt":"2026-01-10T05:00:00Z","state":"CHANGES_REQUESTED","author":{"login":"erin"}}
+         ]}}
+      ]}}}}
+      ''');
+      final s = CycleTimeService.parseGithubGraphqlMergedPulls(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      ).single;
+      // null/PENDING drafts skipped; dave's 09:00 is after merge (06:00) and
+      // skipped; the earliest qualifying submission is erin's at 05:00.
+      expect(s.firstReviewAt, DateTime.utc(2026, 1, 10, 5));
+    });
+
+    test('null first-review when there are no qualifying reviews', () {
+      final body = jsonDecode('''
+      {"data":{"repository":{"pullRequests":{"nodes":[
+        {"number":12,"title":"No review","url":"https://gh/pr/12",
+         "createdAt":"2026-01-10T00:00:00Z","mergedAt":"2026-01-11T00:00:00Z",
+         "author":{"login":"alice"},
+         "reviews":{"nodes":[]}}
+      ]}}}}
+      ''');
+      final s = CycleTimeService.parseGithubGraphqlMergedPulls(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      ).single;
+      expect(s.firstReviewAt, isNull);
+    });
+
+    test('skips PRs missing number or timestamps', () {
+      final body = jsonDecode('''
+      {"data":{"repository":{"pullRequests":{"nodes":[
+        {"title":"no number","createdAt":"2026-01-10T00:00:00Z",
+         "mergedAt":"2026-01-11T00:00:00Z"},
+        {"number":13,"title":"no merged","createdAt":"2026-01-10T00:00:00Z"},
+        {"number":14,"title":"ok","createdAt":"2026-01-10T00:00:00Z",
+         "mergedAt":"2026-01-11T00:00:00Z","author":{"login":"x"},
+         "reviews":{"nodes":[]}}
+      ]}}}}
+      ''');
+      final samples = CycleTimeService.parseGithubGraphqlMergedPulls(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      );
+      expect(samples.map((s) => s.prKey), ['github:o/r:14']);
+    });
+
+    test('malformed response yields empty list', () {
+      expect(
+        CycleTimeService.parseGithubGraphqlMergedPulls(
+          jsonDecode('{"data":{"repository":null}}'),
+          repoKey: 'github:o/r',
+          repoDisplay: 'o/r',
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  group('parseAdoMergedPulls', () {
+    test('maps completed PRs with a null first-review time', () {
+      final body = jsonDecode('''
+      {"value":[
+        {"pullRequestId":42,"title":"ADO PR","status":"completed",
+         "creationDate":"2026-01-10T00:00:00Z","closedDate":"2026-01-12T00:00:00Z",
+         "createdBy":{"displayName":"Dana"}}
+      ]}
+      ''');
+      final s = CycleTimeService.parseAdoMergedPulls(
+        body,
+        repoKey: 'ado:org/proj/repo',
+        repoDisplay: 'org/proj/repo',
+        organization: 'org',
+        project: 'proj',
+        name: 'repo',
+      ).single;
+      expect(s.prKey, 'ado:org/proj/repo:42');
+      expect(s.provider, 'ado');
+      expect(s.firstReviewAt, isNull);
+      expect(s.timeToMergeMs, const Duration(days: 2).inMilliseconds);
+      expect(s.author, 'Dana');
+      expect(s.url, 'https://dev.azure.com/org/proj/_git/repo/pullrequest/42');
+    });
+
+    test('skips non-completed and timestamp-less PRs', () {
+      final body = jsonDecode('''
+      {"value":[
+        {"pullRequestId":1,"status":"active",
+         "creationDate":"2026-01-10T00:00:00Z","closedDate":"2026-01-12T00:00:00Z"},
+        {"pullRequestId":2,"status":"completed",
+         "creationDate":"2026-01-10T00:00:00Z"},
+        {"pullRequestId":3,"status":"completed",
+         "creationDate":"2026-01-10T00:00:00Z","closedDate":"2026-01-11T00:00:00Z"}
+      ]}
+      ''');
+      final samples = CycleTimeService.parseAdoMergedPulls(
+        body,
+        repoKey: 'ado:org/proj/repo',
+        repoDisplay: 'org/proj/repo',
+        organization: 'org',
+        project: 'proj',
+        name: 'repo',
+      );
+      expect(samples.map((s) => s.prKey), ['ado:org/proj/repo:3']);
+    });
+  });
+}

--- a/test/cycle_time_store_test.dart
+++ b/test/cycle_time_store_test.dart
@@ -1,0 +1,206 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/cycle_time.dart';
+import 'package:kode_radar/cycle_time_store.dart';
+import 'package:kode_radar/database/app_database.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+MergedPrSample _pr({
+  required int number,
+  String repoKey = 'github:owner/name',
+  String repoDisplay = 'owner/name',
+  required DateTime createdAt,
+  required DateTime mergedAt,
+  DateTime? firstReviewAt,
+}) => MergedPrSample(
+  provider: 'github',
+  repoKey: repoKey,
+  repoDisplay: repoDisplay,
+  prKey: '$repoKey:$number',
+  createdAt: createdAt,
+  mergedAt: mergedAt,
+  firstReviewAt: firstReviewAt,
+  title: 'PR $number',
+  author: 'octocat',
+  url: 'https://example.com/$number',
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forExecutor(NativeDatabase.memory());
+    CycleTimeStore.debugUseDatabase(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('round-trips samples including a null first-review', () async {
+    final now = DateTime.utc(2026, 1, 15);
+    await CycleTimeStore.record([
+      _pr(
+        number: 1,
+        createdAt: DateTime.utc(2026, 1, 10, 0),
+        firstReviewAt: DateTime.utc(2026, 1, 10, 2),
+        mergedAt: DateTime.utc(2026, 1, 10, 5),
+      ),
+      _pr(
+        number: 2,
+        createdAt: DateTime.utc(2026, 1, 11, 0),
+        mergedAt: DateTime.utc(2026, 1, 11, 4),
+      ),
+    ], now: now);
+
+    final all = await CycleTimeStore.allSamples();
+    expect(all, hasLength(2));
+    final byKey = {for (final s in all) s.prKey: s};
+    expect(
+      byKey['github:owner/name:1']!.firstReviewAt,
+      DateTime.utc(2026, 1, 10, 2),
+    );
+    expect(byKey['github:owner/name:2']!.firstReviewAt, isNull);
+    expect(byKey['github:owner/name:2']!.title, 'PR 2');
+  });
+
+  test('de-duplicates by prKey (re-seen PR does not double-count)', () async {
+    final now = DateTime.utc(2026, 1, 15);
+    await CycleTimeStore.record([
+      _pr(
+        number: 1,
+        createdAt: DateTime.utc(2026, 1, 10),
+        mergedAt: DateTime.utc(2026, 1, 11),
+      ),
+    ], now: now);
+    // Re-seen PR 1 (same prKey, now with a review time) plus a new PR 2.
+    await CycleTimeStore.record([
+      _pr(
+        number: 1,
+        createdAt: DateTime.utc(2026, 1, 10),
+        firstReviewAt: DateTime.utc(2026, 1, 10, 6),
+        mergedAt: DateTime.utc(2026, 1, 11),
+      ),
+      _pr(
+        number: 2,
+        createdAt: DateTime.utc(2026, 1, 12),
+        mergedAt: DateTime.utc(2026, 1, 13),
+      ),
+    ], now: now);
+
+    final all = await CycleTimeStore.allSamples();
+    expect(all, hasLength(2));
+    final one = all.firstWhere((s) => s.prKey == 'github:owner/name:1');
+    expect(
+      one.firstReviewAt,
+      DateTime.utc(2026, 1, 10, 6),
+      reason: 'the re-seen row is upserted with the newer review time',
+    );
+  });
+
+  test('skips samples with an empty prKey', () async {
+    final now = DateTime.utc(2026, 1, 15);
+    await CycleTimeStore.record([
+      MergedPrSample(
+        provider: 'github',
+        repoKey: 'github:owner/name',
+        repoDisplay: 'owner/name',
+        prKey: '',
+        createdAt: DateTime.utc(2026, 1, 10),
+        mergedAt: DateTime.utc(2026, 1, 11),
+      ),
+      _pr(
+        number: 9,
+        createdAt: DateTime.utc(2026, 1, 12),
+        mergedAt: DateTime.utc(2026, 1, 13),
+      ),
+    ], now: now);
+    final all = await CycleTimeStore.allSamples();
+    expect(all, hasLength(1));
+    expect(all.single.prKey, 'github:owner/name:9');
+  });
+
+  test('age prune drops PRs merged before the retention window', () async {
+    final now = DateTime.utc(2026, 6, 1);
+    await CycleTimeStore.record([
+      _pr(
+        number: 1,
+        createdAt: now.subtract(const Duration(days: 200)),
+        mergedAt: now.subtract(const Duration(days: 200)),
+      ),
+      _pr(
+        number: 2,
+        createdAt: now.subtract(const Duration(days: 2)),
+        mergedAt: now.subtract(const Duration(days: 1)),
+      ),
+    ], now: now);
+    final all = await CycleTimeStore.allSamples();
+    expect(all, hasLength(1));
+    expect(all.single.prKey, 'github:owner/name:2');
+  });
+
+  test('removeRepo drops only that repo history', () async {
+    final now = DateTime.utc(2026, 1, 15);
+    await CycleTimeStore.record([
+      _pr(
+        number: 1,
+        repoKey: 'github:owner/a',
+        repoDisplay: 'owner/a',
+        createdAt: DateTime.utc(2026, 1, 10),
+        mergedAt: DateTime.utc(2026, 1, 11),
+      ),
+      _pr(
+        number: 1,
+        repoKey: 'github:owner/b',
+        repoDisplay: 'owner/b',
+        createdAt: DateTime.utc(2026, 1, 10),
+        mergedAt: DateTime.utc(2026, 1, 11),
+      ),
+    ], now: now);
+    await CycleTimeStore.removeRepo('github:owner/a');
+    final all = await CycleTimeStore.allSamples();
+    expect(all, hasLength(1));
+    expect(all.single.repoKey, 'github:owner/b');
+  });
+
+  test(
+    'v12 -> v13 upgrade creates merged_prs with a working unique index',
+    () async {
+      // A database at the pre-v13 schema (user_version = 12): opening
+      // AppDatabase over it runs onUpgrade(12 -> 13), which must create
+      // merged_prs and its UNIQUE pr_key index (the insert-or-replace de-dup
+      // relies on it).
+      final native = sqlite3.openInMemory();
+      native.execute('PRAGMA user_version = 12;');
+      final upgraded = AppDatabase.forExecutor(
+        NativeDatabase.opened(native, closeUnderlyingOnClose: true),
+      );
+      CycleTimeStore.debugUseDatabase(upgraded);
+
+      final now = DateTime.utc(2026, 1, 15);
+      await CycleTimeStore.record([
+        _pr(
+          number: 1,
+          createdAt: DateTime.utc(2026, 1, 10),
+          mergedAt: DateTime.utc(2026, 1, 11),
+        ),
+      ], now: now);
+      await CycleTimeStore.record([
+        _pr(
+          number: 1,
+          createdAt: DateTime.utc(2026, 1, 10),
+          firstReviewAt: DateTime.utc(2026, 1, 10, 3),
+          mergedAt: DateTime.utc(2026, 1, 11),
+        ),
+      ], now: now);
+
+      final all = await CycleTimeStore.allSamples();
+      // Same prKey replaced rather than duplicated: one row, now with a review.
+      expect(all, hasLength(1));
+      expect(all.single.firstReviewAt, DateTime.utc(2026, 1, 10, 3));
+      await upgraded.close();
+    },
+  );
+}

--- a/test/cycle_time_test.dart
+++ b/test/cycle_time_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/cycle_time.dart';
+
+MergedPrSample _pr({
+  required int number,
+  String repoKey = 'github:owner/name',
+  String repoDisplay = 'owner/name',
+  required DateTime createdAt,
+  required DateTime mergedAt,
+  DateTime? firstReviewAt,
+  String provider = 'github',
+}) => MergedPrSample(
+  provider: provider,
+  repoKey: repoKey,
+  repoDisplay: repoDisplay,
+  prKey: '$repoKey:$number',
+  createdAt: createdAt,
+  mergedAt: mergedAt,
+  firstReviewAt: firstReviewAt,
+  title: 'PR $number',
+  author: 'octocat',
+  url: 'https://example.com/$number',
+);
+
+void main() {
+  group('MergedPrSample timings', () {
+    test('time-to-first-review and time-to-merge computed from timestamps', () {
+      final pr = _pr(
+        number: 1,
+        createdAt: DateTime.utc(2026, 1, 1, 0),
+        firstReviewAt: DateTime.utc(2026, 1, 1, 2),
+        mergedAt: DateTime.utc(2026, 1, 1, 5),
+      );
+      expect(pr.timeToFirstReviewMs, const Duration(hours: 2).inMilliseconds);
+      expect(pr.timeToMergeMs, const Duration(hours: 5).inMilliseconds);
+    });
+
+    test('null first-review yields null review time', () {
+      final pr = _pr(
+        number: 1,
+        createdAt: DateTime.utc(2026, 1, 1),
+        mergedAt: DateTime.utc(2026, 1, 2),
+      );
+      expect(pr.timeToFirstReviewMs, isNull);
+      expect(pr.timeToMergeMs, const Duration(days: 1).inMilliseconds);
+    });
+
+    test('negative spans (clock skew) guard to null', () {
+      final pr = _pr(
+        number: 1,
+        createdAt: DateTime.utc(2026, 1, 2),
+        firstReviewAt: DateTime.utc(2026, 1, 1),
+        mergedAt: DateTime.utc(2026, 1, 1, 12),
+      );
+      expect(pr.timeToFirstReviewMs, isNull);
+      expect(pr.timeToMergeMs, isNull);
+    });
+  });
+
+  group('CycleTimeStats.median', () {
+    test('odd count returns middle', () {
+      expect(CycleTimeStats.median([3, 1, 2]), 2);
+    });
+    test('even count averages the two middle values', () {
+      expect(CycleTimeStats.median([10, 20, 30, 40]), 25);
+    });
+    test('empty returns null and does not mutate input', () {
+      final input = <int>[];
+      expect(CycleTimeStats.median(input), isNull);
+      final ordered = [5, 1, 3];
+      CycleTimeStats.median(ordered);
+      expect(ordered, [5, 1, 3]);
+    });
+  });
+
+  group('CycleTimeStats.summarize', () {
+    final now = DateTime.utc(2026, 2, 1);
+
+    test('medians over PRs merged within the window', () {
+      final samples = [
+        _pr(
+          number: 1,
+          createdAt: DateTime.utc(2026, 1, 30, 0),
+          firstReviewAt: DateTime.utc(2026, 1, 30, 1),
+          mergedAt: DateTime.utc(2026, 1, 30, 3),
+        ),
+        _pr(
+          number: 2,
+          createdAt: DateTime.utc(2026, 1, 31, 0),
+          firstReviewAt: DateTime.utc(2026, 1, 31, 3),
+          mergedAt: DateTime.utc(2026, 1, 31, 9),
+        ),
+      ];
+      final s = CycleTimeStats.summarize(samples, now: now);
+      expect(s.mergedCount, 2);
+      expect(s.reviewedCount, 2);
+      // review: [1h, 3h] -> median 2h; merge: [3h, 9h] -> median 6h
+      expect(
+        s.medianTimeToFirstReviewMs,
+        const Duration(hours: 2).inMilliseconds,
+      );
+      expect(s.medianTimeToMergeMs, const Duration(hours: 6).inMilliseconds);
+    });
+
+    test('excludes PRs merged before the window', () {
+      final samples = [
+        _pr(
+          number: 1,
+          createdAt: DateTime.utc(2025, 12, 1),
+          mergedAt: DateTime.utc(2025, 12, 2),
+        ),
+        _pr(
+          number: 2,
+          createdAt: DateTime.utc(2026, 1, 20),
+          mergedAt: DateTime.utc(2026, 1, 21),
+        ),
+      ];
+      final s = CycleTimeStats.summarize(
+        samples,
+        now: now,
+        window: const Duration(days: 30),
+      );
+      expect(s.mergedCount, 1);
+    });
+
+    test('reviewedCount counts only PRs with a first-review time', () {
+      final samples = [
+        _pr(
+          number: 1,
+          createdAt: DateTime.utc(2026, 1, 30, 0),
+          firstReviewAt: DateTime.utc(2026, 1, 30, 1),
+          mergedAt: DateTime.utc(2026, 1, 30, 2),
+        ),
+        _pr(
+          number: 2,
+          createdAt: DateTime.utc(2026, 1, 31, 0),
+          mergedAt: DateTime.utc(2026, 1, 31, 4),
+        ),
+      ];
+      final s = CycleTimeStats.summarize(samples, now: now);
+      expect(s.mergedCount, 2);
+      expect(s.reviewedCount, 1);
+      expect(
+        s.medianTimeToFirstReviewMs,
+        const Duration(hours: 1).inMilliseconds,
+      );
+    });
+
+    test('empty input is empty summary', () {
+      final s = CycleTimeStats.summarize(const [], now: now);
+      expect(s.isEmpty, isTrue);
+      expect(s.medianTimeToFirstReviewMs, isNull);
+      expect(s.medianTimeToMergeMs, isNull);
+    });
+  });
+
+  group('CycleTimeStats.perRepo', () {
+    final now = DateTime.utc(2026, 2, 1);
+
+    test('sorts slowest median merge first', () {
+      final samples = [
+        _pr(
+          number: 1,
+          repoKey: 'github:o/fast',
+          repoDisplay: 'o/fast',
+          createdAt: DateTime.utc(2026, 1, 31, 0),
+          mergedAt: DateTime.utc(2026, 1, 31, 1),
+        ),
+        _pr(
+          number: 2,
+          repoKey: 'github:o/slow',
+          repoDisplay: 'o/slow',
+          createdAt: DateTime.utc(2026, 1, 20, 0),
+          mergedAt: DateTime.utc(2026, 1, 25, 0),
+        ),
+      ];
+      final repos = CycleTimeStats.perRepo(samples, now: now);
+      expect(repos.map((r) => r.repoKey), ['github:o/slow', 'github:o/fast']);
+    });
+
+    test('drops repos with no PRs in the window', () {
+      final samples = [
+        _pr(
+          number: 1,
+          repoKey: 'github:o/old',
+          repoDisplay: 'o/old',
+          createdAt: DateTime.utc(2025, 11, 1),
+          mergedAt: DateTime.utc(2025, 11, 2),
+        ),
+        _pr(
+          number: 2,
+          repoKey: 'github:o/recent',
+          repoDisplay: 'o/recent',
+          createdAt: DateTime.utc(2026, 1, 28),
+          mergedAt: DateTime.utc(2026, 1, 29),
+        ),
+      ];
+      final repos = CycleTimeStats.perRepo(
+        samples,
+        now: now,
+        window: const Duration(days: 30),
+      );
+      expect(repos.map((r) => r.repoKey), ['github:o/recent']);
+    });
+  });
+}

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kode_radar/activity_service.dart';
 import 'package:kode_radar/ci_run_history.dart';
+import 'package:kode_radar/cycle_time.dart';
 import 'package:kode_radar/metric_snapshot.dart';
 import 'package:kode_radar/person.dart';
 import 'package:kode_radar/team.dart';
@@ -11,6 +12,7 @@ import 'package:kode_radar/views/bubble_view.dart';
 import 'package:kode_radar/views/ci_grid_view.dart';
 import 'package:kode_radar/views/ci_trends_view.dart';
 import 'package:kode_radar/views/contributor_cloud_view.dart';
+import 'package:kode_radar/views/cycle_time_view.dart';
 import 'package:kode_radar/views/donut_view.dart';
 import 'package:kode_radar/views/freshness_view.dart';
 import 'package:kode_radar/views/health_gauge_view.dart';
@@ -129,6 +131,24 @@ InsightsData _sampleData() {
           finishedAt: DateTime.utc(2026, 3, 1, 12).subtract(Duration(days: i)),
         ),
     ],
+    cycleSamples: [
+      for (var i = 0; i < 4; i++)
+        MergedPrSample(
+          provider: 'github',
+          repoKey: 'github:o/alpha',
+          repoDisplay: 'o/alpha',
+          prKey: 'github:o/alpha:$i',
+          // Within the default 30-day window of the fixed loadedAt below.
+          createdAt: DateTime.utc(2026, 2, 25, 8).subtract(Duration(days: i)),
+          mergedAt: DateTime.utc(2026, 2, 26, 8).subtract(Duration(days: i)),
+          firstReviewAt: i.isEven
+              ? DateTime.utc(2026, 2, 25, 14).subtract(Duration(days: i))
+              : null,
+          title: 'PR $i',
+          author: 'alice',
+          url: 'https://github.com/o/alpha/pull/$i',
+        ),
+    ],
     loadedAt: DateTime.utc(2026, 3, 1, 13),
   );
 }
@@ -152,6 +172,7 @@ void main() {
     'Donut': (d) => DonutView(data: d),
     'CiGrid': (d) => CiGridView(data: d),
     'CiTrends': (d) => CiTrendsView(data: d),
+    'CycleTime': (d) => CycleTimeView(data: d),
     'Treemap': (d) => TreemapView(data: d),
     'AgeHistogram': (d) => AgeHistogramView(data: d),
     'Heatmap': (d) => HeatmapView(data: d),


### PR DESCRIPTION
## What

Adds a **Cycle time** insight that accumulates recently-merged pull requests across syncs and surfaces **per-repo and per-team medians of open->first-review and open->merge time** — the review/merge bottlenecks a dev-manager watching several large teams (and many OSS projects) wants to spot.

## How
- **`lib/cycle_time.dart`** — pure models + median aggregation (`MergedPrSample`, `CycleSummary`, `RepoCycleStats`, `CycleTimeStats.summarize/perRepo/median`). Timing getters guard clock-skew (negative -> null).
- **`lib/cycle_time_store.dart`** — accumulating drift store mirroring `CiRunHistoryStore`: own `AppDatabase` connection + static lock, dedupe by `prKey` via `insertOrReplace` on a UNIQUE index, 120-day retention (by `mergedAt`) + per-repo cap, `removeRepo`, `recordSafely`.
- **`lib/cycle_time_service.dart`** — fetches merged PRs per monitored repo: GitHub GraphQL (`states:MERGED` + reviews) and ADO REST (`status=completed`). Pure parsers. `firstReviewAt` = earliest **submitted** review, excluding the PR author, pending drafts, and post-merge reviews.
- **`lib/views/cycle_time_view.dart`** — new insight with a 7/30/90-day window selector, per-team + per-repo medians (slowest-to-merge first), and a per-repo drill-down of the individual merged PRs.
- **DB** — new `MergedPrs` table (UNIQUE `pr_key` index + `repo_key`/`merged_at` indexes); schemaVersion **12->13** with idempotent DDL. Wired into `SyncService` (new `cyclePhase`), the Insights load, and the repo-delete prune.

## Notes / scope
- **Review time is GitHub-only** (ADO exposes no cheap review timestamp); the view labels review-timing coverage honestly (`N/M with review time`) rather than implying the rest went unreviewed.
- Merged PRs are **sampled per sync and accumulated** (deduped by `prKey`); a full merged-date-ranged high-water-mark backfill is a planned follow-up.

## Review gate
Ran **code-review** (no significant issues) and **rubber-duck** before opening. Addressed rubber-duck's blocking items: switched first-review to `submittedAt` + state/post-merge filtering, raised the per-repo cap to cover the retention window for active repos, and made review-timing coverage explicit. The single-page sampling limitation is documented as a follow-up.

## Testing
`dart format` clean, `flutter analyze --fatal-infos` clean, **441 tests pass** (+28 new: aggregation, store dedupe/prune/removeRepo + v12->v13 migration, GitHub/ADO parsers, view smoke test).
