### PR TITLE
Add team trend digest + regression alerts

### DIFF
--- a/lib/notification_seen_store.dart
+++ b/lib/notification_seen_store.dart
@@ -270,16 +270,20 @@ class NotificationSeenStore {
             // Corrupt marker: treat as empty and overwrite below.
           }
         }
-        // Keep only this period's already-notified keys (drop older periods).
+        // Scope everything to this period: only keys prefixed `<periodKey>|`
+        // are considered, so a caller that passes an out-of-period key can't
+        // slip an unprunable entry into the stored set (and it matches the doc:
+        // entries from any other period are pruned).
         final prefix = '$periodKey|';
+        final scoped = currentKeys.where((k) => k.startsWith(prefix)).toSet();
         final kept = stored.where((k) => k.startsWith(prefix)).toSet();
-        final fresh = currentKeys.difference(kept);
+        final fresh = scoped.difference(kept);
         // Skip the write when there's nothing new to record and nothing stale
         // to prune.
         if (fresh.isEmpty && kept.length == stored.length) {
           return <String>{};
         }
-        final updated = <String>{...kept, ...currentKeys};
+        final updated = <String>{...kept, ...scoped};
         await _setMeta(db, _regressionKeysKey, jsonEncode(updated.toList()));
         return fresh;
       }),

--- a/lib/notification_seen_store.dart
+++ b/lib/notification_seen_store.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -227,6 +229,88 @@ class NotificationSeenStore {
             db.appMeta,
           )..where((t) => t.key.equals(_digestShownKey))).go();
         }
+      }),
+    );
+  }
+
+  /// `app_meta` key holding the JSON list of regression alert keys already
+  /// notified in the current period (see [claimNewRegressionKeys]).
+  static const String _regressionKeysKey = 'regression_notified_keys';
+
+  /// Records which of [currentKeys] are newly seen this period and returns just
+  /// those (the ones an alert should fire for). Every key is `<periodKey>|…`;
+  /// entries from any period other than [periodKey] are pruned, so a regression
+  /// that persists into a new period alerts again (once), while one that keeps
+  /// standing within a period doesn't re-alert. The read-modify-write runs in a
+  /// single transaction (SQLite-serialized) so foreground and background-sync
+  /// isolates can't both fire the same alert.
+  ///
+  /// Best-effort across a period boundary: if a slow pre-boundary sync commits
+  /// after a new-period sync, it prunes the newer period's keys and can cause
+  /// one duplicate alert next period. That's a benign, rare cosmetic dupe (no
+  /// data loss), so it isn't guarded against here.
+  static Future<Set<String>> claimNewRegressionKeys(
+    Set<String> currentKeys,
+    String periodKey,
+  ) {
+    final db = _database;
+    return _runLocked(
+      () => db.transaction(() async {
+        final raw = await _getMeta(db, _regressionKeysKey);
+        final stored = <String>{};
+        if (raw != null && raw.isNotEmpty) {
+          try {
+            final decoded = jsonDecode(raw);
+            if (decoded is List) {
+              for (final e in decoded) {
+                if (e is String) stored.add(e);
+              }
+            }
+          } catch (_) {
+            // Corrupt marker: treat as empty and overwrite below.
+          }
+        }
+        // Keep only this period's already-notified keys (drop older periods).
+        final prefix = '$periodKey|';
+        final kept = stored.where((k) => k.startsWith(prefix)).toSet();
+        final fresh = currentKeys.difference(kept);
+        // Skip the write when there's nothing new to record and nothing stale
+        // to prune.
+        if (fresh.isEmpty && kept.length == stored.length) {
+          return <String>{};
+        }
+        final updated = <String>{...kept, ...currentKeys};
+        await _setMeta(db, _regressionKeysKey, jsonEncode(updated.toList()));
+        return fresh;
+      }),
+    );
+  }
+
+  /// Un-marks [keys] (e.g. when showing the alert failed) so a later sync
+  /// re-fires them, mirroring [releaseDailyDigest]. Only removes the given keys
+  /// from the stored set; a no-op when none are present.
+  static Future<void> releaseRegressionKeys(Set<String> keys) {
+    if (keys.isEmpty) return Future<void>.value();
+    final db = _database;
+    return _runLocked(
+      () => db.transaction(() async {
+        final raw = await _getMeta(db, _regressionKeysKey);
+        if (raw == null || raw.isEmpty) return;
+        final stored = <String>{};
+        try {
+          final decoded = jsonDecode(raw);
+          if (decoded is List) {
+            for (final e in decoded) {
+              if (e is String) stored.add(e);
+            }
+          }
+        } catch (_) {
+          return;
+        }
+        final before = stored.length;
+        stored.removeAll(keys);
+        if (stored.length == before) return;
+        await _setMeta(db, _regressionKeysKey, jsonEncode(stored.toList()));
       }),
     );
   }

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -662,8 +662,8 @@ class NotificationService {
         await NotificationSeenStore.releaseRegressionKeys(fresh);
         rethrow;
       }
-    } catch (e) {
-      debugPrint('Failed to show regression notification: $e');
+    } catch (e, st) {
+      debugPrint('Failed to show regression notification: $e\n$st');
     }
   }
 

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -9,12 +9,14 @@ import 'mute_store.dart';
 import 'notification_seen_store.dart';
 import 'preferences_store.dart';
 import 'repo_store.dart';
+import 'trend_digest.dart';
 
 class NotificationService {
   NotificationService._();
 
   static const int _summaryNotificationId = 42001;
   static const int _digestNotificationId = 42002;
+  static const int _regressionNotificationId = 42003;
   static const String _channelId = 'attention_inbox';
   static const String _channelName = 'Attention Inbox';
   static const String _channelDescription =
@@ -612,5 +614,72 @@ class NotificationService {
       debugPrint('Failed to show digest notification: $e');
       return false;
     }
+  }
+
+  /// Raises a notification for team trend regressions (review latency, merge
+  /// time, or CI failure rate up week-over-week). No-ops unless regression
+  /// alerts are enabled and notifications are currently allowed. De-duplicates
+  /// via [NotificationSeenStore.claimNewRegressionKeys] keyed by [periodKey],
+  /// so a standing regression alerts at most once per period. Never throws.
+  static Future<void> notifyRegressions(
+    List<TrendRegression> regressions, {
+    required String periodKey,
+    DateTime? now,
+    AppPreferences? prefs,
+  }) async {
+    try {
+      if (!_isSupportedPlatform || regressions.isEmpty) return;
+      final at = now ?? DateTime.now();
+      final appPrefs = prefs ?? await PreferencesStore.load();
+      if (!appPrefs.regressionAlertsEnabled) return;
+      if (!PreferencesStore.notificationsAllowed(appPrefs, at)) return;
+      // Only claim (mark as notified) once we can actually show, so a failed
+      // init/show lets a later sync retry instead of silently swallowing it.
+      await init();
+      if (!_initialized) return;
+      final details = _notificationDetails();
+      if (details == null) return;
+      final fresh = await NotificationSeenStore.claimNewRegressionKeys(
+        regressions.map((r) => r.key).toSet(),
+        periodKey,
+      );
+      if (fresh.isEmpty) return;
+      final freshRegressions = regressions
+          .where((r) => fresh.contains(r.key))
+          .toList(growable: false);
+      if (freshRegressions.isEmpty) return;
+      try {
+        await _plugin.show(
+          id: _regressionNotificationId,
+          title: regressionTitle(freshRegressions.length),
+          body: regressionBody(freshRegressions),
+          notificationDetails: details,
+          payload: attentionPayload,
+        );
+      } catch (e) {
+        // Showing failed after we claimed the keys — release them so a later
+        // sync retries instead of silently dropping the alert for the period.
+        await NotificationSeenStore.releaseRegressionKeys(fresh);
+        rethrow;
+      }
+    } catch (e) {
+      debugPrint('Failed to show regression notification: $e');
+    }
+  }
+
+  /// Title for a regression alert covering [count] regressions. Pure.
+  static String regressionTitle(int count) =>
+      count == 1 ? 'A team trend regressed' : '$count team trends regressed';
+
+  /// Body for a regression alert: up to three "Team: metric a → b" lines, then
+  /// a "+N more" overflow. Pure.
+  static String regressionBody(List<TrendRegression> regressions) {
+    final lines = regressions
+        .take(3)
+        .map((r) => '${r.teamName}: ${r.summary}')
+        .toList();
+    final remaining = regressions.length - lines.length;
+    if (remaining > 0) lines.add('+$remaining more');
+    return lines.join('\n');
   }
 }

--- a/lib/preferences_page.dart
+++ b/lib/preferences_page.dart
@@ -212,6 +212,27 @@ class _PreferencesPageState extends State<PreferencesPage>
                           }
                         : null,
                   ),
+                SwitchListTile(
+                  title: const Text('Team trend alerts'),
+                  subtitle: const Text(
+                    'Notify when a team\u2019s review time, merge time, or CI '
+                    'failure rate rises week-over-week',
+                  ),
+                  value: _prefs.regressionAlertsEnabled,
+                  onChanged: _prefs.notificationsEnabled
+                      ? (value) async {
+                          await PreferencesStore.setRegressionAlertsEnabled(
+                            value,
+                          );
+                          if (!mounted) return;
+                          setState(
+                            () => _prefs = _prefs.copyWith(
+                              regressionAlertsEnabled: value,
+                            ),
+                          );
+                        }
+                      : null,
+                ),
                 const Divider(),
                 _sectionHeader('Activity Feed'),
                 ListTile(

--- a/lib/preferences_store.dart
+++ b/lib/preferences_store.dart
@@ -15,6 +15,7 @@ class AppPreferences {
     this.silencedNotifyCategories = const {},
     this.digestModeEnabled = false,
     this.digestHour = 9,
+    this.regressionAlertsEnabled = true,
   });
 
   final bool notificationsEnabled;
@@ -48,6 +49,10 @@ class AppPreferences {
   /// Local hour [0, 23] at/after which the daily digest is shown.
   final int digestHour;
 
+  /// When true, raise a notification when a team's trends regress week-over-
+  /// week (review latency, merge time, or CI failure rate up past a threshold).
+  final bool regressionAlertsEnabled;
+
   AppPreferences copyWith({
     bool? notificationsEnabled,
     bool? quietHoursEnabled,
@@ -59,6 +64,7 @@ class AppPreferences {
     Set<String>? silencedNotifyCategories,
     bool? digestModeEnabled,
     int? digestHour,
+    bool? regressionAlertsEnabled,
   }) {
     return AppPreferences(
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
@@ -74,6 +80,8 @@ class AppPreferences {
       ),
       digestModeEnabled: digestModeEnabled ?? this.digestModeEnabled,
       digestHour: digestHour ?? this.digestHour,
+      regressionAlertsEnabled:
+          regressionAlertsEnabled ?? this.regressionAlertsEnabled,
     );
   }
 }
@@ -94,6 +102,8 @@ class PreferencesStore {
       'pref_notify_silenced_categories';
   static const String _digestModeEnabled = 'pref_digest_mode_enabled';
   static const String _digestHour = 'pref_digest_hour';
+  static const String _regressionAlertsEnabled =
+      'pref_regression_alerts_enabled';
 
   /// Allowed lookback options shown in the UI.
   static const List<int> lookbackOptions = [7, 14, 30, 60];
@@ -134,6 +144,9 @@ class PreferencesStore {
       digestModeEnabled:
           prefs.getBool(_digestModeEnabled) ?? defaults.digestModeEnabled,
       digestHour: _clampHour(prefs.getInt(_digestHour) ?? defaults.digestHour),
+      regressionAlertsEnabled:
+          prefs.getBool(_regressionAlertsEnabled) ??
+          defaults.regressionAlertsEnabled,
     );
   }
 
@@ -216,6 +229,13 @@ class PreferencesStore {
     return _runLocked(() async {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setInt(_digestHour, _clampHour(hour));
+    });
+  }
+
+  static Future<void> setRegressionAlertsEnabled(bool value) {
+    return _runLocked(() async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_regressionAlertsEnabled, value);
     });
   }
 

--- a/lib/sync_service.dart
+++ b/lib/sync_service.dart
@@ -19,6 +19,8 @@ import 'preferences_store.dart';
 import 'repo_store.dart';
 import 'snooze_store.dart';
 import 'sync_state_store.dart';
+import 'team_store.dart';
+import 'trend_digest.dart';
 
 /// Outcome of a sync. [activityOk] reflects whether the repo-activity + trend
 /// capture half succeeded (the part a manual "Sync now" reports on); attention
@@ -172,6 +174,37 @@ class SyncService {
       }
     }
 
+    // Runs AFTER the CI (activity) and cycle-time captures have recorded, since
+    // it reads back both histories to compare this week vs last per team and
+    // alert on regressions. Best-effort and never throws.
+    Future<void> regressionPhase() async {
+      try {
+        final appPrefs = await PreferencesStore.load();
+        if (!appPrefs.regressionAlertsEnabled) return;
+        final teams = await TeamStore.list();
+        if (teams.isEmpty) return;
+        final cycleSamples = await CycleTimeStore.allSamples();
+        final ciSamples = await CiRunHistoryStore.allSamples();
+        final now = DateTime.now();
+        const window = Duration(days: 7);
+        final regressions = TrendDigest.regressions(
+          teams: teams,
+          cycleSamples: cycleSamples,
+          ciSamples: ciSamples,
+          now: now,
+          window: window,
+        );
+        await NotificationService.notifyRegressions(
+          regressions,
+          periodKey: TrendDigest.periodKeyFor(now, window),
+          now: now,
+          prefs: appPrefs,
+        );
+      } catch (e, st) {
+        debugPrint('SyncService: regression alerts failed: $e\n$st');
+      }
+    }
+
     if (background) {
       // Concurrent to fit the budget; each phase is independently deadlined and
       // its errors isolated.
@@ -182,6 +215,9 @@ class SyncService {
         feedPhase(),
         cyclePhase(),
       ]);
+      // Regression detection reads back the CI + cycle histories just recorded,
+      // so it runs after the capture phases complete.
+      await regressionPhase();
       return result;
     }
 
@@ -189,6 +225,7 @@ class SyncService {
     await attentionPhase();
     await feedPhase();
     await cyclePhase();
+    await regressionPhase();
     return result;
   }
 }

--- a/lib/sync_service.dart
+++ b/lib/sync_service.dart
@@ -181,24 +181,31 @@ class SyncService {
       try {
         final appPrefs = await PreferencesStore.load();
         if (!appPrefs.regressionAlertsEnabled) return;
-        final teams = await TeamStore.list();
-        if (teams.isEmpty) return;
-        final cycleSamples = await CycleTimeStore.allSamples();
-        final ciSamples = await CiRunHistoryStore.allSamples();
-        final now = DateTime.now();
-        const window = Duration(days: 7);
-        final regressions = TrendDigest.regressions(
-          teams: teams,
-          cycleSamples: cycleSamples,
-          ciSamples: ciSamples,
-          now: now,
-          window: window,
-        );
-        await NotificationService.notifyRegressions(
-          regressions,
-          periodKey: TrendDigest.periodKeyFor(now, window),
-          now: now,
-          prefs: appPrefs,
+        // Bound the read+compute+notify by the same background deadline as the
+        // other phases so it can't extend an iOS BGAppRefreshTask past budget
+        // (no-op in the foreground where deadline is null).
+        await withDeadline(
+          Future(() async {
+            final teams = await TeamStore.list();
+            if (teams.isEmpty) return;
+            final cycleSamples = await CycleTimeStore.allSamples();
+            final ciSamples = await CiRunHistoryStore.allSamples();
+            final now = DateTime.now();
+            const window = Duration(days: 7);
+            final regressions = TrendDigest.regressions(
+              teams: teams,
+              cycleSamples: cycleSamples,
+              ciSamples: ciSamples,
+              now: now,
+              window: window,
+            );
+            await NotificationService.notifyRegressions(
+              regressions,
+              periodKey: TrendDigest.periodKeyFor(now, window),
+              now: now,
+              prefs: appPrefs,
+            );
+          }),
         );
       } catch (e, st) {
         debugPrint('SyncService: regression alerts failed: $e\n$st');

--- a/lib/trend_digest.dart
+++ b/lib/trend_digest.dart
@@ -135,8 +135,9 @@ class TrendDigest {
   /// from being silently dropped.
   static const double _rateEpsilon = 1e-9;
 
-  /// Builds a per-team [TeamTrend] for the current window `[now-window, now]`
-  /// versus the immediately-preceding window `[now-2*window, now-window]`.
+  /// Builds a per-team [TeamTrend] for the current window `[now-window, now)`
+  /// versus the immediately-preceding window `[now-2*window, now-window)`
+  /// (both half-open, so the shared boundary belongs to the current window).
   ///
   /// [periodKey] (default derived from [now]) is embedded in each regression's
   /// de-dup key so a standing regression alerts at most once per period.

--- a/lib/trend_digest.dart
+++ b/lib/trend_digest.dart
@@ -1,0 +1,356 @@
+// Period-over-period (this week vs last week) per-team trend comparison and
+// regression detection for the manager digest: it rolls the accumulated
+// merged-PR (cycle-time) and CI-run histories into a current- and previous-
+// window summary per team, computes the deltas a manager cares about (merge
+// throughput, review latency, merge time, CI failure rate), and flags the ones
+// that regressed past a threshold. Pure and provider-agnostic so it's easy to
+// unit-test and reuse from both the in-app view and the alert path.
+
+import 'ci_run_history.dart';
+import 'cycle_time.dart';
+import 'team.dart';
+
+/// The kinds of regression the digest can flag. The string value is stable and
+/// used to build de-duplication keys for alerting, so don't rename casually.
+enum RegressionKind {
+  reviewLatencyUp('reviewLatencyUp'),
+  mergeTimeUp('mergeTimeUp'),
+  ciFailureRateUp('ciFailureRateUp');
+
+  const RegressionKind(this.id);
+  final String id;
+}
+
+/// One team's roll-up over a single window.
+class TeamPeriodStats {
+  const TeamPeriodStats({
+    required this.mergedCount,
+    required this.reviewedCount,
+    required this.medianTimeToFirstReviewMs,
+    required this.medianTimeToMergeMs,
+    required this.ciCompleted,
+    required this.ciFailures,
+  });
+
+  final int mergedCount;
+  final int reviewedCount;
+  final int? medianTimeToFirstReviewMs;
+  final int? medianTimeToMergeMs;
+
+  /// Completed (pass/fail) CI runs on tracked repos in the window.
+  final int ciCompleted;
+  final int ciFailures;
+
+  /// Fraction of completed CI runs that failed, or null when none completed.
+  double? get ciFailureRate =>
+      ciCompleted == 0 ? null : ciFailures / ciCompleted;
+
+  bool get isEmpty => mergedCount == 0 && ciCompleted == 0;
+
+  static const TeamPeriodStats empty = TeamPeriodStats(
+    mergedCount: 0,
+    reviewedCount: 0,
+    medianTimeToFirstReviewMs: null,
+    medianTimeToMergeMs: null,
+    ciCompleted: 0,
+    ciFailures: 0,
+  );
+}
+
+/// A flagged regression for one team + metric, with the values behind it and a
+/// stable [key] for de-duplicating alerts.
+class TrendRegression {
+  const TrendRegression({
+    required this.teamId,
+    required this.teamName,
+    required this.kind,
+    required this.summary,
+    required this.key,
+  });
+
+  final String teamId;
+  final String teamName;
+  final RegressionKind kind;
+
+  /// Short human-readable description, e.g. "merge time 2d → 3d 4h".
+  final String summary;
+
+  /// Stable de-dup key: `<periodKey>|<teamId>|<kind>`.
+  final String key;
+}
+
+/// A team's current- vs previous-window stats plus any regressions.
+class TeamTrend {
+  const TeamTrend({
+    required this.teamId,
+    required this.teamName,
+    required this.current,
+    required this.previous,
+    required this.regressions,
+  });
+
+  final String teamId;
+  final String teamName;
+  final TeamPeriodStats current;
+  final TeamPeriodStats previous;
+  final List<TrendRegression> regressions;
+
+  bool get hasRegression => regressions.isNotEmpty;
+
+  /// True when neither window has any data (nothing meaningful to show yet).
+  bool get isEmpty => current.isEmpty && previous.isEmpty;
+}
+
+/// Pure roll-ups + regression detection over the accumulated histories.
+class TrendDigest {
+  const TrendDigest._();
+
+  /// A regression fires only when the metric got meaningfully worse: the newer
+  /// value is at least [_ratioThreshold]× the older AND the absolute change
+  /// clears a floor, so tiny or noisy swings don't alert.
+  static const double _ratioThreshold = 1.3;
+
+  /// Absolute floor for a duration regression (review/merge time): 4 hours.
+  static const int _minDurationDeltaMs = 4 * 60 * 60 * 1000;
+
+  /// A duration regression needs at least this many contributing samples in
+  /// BOTH windows, so a single-PR outlier in either period can't drive a median
+  /// swing into an alert.
+  static const int _minSamplesForDurationRegression = 2;
+
+  /// A CI-failure-rate regression needs at least this many completed runs in
+  /// the current window (so a 1-of-1 fluke doesn't alert) …
+  static const int _minCiRunsForRegression = 5;
+
+  /// … the rate must rise by at least this many points …
+  static const double _minCiFailureRateDelta = 0.15;
+
+  /// … and the current rate must be at least this high (a low rate isn't worth
+  /// alerting on even if it doubled).
+  static const double _minCiFailureRateFloor = 0.2;
+
+  /// Tolerance for the failure-rate comparisons: rates are `failures/completed`
+  /// binary fractions, so an exact threshold (e.g. 0.35 − 0.20 == 0.15) can
+  /// land a hair low in floating point. A tiny epsilon keeps on-the-nose cases
+  /// from being silently dropped.
+  static const double _rateEpsilon = 1e-9;
+
+  /// Builds a per-team [TeamTrend] for the current window `[now-window, now]`
+  /// versus the immediately-preceding window `[now-2*window, now-window]`.
+  ///
+  /// [periodKey] (default derived from [now]) is embedded in each regression's
+  /// de-dup key so a standing regression alerts at most once per period.
+  static List<TeamTrend> compare({
+    required List<Team> teams,
+    required List<MergedPrSample> cycleSamples,
+    required List<CiRunSample> ciSamples,
+    DateTime? now,
+    Duration window = const Duration(days: 7),
+    String? periodKey,
+  }) {
+    final at = now ?? DateTime.now();
+    final period = periodKey ?? periodKeyFor(at, window);
+    final currentStart = at.subtract(window);
+    final previousStart = at.subtract(window * 2);
+
+    // Index samples by repoKey once so each team unions its repos' rows without
+    // rescanning the full lists per team.
+    final cycleByRepo = <String, List<MergedPrSample>>{};
+    for (final s in cycleSamples) {
+      cycleByRepo.putIfAbsent(s.repoKey, () => []).add(s);
+    }
+    final ciByRepo = <String, List<CiRunSample>>{};
+    for (final s in ciSamples) {
+      ciByRepo.putIfAbsent(s.repoKey, () => []).add(s);
+    }
+
+    final result = <TeamTrend>[];
+    for (final team in teams) {
+      if (team.repoKeys.isEmpty) continue;
+      final teamCycle = [for (final key in team.repoKeys) ...?cycleByRepo[key]];
+      final teamCi = [for (final key in team.repoKeys) ...?ciByRepo[key]];
+
+      final current = _period(teamCycle, teamCi, start: currentStart, end: at);
+      final previous = _period(
+        teamCycle,
+        teamCi,
+        start: previousStart,
+        end: currentStart,
+      );
+      final trend = TeamTrend(
+        teamId: team.id,
+        teamName: team.name,
+        current: current,
+        previous: previous,
+        regressions: _regressions(
+          team: team,
+          current: current,
+          previous: previous,
+          periodKey: period,
+        ),
+      );
+      if (trend.isEmpty) continue;
+      result.add(trend);
+    }
+    // Regressed teams first, then by name, so what needs attention sorts up.
+    result.sort((a, b) {
+      if (a.hasRegression != b.hasRegression) return a.hasRegression ? -1 : 1;
+      return a.teamName.toLowerCase().compareTo(b.teamName.toLowerCase());
+    });
+    return result;
+  }
+
+  /// All regressions across [teams], flattened — the alert path's input.
+  static List<TrendRegression> regressions({
+    required List<Team> teams,
+    required List<MergedPrSample> cycleSamples,
+    required List<CiRunSample> ciSamples,
+    DateTime? now,
+    Duration window = const Duration(days: 7),
+    String? periodKey,
+  }) => [
+    for (final t in compare(
+      teams: teams,
+      cycleSamples: cycleSamples,
+      ciSamples: ciSamples,
+      now: now,
+      window: window,
+      periodKey: periodKey,
+    ))
+      ...t.regressions,
+  ];
+
+  /// The period bucket key for [now] (the window-aligned start date), used to
+  /// scope alert de-duplication to one window. Same for any two instants in the
+  /// same window relative to a fixed epoch.
+  static String periodKeyFor(DateTime now, Duration window) {
+    final days = window.inDays <= 0 ? 1 : window.inDays;
+    final epochDay = now.toUtc().millisecondsSinceEpoch ~/ 86400000;
+    final bucket = epochDay ~/ days;
+    return 'w$days-$bucket';
+  }
+
+  static TeamPeriodStats _period(
+    List<MergedPrSample> cycle,
+    List<CiRunSample> ci, {
+    required DateTime start,
+    required DateTime end,
+  }) {
+    final mergeTimes = <int>[];
+    final reviewTimes = <int>[];
+    var merged = 0;
+    for (final s in cycle) {
+      if (s.mergedAt.isBefore(start) || !s.mergedAt.isBefore(end)) continue;
+      merged++;
+      final m = s.timeToMergeMs;
+      if (m != null) mergeTimes.add(m);
+      final r = s.timeToFirstReviewMs;
+      if (r != null) reviewTimes.add(r);
+    }
+    var completed = 0;
+    var failures = 0;
+    for (final run in ci) {
+      final finished = run.finishedAt;
+      if (finished == null) continue;
+      if (finished.isBefore(start) || !finished.isBefore(end)) continue;
+      if (!CiOutcome.isCompleted(run.outcome)) continue;
+      completed++;
+      if (run.outcome == CiOutcome.failure) failures++;
+    }
+    return TeamPeriodStats(
+      mergedCount: merged,
+      reviewedCount: reviewTimes.length,
+      medianTimeToFirstReviewMs: CycleTimeStats.median(reviewTimes),
+      medianTimeToMergeMs: CycleTimeStats.median(mergeTimes),
+      ciCompleted: completed,
+      ciFailures: failures,
+    );
+  }
+
+  static List<TrendRegression> _regressions({
+    required Team team,
+    required TeamPeriodStats current,
+    required TeamPeriodStats previous,
+    required String periodKey,
+  }) {
+    final out = <TrendRegression>[];
+    void addDuration(
+      RegressionKind kind,
+      int? cur,
+      int? prev,
+      int curCount,
+      int prevCount,
+      String label,
+    ) {
+      if (cur == null || prev == null || prev <= 0) return;
+      // Require enough samples in both windows so an outlier can't drive it.
+      if (curCount < _minSamplesForDurationRegression ||
+          prevCount < _minSamplesForDurationRegression) {
+        return;
+      }
+      if (cur < prev * _ratioThreshold) return;
+      if (cur - prev < _minDurationDeltaMs) return;
+      out.add(
+        TrendRegression(
+          teamId: team.id,
+          teamName: team.name,
+          kind: kind,
+          summary: '$label ${_fmtDuration(prev)} → ${_fmtDuration(cur)}',
+          key: '$periodKey|${team.id}|${kind.id}',
+        ),
+      );
+    }
+
+    addDuration(
+      RegressionKind.reviewLatencyUp,
+      current.medianTimeToFirstReviewMs,
+      previous.medianTimeToFirstReviewMs,
+      current.reviewedCount,
+      previous.reviewedCount,
+      'review time',
+    );
+    addDuration(
+      RegressionKind.mergeTimeUp,
+      current.medianTimeToMergeMs,
+      previous.medianTimeToMergeMs,
+      current.mergedCount,
+      previous.mergedCount,
+      'merge time',
+    );
+
+    final curRate = current.ciFailureRate;
+    final prevRate = previous.ciFailureRate;
+    if (curRate != null &&
+        prevRate != null &&
+        current.ciCompleted >= _minCiRunsForRegression &&
+        curRate >= _minCiFailureRateFloor - _rateEpsilon &&
+        curRate - prevRate >= _minCiFailureRateDelta - _rateEpsilon) {
+      out.add(
+        TrendRegression(
+          teamId: team.id,
+          teamName: team.name,
+          kind: RegressionKind.ciFailureRateUp,
+          summary: 'CI failures ${_fmtPct(prevRate)} → ${_fmtPct(curRate)}',
+          key: '$periodKey|${team.id}|${RegressionKind.ciFailureRateUp.id}',
+        ),
+      );
+    }
+    return out;
+  }
+
+  static String _fmtPct(double rate) => '${(rate * 100).round()}%';
+
+  /// Compact day/hour/minute duration for summaries (mirrors the view's
+  /// long-duration formatting, kept here so the pure layer has no UI dep).
+  static String _fmtDuration(int ms) {
+    if (ms <= 0) return '<1m';
+    final totalMinutes = ms ~/ 60000;
+    final d = totalMinutes ~/ 1440;
+    final h = (totalMinutes % 1440) ~/ 60;
+    final m = totalMinutes % 60;
+    if (d > 0) return h > 0 ? '${d}d ${h}h' : '${d}d';
+    if (h > 0) return m > 0 ? '${h}h ${m}m' : '${h}h';
+    if (m > 0) return '${m}m';
+    return '<1m';
+  }
+}

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -27,6 +27,7 @@ import 'review_load_view.dart';
 import 'stacked_area_view.dart';
 import 'team_radar_view.dart';
 import 'treemap_view.dart';
+import 'trend_digest_view.dart';
 import 'trend_lines_view.dart';
 import 'views_common.dart';
 
@@ -94,6 +95,12 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       blurb: 'PR review & merge speed trends',
       icon: Icons.speed,
       builder: (d) => CycleTimeView(data: d),
+    ),
+    ViewInfo(
+      title: 'Trends digest',
+      blurb: 'Per-team week-over-week, regressions flagged',
+      icon: Icons.trending_up,
+      builder: (d) => TrendDigestView(data: d),
     ),
     ViewInfo(
       title: 'Treemap',

--- a/lib/views/trend_digest_view.dart
+++ b/lib/views/trend_digest_view.dart
@@ -1,0 +1,360 @@
+import 'package:flutter/material.dart';
+
+import '../trend_digest.dart';
+import 'views_common.dart';
+
+/// A manager digest: for each team, this period vs the previous one — merge
+/// throughput, review latency, merge time, and CI failure rate — with the
+/// changes that regressed flagged. Teams that regressed sort first. A window
+/// selector re-aggregates the already-loaded histories client-side.
+class TrendDigestView extends StatefulWidget {
+  const TrendDigestView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  State<TrendDigestView> createState() => _TrendDigestViewState();
+}
+
+class _TrendDigestViewState extends State<TrendDigestView> {
+  static const List<int> _windowChoices = [7, 14, 30];
+  int _windowDays = 7;
+
+  Duration get _window => Duration(days: _windowDays);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final now = widget.data.loadedAt;
+    final trends = TrendDigest.compare(
+      teams: widget.data.teams,
+      cycleSamples: widget.data.cycleSamples,
+      ciSamples: widget.data.ciRunSamples,
+      now: now,
+      window: _window,
+    );
+    final regressed = trends.where((t) => t.hasRegression).length;
+
+    return ViewScaffold(
+      title: 'Trends digest',
+      loadedAt: now,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    trends.isEmpty
+                        ? 'No team trends yet'
+                        : regressed == 0
+                        ? '${trends.length} teams · all steady'
+                        : '$regressed regressed · ${trends.length} teams',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: regressed == 0
+                          ? theme.colorScheme.onSurfaceVariant
+                          : _worse,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                SegmentedButton<int>(
+                  showSelectedIcon: false,
+                  style: const ButtonStyle(
+                    visualDensity: VisualDensity.compact,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  segments: [
+                    for (final d in _windowChoices)
+                      ButtonSegment(value: d, label: Text('${d}d')),
+                  ],
+                  selected: {_windowDays},
+                  onSelectionChanged: (s) =>
+                      setState(() => _windowDays = s.first),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'Last $_windowDays days vs the previous $_windowDays. '
+                'Review time is GitHub-only.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: trends.isEmpty
+                ? const ViewEmpty(
+                    message:
+                        'No team trends yet.\nAdd teams and let a couple of '
+                        'sync cycles accumulate merged-PR and CI history, then '
+                        'week-over-week trends appear here.',
+                  )
+                : ListView.separated(
+                    padding: const EdgeInsets.all(12),
+                    itemCount: trends.length,
+                    separatorBuilder: (_, _) => const SizedBox(height: 8),
+                    itemBuilder: (context, i) => _TeamCard(trend: trends[i]),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+const Color _worse = Color(0xFFD32F2F);
+const Color _better = Color(0xFF2E7D32);
+
+class _TeamCard extends StatelessWidget {
+  const _TeamCard({required this.trend});
+
+  final TeamTrend trend;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cur = trend.current;
+    final prev = trend.previous;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.groups_2,
+                  size: 18,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    trend.teamName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                for (final r in trend.regressions)
+                  Padding(
+                    padding: const EdgeInsets.only(left: 4),
+                    child: _Badge(label: _kindLabel(r.kind)),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 20,
+              runSpacing: 10,
+              children: [
+                _CountMetric(
+                  label: 'Merged',
+                  current: cur.mergedCount,
+                  previous: prev.mergedCount,
+                ),
+                _DurationMetric(
+                  label: 'Review',
+                  currentMs: cur.medianTimeToFirstReviewMs,
+                  previousMs: prev.medianTimeToFirstReviewMs,
+                ),
+                _DurationMetric(
+                  label: 'Merge',
+                  currentMs: cur.medianTimeToMergeMs,
+                  previousMs: prev.medianTimeToMergeMs,
+                ),
+                _RateMetric(
+                  label: 'CI fail',
+                  current: cur.ciFailureRate,
+                  previous: prev.ciFailureRate,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _kindLabel(RegressionKind kind) => switch (kind) {
+    RegressionKind.reviewLatencyUp => 'Review ↑',
+    RegressionKind.mergeTimeUp => 'Merge ↑',
+    RegressionKind.ciFailureRateUp => 'CI ↑',
+  };
+}
+
+class _Badge extends StatelessWidget {
+  const _Badge({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: _worse.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: _worse.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: _worse,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// Shared metric column: a label, a big current value, and a small change hint.
+class _MetricColumn extends StatelessWidget {
+  const _MetricColumn({
+    required this.label,
+    required this.value,
+    required this.change,
+    this.changeColor,
+  });
+
+  final String label;
+  final String value;
+  final String? change;
+  final Color? changeColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          label.toUpperCase(),
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+            letterSpacing: 0.5,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          value,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        Text(
+          change ?? '—',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: changeColor ?? theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CountMetric extends StatelessWidget {
+  const _CountMetric({
+    required this.label,
+    required this.current,
+    required this.previous,
+  });
+
+  final String label;
+  final int current;
+  final int previous;
+
+  @override
+  Widget build(BuildContext context) {
+    final delta = current - previous;
+    // More merges is generally good (green when up, neutral when down).
+    return _MetricColumn(
+      label: label,
+      value: '$current',
+      change: delta == 0 ? 'vs $previous' : '${delta > 0 ? '+' : ''}$delta',
+      changeColor: delta > 0 ? _better : null,
+    );
+  }
+}
+
+class _DurationMetric extends StatelessWidget {
+  const _DurationMetric({
+    required this.label,
+    required this.currentMs,
+    required this.previousMs,
+  });
+
+  final String label;
+  final int? currentMs;
+  final int? previousMs;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = formatLongDurationMs(currentMs) ?? '—';
+    String? change;
+    Color? color;
+    if (currentMs != null && previousMs != null && previousMs! > 0) {
+      final up = currentMs! > previousMs!;
+      final down = currentMs! < previousMs!;
+      // Faster (down) is better; slower (up) is worse.
+      color = up ? _worse : (down ? _better : null);
+      final arrow = up ? '↑' : (down ? '↓' : '=');
+      change = '$arrow ${formatLongDurationMs(previousMs) ?? '—'}';
+    } else if (currentMs != null) {
+      change = 'new';
+    }
+    return _MetricColumn(
+      label: label,
+      value: value,
+      change: change,
+      changeColor: color,
+    );
+  }
+}
+
+class _RateMetric extends StatelessWidget {
+  const _RateMetric({
+    required this.label,
+    required this.current,
+    required this.previous,
+  });
+
+  final double? current;
+  final double? previous;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = current == null ? '—' : '${(current! * 100).round()}%';
+    String? change;
+    Color? color;
+    if (current != null && previous != null) {
+      final up = current! > previous!;
+      final down = current! < previous!;
+      // Lower failure rate (down) is better.
+      color = up ? _worse : (down ? _better : null);
+      final arrow = up ? '↑' : (down ? '↓' : '=');
+      change = '$arrow ${(previous! * 100).round()}%';
+    }
+    return _MetricColumn(
+      label: label,
+      value: value,
+      change: change,
+      changeColor: color,
+    );
+  }
+}

--- a/test/notification_seen_store_test.dart
+++ b/test/notification_seen_store_test.dart
@@ -126,4 +126,63 @@ void main() {
     await NotificationSeenStore.releaseDailyDigest('2026-7-23');
     expect(await NotificationSeenStore.claimDailyDigest('2026-7-24'), isFalse);
   });
+
+  group('claimNewRegressionKeys', () {
+    test('returns only newly-seen keys within a period', () async {
+      final first = await NotificationSeenStore.claimNewRegressionKeys({
+        'w7-1|t1|mergeTimeUp',
+        'w7-1|t2|reviewLatencyUp',
+      }, 'w7-1');
+      expect(first, {'w7-1|t1|mergeTimeUp', 'w7-1|t2|reviewLatencyUp'});
+      // Re-seeing the same standing regressions plus a new one: only the new
+      // one is returned (the others already alerted this period).
+      final second = await NotificationSeenStore.claimNewRegressionKeys({
+        'w7-1|t1|mergeTimeUp',
+        'w7-1|t2|reviewLatencyUp',
+        'w7-1|t3|ciFailureRateUp',
+      }, 'w7-1');
+      expect(second, {'w7-1|t3|ciFailureRateUp'});
+    });
+
+    test(
+      'a new period re-alerts a standing regression and prunes old',
+      () async {
+        await NotificationSeenStore.claimNewRegressionKeys({
+          'w7-1|t1|mergeTimeUp',
+        }, 'w7-1');
+        // Next period: the same regression (new period key) alerts again.
+        final next = await NotificationSeenStore.claimNewRegressionKeys({
+          'w7-2|t1|mergeTimeUp',
+        }, 'w7-2');
+        expect(next, {'w7-2|t1|mergeTimeUp'});
+        // The old period's key was pruned, so returning to it (unlikely) would
+        // alert once more — and importantly it's no longer stored.
+        final backAgain = await NotificationSeenStore.claimNewRegressionKeys({
+          'w7-2|t1|mergeTimeUp',
+        }, 'w7-2');
+        expect(backAgain, isEmpty, reason: 'still standing in the same period');
+      },
+    );
+
+    test('empty current keys is a no-op returning nothing', () async {
+      expect(
+        await NotificationSeenStore.claimNewRegressionKeys({}, 'w7-9'),
+        isEmpty,
+      );
+    });
+
+    test('releaseRegressionKeys lets a claimed key re-fire', () async {
+      await NotificationSeenStore.claimNewRegressionKeys({
+        'w7-1|t1|mergeTimeUp',
+      }, 'w7-1');
+      // Released (e.g. after a failed show) → the same key is fresh again.
+      await NotificationSeenStore.releaseRegressionKeys({
+        'w7-1|t1|mergeTimeUp',
+      });
+      final again = await NotificationSeenStore.claimNewRegressionKeys({
+        'w7-1|t1|mergeTimeUp',
+      }, 'w7-1');
+      expect(again, {'w7-1|t1|mergeTimeUp'});
+    });
+  });
 }

--- a/test/notification_seen_store_test.dart
+++ b/test/notification_seen_store_test.dart
@@ -184,5 +184,21 @@ void main() {
       }, 'w7-1');
       expect(again, {'w7-1|t1|mergeTimeUp'});
     });
+
+    test('ignores current keys from a different period', () async {
+      // Only the key matching the caller's period is claimed/returned; a
+      // mismatched-period key is neither alerted nor stored.
+      final fresh = await NotificationSeenStore.claimNewRegressionKeys({
+        'w7-2|t1|mergeTimeUp',
+        'w7-1|t9|ciFailureRateUp',
+      }, 'w7-2');
+      expect(fresh, {'w7-2|t1|mergeTimeUp'});
+      // The out-of-period key wasn't stored, so it's still fresh in its own
+      // period (never silently recorded as notified).
+      final other = await NotificationSeenStore.claimNewRegressionKeys({
+        'w7-1|t9|ciFailureRateUp',
+      }, 'w7-1');
+      expect(other, {'w7-1|t9|ciFailureRateUp'});
+    });
   });
 }

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kode_radar/attention_service.dart';
 import 'package:kode_radar/notification_service.dart';
+import 'package:kode_radar/trend_digest.dart';
 
 void main() {
   test('diffNew returns current ids not already seen', () {
@@ -587,6 +588,40 @@ void main() {
       expect(
         NotificationService.digestBody(items),
         '2 review requested · 1 changes requested · 1 approved',
+      );
+    });
+  });
+
+  group('regression alert copy', () {
+    TrendRegression reg(String team, RegressionKind kind, String summary) =>
+        TrendRegression(
+          teamId: team,
+          teamName: team,
+          kind: kind,
+          summary: summary,
+          key: 'w7-1|$team|${kind.id}',
+        );
+
+    test('title is singular for one, counted for many', () {
+      expect(NotificationService.regressionTitle(1), 'A team trend regressed');
+      expect(NotificationService.regressionTitle(3), '3 team trends regressed');
+    });
+
+    test('body lists up to three team lines then overflows', () {
+      final regs = [
+        reg('Platform', RegressionKind.mergeTimeUp, 'merge time 1d → 3d'),
+        reg('Infra', RegressionKind.reviewLatencyUp, 'review time 2h → 8h'),
+        reg('Web', RegressionKind.ciFailureRateUp, 'CI failures 10% → 40%'),
+        reg('Mobile', RegressionKind.mergeTimeUp, 'merge time 4h → 12h'),
+      ];
+      expect(
+        NotificationService.regressionBody(regs),
+        [
+          'Platform: merge time 1d → 3d',
+          'Infra: review time 2h → 8h',
+          'Web: CI failures 10% → 40%',
+          '+1 more',
+        ].join('\n'),
       );
     });
   });

--- a/test/trend_digest_test.dart
+++ b/test/trend_digest_test.dart
@@ -1,0 +1,453 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/ci_run_history.dart';
+import 'package:kode_radar/cycle_time.dart';
+import 'package:kode_radar/team.dart';
+import 'package:kode_radar/trend_digest.dart';
+
+MergedPrSample _pr({
+  required int number,
+  required String repoKey,
+  required DateTime createdAt,
+  required DateTime mergedAt,
+  DateTime? firstReviewAt,
+}) => MergedPrSample(
+  provider: 'github',
+  repoKey: repoKey,
+  repoDisplay: repoKey,
+  prKey: '$repoKey:$number',
+  createdAt: createdAt,
+  mergedAt: mergedAt,
+  firstReviewAt: firstReviewAt,
+);
+
+CiRunSample _run({
+  required String repoKey,
+  required String runKey,
+  required String outcome,
+  required DateTime finishedAt,
+}) => CiRunSample(
+  provider: 'github',
+  repoKey: repoKey,
+  repoDisplay: repoKey,
+  workflow: 'CI',
+  runKey: runKey,
+  outcome: outcome,
+  conclusion: outcome,
+  finishedAt: finishedAt,
+);
+
+void main() {
+  final now = DateTime.utc(2026, 3, 15, 12);
+  const window = Duration(days: 7);
+  final team = const Team(id: 't1', name: 'Platform', repoKeys: {'github:o/a'});
+
+  group('periodKeyFor', () {
+    test('same bucket for two instants in the same window', () {
+      final a = DateTime.utc(2026, 3, 15, 1);
+      final b = DateTime.utc(2026, 3, 15, 23);
+      expect(
+        TrendDigest.periodKeyFor(a, window),
+        TrendDigest.periodKeyFor(b, window),
+      );
+    });
+    test('different bucket a window later', () {
+      final a = DateTime.utc(2026, 3, 15);
+      final b = DateTime.utc(2026, 3, 25);
+      expect(
+        TrendDigest.periodKeyFor(a, window),
+        isNot(TrendDigest.periodKeyFor(b, window)),
+      );
+    });
+  });
+
+  group('compare — windows', () {
+    test('splits merges into current vs previous window', () {
+      final samples = [
+        // current window (last 7d): merged 2 days ago
+        _pr(
+          number: 1,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 3)),
+          mergedAt: now.subtract(const Duration(days: 2)),
+        ),
+        // previous window (7-14d ago): merged 10 days ago
+        _pr(
+          number: 2,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 11)),
+          mergedAt: now.subtract(const Duration(days: 10)),
+        ),
+        // outside both windows (merged 20 days ago)
+        _pr(
+          number: 3,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 21)),
+          mergedAt: now.subtract(const Duration(days: 20)),
+        ),
+      ];
+      final trends = TrendDigest.compare(
+        teams: [team],
+        cycleSamples: samples,
+        ciSamples: const [],
+        now: now,
+        window: window,
+      );
+      expect(trends, hasLength(1));
+      expect(trends.single.current.mergedCount, 1);
+      expect(trends.single.previous.mergedCount, 1);
+    });
+
+    test('drops teams with no data in either window', () {
+      final trends = TrendDigest.compare(
+        teams: [team],
+        cycleSamples: const [],
+        ciSamples: const [],
+        now: now,
+        window: window,
+      );
+      expect(trends, isEmpty);
+    });
+
+    test('ignores repos not in the team', () {
+      final samples = [
+        _pr(
+          number: 1,
+          repoKey: 'github:o/other',
+          createdAt: now.subtract(const Duration(days: 3)),
+          mergedAt: now.subtract(const Duration(days: 2)),
+        ),
+      ];
+      final trends = TrendDigest.compare(
+        teams: [team],
+        cycleSamples: samples,
+        ciSamples: const [],
+        now: now,
+        window: window,
+      );
+      expect(trends, isEmpty);
+    });
+  });
+
+  group('regressions — merge/review time', () {
+    test('flags merge time up past ratio + absolute floor', () {
+      final samples = [
+        // previous window: two PRs merged in ~1h each
+        _pr(
+          number: 1,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 10, hours: 1)),
+          mergedAt: now.subtract(const Duration(days: 10)),
+        ),
+        _pr(
+          number: 2,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 9, hours: 1)),
+          mergedAt: now.subtract(const Duration(days: 9)),
+        ),
+        // current window: two PRs merged in ~2 days each (way up)
+        _pr(
+          number: 3,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 4)),
+          mergedAt: now.subtract(const Duration(days: 2)),
+        ),
+        _pr(
+          number: 4,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 5)),
+          mergedAt: now.subtract(const Duration(days: 3)),
+        ),
+      ];
+      final regs = TrendDigest.regressions(
+        teams: [team],
+        cycleSamples: samples,
+        ciSamples: const [],
+        now: now,
+        window: window,
+      );
+      expect(regs.map((r) => r.kind), contains(RegressionKind.mergeTimeUp));
+      expect(regs.first.key, startsWith(TrendDigest.periodKeyFor(now, window)));
+    });
+
+    test('does not flag a small merge-time increase (below floor)', () {
+      final samples = [
+        _pr(
+          number: 1,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 10, hours: 1)),
+          mergedAt: now.subtract(const Duration(days: 10)),
+        ),
+        _pr(
+          number: 2,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 9, hours: 1)),
+          mergedAt: now.subtract(const Duration(days: 9)),
+        ),
+        // current: ~1h -> ~1h5m — ratio < 1.3 and delta < 4h
+        _pr(
+          number: 3,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(
+            const Duration(days: 2, hours: 1, minutes: 5),
+          ),
+          mergedAt: now.subtract(const Duration(days: 2)),
+        ),
+        _pr(
+          number: 4,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(
+            const Duration(days: 3, hours: 1, minutes: 5),
+          ),
+          mergedAt: now.subtract(const Duration(days: 3)),
+        ),
+      ];
+      final regs = TrendDigest.regressions(
+        teams: [team],
+        cycleSamples: samples,
+        ciSamples: const [],
+        now: now,
+        window: window,
+      );
+      expect(regs, isEmpty);
+    });
+
+    test('does not flag a duration jump backed by a single PR per window', () {
+      // One PR each window with a huge jump: real ratio/floor breach, but the
+      // min-sample guard suppresses it (outlier protection).
+      final samples = [
+        _pr(
+          number: 1,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 10, hours: 1)),
+          mergedAt: now.subtract(const Duration(days: 10)),
+        ),
+        _pr(
+          number: 2,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 4)),
+          mergedAt: now.subtract(const Duration(days: 2)),
+        ),
+      ];
+      final regs = TrendDigest.regressions(
+        teams: [team],
+        cycleSamples: samples,
+        ciSamples: const [],
+        now: now,
+        window: window,
+      );
+      expect(regs, isEmpty);
+    });
+
+    test('flags review latency up', () {
+      final samples = [
+        _pr(
+          number: 1,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 10, hours: 2)),
+          firstReviewAt: now.subtract(const Duration(days: 10, hours: 1)),
+          mergedAt: now.subtract(const Duration(days: 10)),
+        ),
+        _pr(
+          number: 2,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 9, hours: 2)),
+          firstReviewAt: now.subtract(const Duration(days: 9, hours: 1)),
+          mergedAt: now.subtract(const Duration(days: 9)),
+        ),
+        _pr(
+          number: 3,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 3)),
+          firstReviewAt: now.subtract(const Duration(days: 2)),
+          mergedAt: now.subtract(const Duration(days: 1)),
+        ),
+        _pr(
+          number: 4,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 4)),
+          firstReviewAt: now.subtract(const Duration(days: 3)),
+          mergedAt: now.subtract(const Duration(days: 2)),
+        ),
+      ];
+      final regs = TrendDigest.regressions(
+        teams: [team],
+        cycleSamples: samples,
+        ciSamples: const [],
+        now: now,
+        window: window,
+      );
+      expect(regs.map((r) => r.kind), contains(RegressionKind.reviewLatencyUp));
+    });
+
+    test('no regression without a previous-window baseline', () {
+      final samples = [
+        _pr(
+          number: 3,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 4)),
+          mergedAt: now.subtract(const Duration(days: 2)),
+        ),
+        _pr(
+          number: 4,
+          repoKey: 'github:o/a',
+          createdAt: now.subtract(const Duration(days: 5)),
+          mergedAt: now.subtract(const Duration(days: 3)),
+        ),
+      ];
+      final regs = TrendDigest.regressions(
+        teams: [team],
+        cycleSamples: samples,
+        ciSamples: const [],
+        now: now,
+        window: window,
+      );
+      expect(regs, isEmpty);
+    });
+  });
+
+  group('regressions — CI failure rate', () {
+    List<CiRunSample> runs({
+      required DateTime base,
+      required int total,
+      required int failures,
+    }) => [
+      for (var i = 0; i < total; i++)
+        _run(
+          repoKey: 'github:o/a',
+          runKey: 'github:o/a:${base.millisecondsSinceEpoch}:$i',
+          outcome: i < failures ? CiOutcome.failure : CiOutcome.success,
+          finishedAt: base.add(Duration(minutes: i)),
+        ),
+    ];
+
+    test('flags a large jump in failure rate with enough runs', () {
+      final ci = [
+        // previous: 1/10 failed (10%)
+        ...runs(
+          base: now.subtract(const Duration(days: 10)),
+          total: 10,
+          failures: 1,
+        ),
+        // current: 5/10 failed (50%) — up 40 pts, above floor, >=5 runs
+        ...runs(
+          base: now.subtract(const Duration(days: 2)),
+          total: 10,
+          failures: 5,
+        ),
+      ];
+      final regs = TrendDigest.regressions(
+        teams: [team],
+        cycleSamples: const [],
+        ciSamples: ci,
+        now: now,
+        window: window,
+      );
+      expect(regs.map((r) => r.kind), contains(RegressionKind.ciFailureRateUp));
+    });
+
+    test('does not flag when too few current runs', () {
+      final ci = [
+        ...runs(
+          base: now.subtract(const Duration(days: 10)),
+          total: 10,
+          failures: 1,
+        ),
+        // current: 2/3 failed but only 3 completed (< min 5)
+        ...runs(
+          base: now.subtract(const Duration(days: 2)),
+          total: 3,
+          failures: 2,
+        ),
+      ];
+      final regs = TrendDigest.regressions(
+        teams: [team],
+        cycleSamples: const [],
+        ciSamples: ci,
+        now: now,
+        window: window,
+      );
+      expect(regs, isEmpty);
+    });
+
+    test('ignores still-running runs in the rate', () {
+      final ci = [
+        ...runs(
+          base: now.subtract(const Duration(days: 10)),
+          total: 6,
+          failures: 0,
+        ),
+        // current: 6 completed all-fail + a running one that must not count
+        ...runs(
+          base: now.subtract(const Duration(days: 2)),
+          total: 6,
+          failures: 6,
+        ),
+        _run(
+          repoKey: 'github:o/a',
+          runKey: 'github:o/a:running',
+          outcome: CiOutcome.running,
+          finishedAt: now.subtract(const Duration(days: 1)),
+        ),
+      ];
+      final trends = TrendDigest.compare(
+        teams: [team],
+        cycleSamples: const [],
+        ciSamples: ci,
+        now: now,
+        window: window,
+      );
+      expect(trends.single.current.ciCompleted, 6);
+      expect(trends.single.current.ciFailureRate, 1.0);
+    });
+  });
+
+  test('regressed teams sort before steady ones', () {
+    final steady = const Team(
+      id: 't2',
+      name: 'AAA-Steady',
+      repoKeys: {'github:o/b'},
+    );
+    final samples = [
+      // team t1 regresses on merge time (2 PRs per window)
+      _pr(
+        number: 1,
+        repoKey: 'github:o/a',
+        createdAt: now.subtract(const Duration(days: 10, hours: 1)),
+        mergedAt: now.subtract(const Duration(days: 10)),
+      ),
+      _pr(
+        number: 2,
+        repoKey: 'github:o/a',
+        createdAt: now.subtract(const Duration(days: 9, hours: 1)),
+        mergedAt: now.subtract(const Duration(days: 9)),
+      ),
+      _pr(
+        number: 3,
+        repoKey: 'github:o/a',
+        createdAt: now.subtract(const Duration(days: 4)),
+        mergedAt: now.subtract(const Duration(days: 2)),
+      ),
+      _pr(
+        number: 4,
+        repoKey: 'github:o/a',
+        createdAt: now.subtract(const Duration(days: 5)),
+        mergedAt: now.subtract(const Duration(days: 3)),
+      ),
+      // team t2 steady
+      _pr(
+        number: 5,
+        repoKey: 'github:o/b',
+        createdAt: now.subtract(const Duration(days: 3)),
+        mergedAt: now.subtract(const Duration(days: 2, hours: 23)),
+      ),
+    ];
+    final trends = TrendDigest.compare(
+      teams: [steady, team],
+      cycleSamples: samples,
+      ciSamples: const [],
+      now: now,
+      window: window,
+    );
+    expect(trends.first.teamId, 't1', reason: 'regressed team sorts first');
+  });
+}

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -25,6 +25,7 @@ import 'package:kode_radar/views/review_load_view.dart';
 import 'package:kode_radar/views/stacked_area_view.dart';
 import 'package:kode_radar/views/team_radar_view.dart';
 import 'package:kode_radar/views/treemap_view.dart';
+import 'package:kode_radar/views/trend_digest_view.dart';
 import 'package:kode_radar/views/trend_lines_view.dart';
 import 'package:kode_radar/views/views_common.dart';
 
@@ -173,6 +174,7 @@ void main() {
     'CiGrid': (d) => CiGridView(data: d),
     'CiTrends': (d) => CiTrendsView(data: d),
     'CycleTime': (d) => CycleTimeView(data: d),
+    'TrendDigest': (d) => TrendDigestView(data: d),
     'Treemap': (d) => TreemapView(data: d),
     'AgeHistogram': (d) => AgeHistogramView(data: d),
     'Heatmap': (d) => HeatmapView(data: d),


### PR DESCRIPTION
## What

Adds a **Trends digest + regression alerts** feature: it rolls the already-accumulated merged-PR (cycle-time) and CI-run histories into a **per-team "this period vs last period"** comparison — merge throughput, review latency, merge time, CI failure rate — surfaced in an Insights view, and **proactively notifies** when a team regresses. Turns the passive trend data into the two highest-value manager artifacts.

## How
- **`lib/trend_digest.dart`** (pure) — `TeamPeriodStats`, `TeamTrend`, `TrendRegression`; `TrendDigest.compare/regressions` over cycle + CI samples. Current window `[now-w, now)` vs previous `[now-2w, now-w)`, indexed by repoKey once, regressed teams sorted first. Thresholds: review/merge-time up needs ratio >=1.3 **and** >=4h absolute **and** >=2 samples in both windows (outlier guard); CI failure-rate up needs >=5 completed runs, current >=20%, +>=15 pts (epsilon-tolerant).
- **`lib/views/trend_digest_view.dart`** — new "Trends digest" Insights view: per-team current-vs-previous cards with colored up/down deltas + regression badges, 7/14/30-day selector.
- **Regression alerts** — `NotificationService.notifyRegressions`, deduped once-per-period via `NotificationSeenStore.claimNewRegressionKeys` (a JSON key-set in the existing `app_meta` table — **no schema migration**), **released on show-failure** so a later sync retries. Gated by a new `regressionAlertsEnabled` pref + a "Team trend alerts" Settings toggle, wired into `SyncService.regressionPhase` after the capture phases.

## Notes / scope
- **Review time is GitHub-only** (ADO exposes no cheap review timestamp).
- Alert taps open the app (Attention inbox) with a fully descriptive body; deep-linking to the Trends digest view is a noted follow-up.
- Dedup is best-effort across a period boundary (a rare out-of-order sync can cause one duplicate alert — documented, no data loss).

## Review gate
Ran **code-review** and **rubber-duck** before opening. Addressed the shared blocking finding (claimed keys were dropped if `_plugin.show` threw → added `releaseRegressionKeys` + release-on-failure) plus rubber-duck's FP-rounding and single-PR-outlier points.

## Testing
`dart format` clean, `flutter analyze --fatal-infos` clean, **465 tests pass** (+22 new: window math, regression thresholds/guards, CI failure-rate, dedup claim/release, notification copy, view smoke).
