### PR TITLE
Add GitHub issue-awareness insight

### DIFF
--- a/lib/issue_service.dart
+++ b/lib/issue_service.dart
@@ -1,0 +1,350 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'repo_discovery_service.dart';
+import 'repo_store.dart';
+import 'team.dart';
+import 'token_store.dart';
+
+/// A current-state snapshot of a repo's open issues, for the "Issues" insight.
+/// Provider-agnostic and pure so it's easy to unit-test.
+class RepoIssues {
+  const RepoIssues({
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.openCount,
+    required this.staleCount,
+    required this.oldestAgeDays,
+  });
+
+  final String repoKey;
+  final String repoDisplay;
+
+  /// Exact count of open issues (excludes pull requests).
+  final int openCount;
+
+  /// Of those, how many are older than the staleness threshold.
+  final int staleCount;
+
+  /// Age in days of the oldest open issue, or null when there are none.
+  final int? oldestAgeDays;
+
+  bool get isEmpty => openCount == 0;
+}
+
+/// The issue snapshots plus a source-health signal, so the UI can tell an
+/// all-fetched "no issues" apart from a partial/failed fetch.
+class IssuesResult {
+  const IssuesResult({this.snapshots = const [], this.failedRepos = 0});
+
+  final List<RepoIssues> snapshots;
+
+  /// Number of monitored GitHub repos whose issue fetch failed (auth/network/
+  /// malformed), so their issues aren't represented in [snapshots].
+  final int failedRepos;
+}
+
+/// Pure roll-ups over [RepoIssues], for the per-team section.
+class IssueStats {
+  const IssueStats._();
+
+  /// Per-team totals (open + stale), for teams that have any open issues.
+  /// Sorted most-stale first, then most-open, then name, then id.
+  static List<TeamIssues> perTeam(
+    Iterable<RepoIssues> snapshots,
+    List<Team> teams,
+  ) {
+    final byRepo = <String, RepoIssues>{
+      for (final s in snapshots) s.repoKey: s,
+    };
+    final result = <TeamIssues>[];
+    for (final team in teams) {
+      if (team.repoKeys.isEmpty) continue;
+      var open = 0;
+      var stale = 0;
+      for (final key in team.repoKeys) {
+        final s = byRepo[key];
+        if (s == null) continue;
+        open += s.openCount;
+        stale += s.staleCount;
+      }
+      if (open == 0) continue;
+      result.add(
+        TeamIssues(
+          teamId: team.id,
+          teamName: team.name,
+          openCount: open,
+          staleCount: stale,
+        ),
+      );
+    }
+    result.sort((a, b) {
+      if (a.staleCount != b.staleCount) {
+        return b.staleCount.compareTo(a.staleCount);
+      }
+      if (a.openCount != b.openCount) return b.openCount.compareTo(a.openCount);
+      final byName = a.teamName.toLowerCase().compareTo(
+        b.teamName.toLowerCase(),
+      );
+      return byName != 0 ? byName : a.teamId.compareTo(b.teamId);
+    });
+    return result;
+  }
+
+  /// Repos with open issues, sorted most-stale first, then most-open, then
+  /// display, then key.
+  static List<RepoIssues> rankRepos(Iterable<RepoIssues> snapshots) {
+    final result = snapshots.where((s) => !s.isEmpty).toList();
+    result.sort((a, b) {
+      if (a.staleCount != b.staleCount) {
+        return b.staleCount.compareTo(a.staleCount);
+      }
+      if (a.openCount != b.openCount) return b.openCount.compareTo(a.openCount);
+      final byName = a.repoDisplay.toLowerCase().compareTo(
+        b.repoDisplay.toLowerCase(),
+      );
+      return byName != 0 ? byName : a.repoKey.compareTo(b.repoKey);
+    });
+    return result;
+  }
+}
+
+/// A per-team open-issue roll-up.
+class TeamIssues {
+  const TeamIssues({
+    required this.teamId,
+    required this.teamName,
+    required this.openCount,
+    required this.staleCount,
+  });
+
+  final String teamId;
+  final String teamName;
+  final int openCount;
+  final int staleCount;
+}
+
+/// Fetches open-issue counts for the monitored GitHub repos, so the "Issues"
+/// insight can surface where open (and stale) issue backlogs are piling up.
+///
+/// Uses GitHub GraphQL for exact, issues-only counts: the `issues(states:OPEN)`
+/// connection excludes pull requests (so no cap/PR-mixing guesswork), a
+/// `search(... is:issue is:open created:<cutoff)` field gives the exact stale
+/// count, and `orderBy CREATED_AT ASC` yields the true oldest issue. Issues are
+/// a current-state snapshot (not accumulated history). ADO work items are
+/// project-scoped WIQL queries and aren't covered yet (a planned follow-up), so
+/// ADO repos contribute no issue data. Parsers are pure static methods for
+/// unit-testing; [computeAll] wires the network fetch, mirroring
+/// [CycleTimeService].
+class IssueService {
+  IssueService._();
+
+  static const Duration _requestTimeout = Duration(seconds: 20);
+
+  /// Open issues older than this are counted as "stale".
+  static const Duration staleThreshold = Duration(days: 30);
+
+  /// GraphQL query: exact open-issue count, the oldest open issue's creation
+  /// time, and the stale count (open issues created before the cutoff). `$stale`
+  /// carries the full search query (`repo:o/n is:issue is:open created:<DATE`).
+  static const String openIssuesQuery =
+      r'query($owner:String!,$name:String!,$stale:String!){'
+      r'repository(owner:$owner,name:$name){'
+      r'issues(states:OPEN){totalCount}'
+      r'oldest:issues(states:OPEN,first:1,orderBy:{field:CREATED_AT,direction:ASC}){nodes{createdAt}}'
+      r'}'
+      r'stale:search(query:$stale,type:ISSUE){issueCount}'
+      r'}';
+
+  // ---- Pure parser ---------------------------------------------------------
+
+  /// Normalizes a GitHub GraphQL response (see [openIssuesQuery]) into a
+  /// [RepoIssues] snapshot, or null when the response is malformed (missing
+  /// `repository`), so the caller can count it as a failed fetch. [now] anchors
+  /// the oldest-issue age.
+  static RepoIssues? issuesFromGithubGraphql(
+    dynamic body, {
+    required String repoKey,
+    required String repoDisplay,
+    required DateTime now,
+  }) {
+    final data = body is Map ? body['data'] : null;
+    final repository = data is Map ? data['repository'] : null;
+    if (repository is! Map) return null;
+    final issues = repository['issues'];
+    final open = issues is Map ? _int(issues['totalCount']) : null;
+    if (open == null) return null;
+
+    final staleField = data is Map ? data['stale'] : null;
+    final stale = staleField is Map ? _int(staleField['issueCount']) ?? 0 : 0;
+
+    int? oldestAgeDays;
+    final oldest = repository['oldest'];
+    final nodes = oldest is Map ? oldest['nodes'] : null;
+    if (nodes is List && nodes.isNotEmpty && nodes.first is Map) {
+      final created = _parseDate((nodes.first as Map)['createdAt']);
+      if (created != null) {
+        final days = now.difference(created).inDays;
+        oldestAgeDays = days < 0 ? 0 : days;
+      }
+    }
+
+    return RepoIssues(
+      repoKey: repoKey,
+      repoDisplay: repoDisplay,
+      openCount: open,
+      staleCount: stale,
+      oldestAgeDays: oldestAgeDays,
+    );
+  }
+
+  static int? _int(dynamic v) => v is int ? v : null;
+
+  static DateTime? _parseDate(dynamic value) {
+    if (value is! String || value.isEmpty) return null;
+    return DateTime.tryParse(value);
+  }
+
+  static String? _str(Map map, String key) {
+    final v = map[key];
+    return v is String && v.isNotEmpty ? v : null;
+  }
+
+  /// The `<YYYY-MM-DD` search cutoff for staleness, relative to [now] (UTC).
+  static String staleCutoffDate(DateTime now) {
+    final cutoff = now.toUtc().subtract(staleThreshold);
+    final m = cutoff.month.toString().padLeft(2, '0');
+    final d = cutoff.day.toString().padLeft(2, '0');
+    return '${cutoff.year}-$m-$d';
+  }
+
+  // ---- Network -------------------------------------------------------------
+
+  /// Fetches open-issue snapshots for every monitored GitHub repo, plus a count
+  /// of repos whose fetch failed. Never throws — top-level setup failures
+  /// return an empty result. Bounded to [concurrency] in-flight requests.
+  static Future<IssuesResult> computeAll({
+    http.Client? client,
+    int concurrency = 5,
+    Set<String>? onlyRepoKeys,
+    DateTime? now,
+  }) async {
+    final httpClient = client ?? http.Client();
+    final at = now ?? DateTime.now();
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final githubRepos =
+          prefs.getStringList(RepoStore.githubKey) ?? const <String>[];
+
+      final tasks = <Future<RepoIssues?> Function()>[];
+      for (final raw in githubRepos) {
+        try {
+          final decoded = jsonDecode(raw);
+          if (decoded is! Map) continue;
+          final owner = _str(decoded, 'owner');
+          final name = _str(decoded, 'repoName');
+          if (owner == null || name == null) continue;
+          final repoKey = RepoDiscoveryService.githubKey(owner, name);
+          if (onlyRepoKeys != null && !onlyRepoKeys.contains(repoKey)) continue;
+          final tokenId = _str(decoded, 'tokenId');
+          tasks.add(
+            () => _fetchGithub(
+              httpClient,
+              owner: owner,
+              name: name,
+              repoKey: repoKey,
+              tokenId: tokenId,
+              now: at,
+            ),
+          );
+        } catch (_) {
+          // Skip malformed entries.
+        }
+      }
+
+      final results = await _runBounded(tasks, concurrency);
+      final snapshots = <RepoIssues>[];
+      var failed = 0;
+      for (final r in results) {
+        if (r == null) {
+          failed++;
+        } else {
+          snapshots.add(r);
+        }
+      }
+      return IssuesResult(snapshots: snapshots, failedRepos: failed);
+    } catch (_) {
+      // Top-level setup (prefs) failure: report nothing rather than throw so a
+      // caller (e.g. the Insights hub) isn't taken down with it.
+      return const IssuesResult();
+    } finally {
+      if (client == null) httpClient.close();
+    }
+  }
+
+  static Future<RepoIssues?> _fetchGithub(
+    http.Client httpClient, {
+    required String owner,
+    required String name,
+    required String repoKey,
+    String? tokenId,
+    required DateTime now,
+  }) async {
+    try {
+      final secret = (await TokenStore.resolveGithubSecret(
+        owner,
+        tokenId: tokenId,
+      ))?.trim();
+      if (secret == null || secret.isEmpty) return null;
+      final staleQuery =
+          'repo:$owner/$name is:issue is:open '
+          'created:<${staleCutoffDate(now)}';
+      final response = await httpClient
+          .post(
+            Uri.https('api.github.com', '/graphql'),
+            headers: {
+              'Authorization': 'Bearer $secret',
+              'Content-Type': 'application/json',
+            },
+            body: jsonEncode({
+              'query': openIssuesQuery,
+              'variables': {'owner': owner, 'name': name, 'stale': staleQuery},
+            }),
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode != 200) return null;
+      final body = jsonDecode(response.body);
+      if (body is Map && body['errors'] != null) return null;
+      return issuesFromGithubGraphql(
+        body,
+        repoKey: repoKey,
+        repoDisplay: '$owner/$name',
+        now: now,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static Future<List<T>> _runBounded<T>(
+    List<Future<T> Function()> tasks,
+    int concurrency,
+  ) async {
+    if (tasks.isEmpty) return <T>[];
+    final results = <T>[];
+    var next = 0;
+    Future<void> worker() async {
+      while (true) {
+        final i = next++;
+        if (i >= tasks.length) break;
+        results.add(await tasks[i]());
+      }
+    }
+
+    final workerCount = concurrency.clamp(1, tasks.length);
+    await Future.wait(List.generate(workerCount, (_) => worker()));
+    return results;
+  }
+}

--- a/lib/issue_service.dart
+++ b/lib/issue_service.dart
@@ -239,13 +239,23 @@ class IssueService {
           prefs.getStringList(RepoStore.githubKey) ?? const <String>[];
 
       final tasks = <Future<RepoIssues?> Function()>[];
+      // Repos we couldn't even attempt (malformed stored entry / missing
+      // fields) count toward failedRepos too, so the partial-coverage signal
+      // stays honest — but an intentional onlyRepoKeys filter-out does not.
+      var setupFailed = 0;
       for (final raw in githubRepos) {
         try {
           final decoded = jsonDecode(raw);
-          if (decoded is! Map) continue;
+          if (decoded is! Map) {
+            setupFailed++;
+            continue;
+          }
           final owner = _str(decoded, 'owner');
           final name = _str(decoded, 'repoName');
-          if (owner == null || name == null) continue;
+          if (owner == null || name == null) {
+            setupFailed++;
+            continue;
+          }
           final repoKey = RepoDiscoveryService.githubKey(owner, name);
           if (onlyRepoKeys != null && !onlyRepoKeys.contains(repoKey)) continue;
           final tokenId = _str(decoded, 'tokenId');
@@ -260,13 +270,14 @@ class IssueService {
             ),
           );
         } catch (_) {
-          // Skip malformed entries.
+          // A malformed entry we couldn't parse — count it as unavailable.
+          setupFailed++;
         }
       }
 
       final results = await _runBounded(tasks, concurrency);
       final snapshots = <RepoIssues>[];
-      var failed = 0;
+      var failed = setupFailed;
       for (final r in results) {
         if (r == null) {
           failed++;

--- a/lib/issue_service.dart
+++ b/lib/issue_service.dart
@@ -327,7 +327,10 @@ class IssueService {
           .timeout(_requestTimeout);
       if (response.statusCode != 200) return null;
       final body = jsonDecode(response.body);
-      if (body is Map && body['errors'] != null) return null;
+      // GitHub can return an empty `errors: []` alongside valid data; only a
+      // non-empty errors list is a real failure.
+      final errors = body is Map ? body['errors'] : null;
+      if (errors is List && errors.isNotEmpty) return null;
       return issuesFromGithubGraphql(
         body,
         repoKey: repoKey,

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -5,6 +5,7 @@ import '../app_http.dart';
 import '../ci_run_history_store.dart';
 import '../cycle_time_service.dart';
 import '../cycle_time_store.dart';
+import '../issue_service.dart';
 import '../metric_store.dart';
 import '../people_service.dart';
 import '../team_service.dart';
@@ -19,6 +20,7 @@ import 'donut_view.dart';
 import 'freshness_view.dart';
 import 'health_gauge_view.dart';
 import 'heatmap_view.dart';
+import 'issues_view.dart';
 import 'provider_split_view.dart';
 import 'pulse_view.dart';
 import 'quadrant_view.dart';
@@ -103,6 +105,12 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       builder: (d) => TrendDigestView(data: d),
     ),
     ViewInfo(
+      title: 'Issues',
+      blurb: 'Open & stale issue backlogs',
+      icon: Icons.bug_report_outlined,
+      builder: (d) => IssuesView(data: d),
+    ),
+    ViewInfo(
       title: 'Treemap',
       blurb: 'Repos sized by activity',
       icon: Icons.dashboard,
@@ -183,12 +191,13 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       _error = null;
     });
     try {
-      // Run the three network passes concurrently (repo activity, People, and
-      // merged-PR cycle time) so none serializes behind the others.
-      final (activities, people, cycleFetched) = await (
+      // Run the network passes concurrently (repo activity, People, merged-PR
+      // cycle time, and open issues) so none serializes behind the others.
+      final (activities, people, cycleFetched, issuesResult) = await (
         ActivityService.computeAll(client: AppHttp.client),
         PeopleService.computeAll(client: AppHttp.client),
         CycleTimeService.computeAll(client: AppHttp.client),
+        IssueService.computeAll(client: AppHttp.client),
       ).wait;
       // Record a trend snapshot from this load too (deduped ~1/day), matching
       // Radar/Teams/Digest, so opening Insights also advances trend history.
@@ -215,6 +224,8 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
           people: people,
           ciRunSamples: ciRunSamples,
           cycleSamples: cycleSamples,
+          issueSnapshots: issuesResult.snapshots,
+          issuesFailedRepos: issuesResult.failedRepos,
           loadedAt: DateTime.now(),
         );
         _loading = false;

--- a/lib/views/issues_view.dart
+++ b/lib/views/issues_view.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+
+import '../issue_service.dart';
+import 'views_common.dart';
+
+/// Surfaces where open (and stale) issue backlogs are piling up: per-repo and
+/// per-team open-issue counts, ranked most-stale first so the backlogs that
+/// need triage bubble up. GitHub-only for now (ADO work items are a planned
+/// follow-up).
+class IssuesView extends StatelessWidget {
+  const IssuesView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final repos = IssueStats.rankRepos(data.issueSnapshots);
+    final teams = IssueStats.perTeam(data.issueSnapshots, data.teams);
+    final totalOpen = repos.fold<int>(0, (t, r) => t + r.openCount);
+    final totalStale = repos.fold<int>(0, (t, r) => t + r.staleCount);
+    final failed = data.issuesFailedRepos;
+
+    return ViewScaffold(
+      title: 'Issues',
+      loadedAt: data.loadedAt,
+      child: repos.isEmpty
+          ? ViewEmpty(
+              message: failed > 0
+                  ? 'Couldn\u2019t fetch issues for $failed '
+                        '${failed == 1 ? 'repo' : 'repos'}.\nCheck your '
+                        'connection and tokens, then refresh.'
+                  : 'No open issues.\nOpen-issue counts are fetched for GitHub '
+                        'repos — check back after a sync, or once a monitored '
+                        'repo has open issues.',
+            )
+          : ListView(
+              padding: const EdgeInsets.all(12),
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(4, 4, 4, 8),
+                  child: Text(
+                    '$totalOpen open · $totalStale stale '
+                    '(>${IssueService.staleThreshold.inDays}d) · GitHub only'
+                    '${failed > 0 ? ' · $failed unavailable' : ''}',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: totalStale > 0
+                          ? _stale
+                          : theme.colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                if (teams.isNotEmpty) ...[
+                  _SectionLabel(label: 'By team'),
+                  for (final t in teams)
+                    _IssueTile(
+                      title: t.teamName,
+                      leadingIcon: Icons.groups_2,
+                      openCount: t.openCount,
+                      staleCount: t.staleCount,
+                      oldestAgeDays: null,
+                    ),
+                  const SizedBox(height: 16),
+                  _SectionLabel(label: 'By repo'),
+                ],
+                for (final r in repos)
+                  _IssueTile(
+                    title: r.repoDisplay,
+                    leadingIcon: Icons.bug_report_outlined,
+                    openCount: r.openCount,
+                    staleCount: r.staleCount,
+                    oldestAgeDays: r.oldestAgeDays,
+                  ),
+              ],
+            ),
+    );
+  }
+}
+
+const Color _stale = Color(0xFFEF6C00);
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
+      child: Text(
+        label.toUpperCase(),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.6,
+        ),
+      ),
+    );
+  }
+}
+
+class _IssueTile extends StatelessWidget {
+  const _IssueTile({
+    required this.title,
+    required this.leadingIcon,
+    required this.openCount,
+    required this.staleCount,
+    required this.oldestAgeDays,
+  });
+
+  final String title;
+  final IconData leadingIcon;
+  final int openCount;
+  final int staleCount;
+  final int? oldestAgeDays;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final subtitleParts = <String>[
+      if (staleCount > 0) '$staleCount stale',
+      if (oldestAgeDays != null) 'oldest ${oldestAgeDays}d',
+    ];
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            Icon(leadingIcon, size: 18, color: theme.colorScheme.primary),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  if (subtitleParts.isNotEmpty)
+                    Text(
+                      subtitleParts.join(' · '),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: staleCount > 0
+                            ? _stale
+                            : theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              '$openCount',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -4,6 +4,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../activity_service.dart';
 import '../ci_run_history.dart';
 import '../cycle_time.dart';
+import '../issue_service.dart';
 import '../metric_snapshot.dart';
 import '../person.dart';
 import '../team.dart';
@@ -23,6 +24,8 @@ class InsightsData {
     required List<Person> people,
     List<CiRunSample> ciRunSamples = const [],
     List<MergedPrSample> cycleSamples = const [],
+    List<RepoIssues> issueSnapshots = const [],
+    this.issuesFailedRepos = 0,
     required this.loadedAt,
   }) : activities = List.unmodifiable(activities),
        history = Map.unmodifiable({
@@ -35,7 +38,8 @@ class InsightsData {
        }),
        people = List.unmodifiable(people),
        ciRunSamples = List.unmodifiable(ciRunSamples),
-       cycleSamples = List.unmodifiable(cycleSamples);
+       cycleSamples = List.unmodifiable(cycleSamples),
+       issueSnapshots = List.unmodifiable(issueSnapshots);
 
   final List<RepoActivity> activities;
   final Map<String, List<MetricSnapshot>> history;
@@ -50,6 +54,13 @@ class InsightsData {
   /// Raw merged-PR history (bounded by retention) from which the cycle-time
   /// view aggregates per-repo / per-team review- and merge-time medians.
   final List<MergedPrSample> cycleSamples;
+
+  /// Current-state open-issue snapshots per GitHub repo (for the Issues view).
+  final List<RepoIssues> issueSnapshots;
+
+  /// How many monitored GitHub repos' issue fetches failed this load, so the
+  /// Issues view can show partial-coverage instead of a false "no issues".
+  final int issuesFailedRepos;
   final DateTime loadedAt;
 
   /// Repos whose fetch succeeded (errored repos would read as healthy zeros).

--- a/test/issue_service_test.dart
+++ b/test/issue_service_test.dart
@@ -2,9 +2,13 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kode_radar/issue_service.dart';
+import 'package:kode_radar/repo_store.dart';
 import 'package:kode_radar/team.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final now = DateTime.utc(2026, 3, 1);
 
   group('issuesFromGithubGraphql', () {
@@ -147,6 +151,23 @@ void main() {
       expect(result.single.teamId, 't1');
       expect(result.single.openCount, 8);
       expect(result.single.staleCount, 3);
+    });
+  });
+
+  group('computeAll', () {
+    test('malformed monitored entries count toward failedRepos', () async {
+      // Malformed entries never create a fetch task, so no network is hit;
+      // they must still be reported as unavailable so the partial-coverage
+      // signal is honest.
+      SharedPreferences.setMockInitialValues({
+        RepoStore.githubKey: <String>[
+          'not json',
+          '{"owner":"o"}', // missing repoName
+        ],
+      });
+      final result = await IssueService.computeAll(now: now);
+      expect(result.snapshots, isEmpty);
+      expect(result.failedRepos, 2);
     });
   });
 }

--- a/test/issue_service_test.dart
+++ b/test/issue_service_test.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/issue_service.dart';
+import 'package:kode_radar/team.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 3, 1);
+
+  group('issuesFromGithubGraphql', () {
+    test('reads exact open + stale counts and the oldest issue age', () {
+      final body = jsonDecode('''
+      {"data":{
+        "repository":{
+          "issues":{"totalCount":12},
+          "oldest":{"nodes":[{"createdAt":"2025-12-01T00:00:00Z"}]}
+        },
+        "stale":{"issueCount":4}
+      }}
+      ''');
+      final r = IssueService.issuesFromGithubGraphql(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+        now: now,
+      )!;
+      expect(r.openCount, 12);
+      expect(r.staleCount, 4);
+      expect(r.oldestAgeDays, now.difference(DateTime.utc(2025, 12, 1)).inDays);
+      expect(r.isEmpty, isFalse);
+    });
+
+    test('zero open issues → empty snapshot, null oldest', () {
+      final body = jsonDecode('''
+      {"data":{
+        "repository":{"issues":{"totalCount":0},"oldest":{"nodes":[]}},
+        "stale":{"issueCount":0}
+      }}
+      ''');
+      final r = IssueService.issuesFromGithubGraphql(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+        now: now,
+      )!;
+      expect(r.openCount, 0);
+      expect(r.staleCount, 0);
+      expect(r.oldestAgeDays, isNull);
+      expect(r.isEmpty, isTrue);
+    });
+
+    test('missing repository (malformed) → null (a failed fetch)', () {
+      final r = IssueService.issuesFromGithubGraphql(
+        jsonDecode('{"data":{"repository":null}}'),
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+        now: now,
+      );
+      expect(r, isNull);
+    });
+
+    test('missing totalCount → null', () {
+      final r = IssueService.issuesFromGithubGraphql(
+        jsonDecode('{"data":{"repository":{"issues":{}}}}'),
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+        now: now,
+      );
+      expect(r, isNull);
+    });
+
+    test('absent stale field defaults stale to 0', () {
+      final body = jsonDecode('''
+      {"data":{"repository":{
+        "issues":{"totalCount":3},
+        "oldest":{"nodes":[{"createdAt":"2026-02-27T00:00:00Z"}]}
+      }}}
+      ''');
+      final r = IssueService.issuesFromGithubGraphql(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+        now: now,
+      )!;
+      expect(r.openCount, 3);
+      expect(r.staleCount, 0);
+    });
+  });
+
+  group('staleCutoffDate', () {
+    test('is 30 days before now, YYYY-MM-DD (UTC)', () {
+      expect(
+        IssueService.staleCutoffDate(DateTime.utc(2026, 3, 1)),
+        '2026-01-30',
+      );
+      expect(
+        IssueService.staleCutoffDate(DateTime.utc(2026, 1, 5)),
+        '2025-12-06',
+      );
+    });
+  });
+
+  group('IssueStats', () {
+    RepoIssues snap(
+      String key, {
+      required int open,
+      int stale = 0,
+      int? oldest,
+    }) => RepoIssues(
+      repoKey: key,
+      repoDisplay: key,
+      openCount: open,
+      staleCount: stale,
+      oldestAgeDays: oldest,
+    );
+
+    test('rankRepos drops empty and sorts most-stale then most-open', () {
+      final ranked = IssueStats.rankRepos([
+        snap('github:o/empty', open: 0),
+        snap('github:o/a', open: 10, stale: 1),
+        snap('github:o/b', open: 3, stale: 5),
+        snap('github:o/c', open: 8, stale: 1),
+      ]);
+      expect(ranked.map((r) => r.repoKey), [
+        'github:o/b', // most stale (5)
+        'github:o/a', // stale 1, tie broken by open desc: 10 > 8
+        'github:o/c', // stale 1, open 8
+      ]);
+    });
+
+    test('perTeam sums member repos and drops issue-free teams', () {
+      final snapshots = [
+        snap('github:o/a', open: 5, stale: 2),
+        snap('github:o/b', open: 3, stale: 1),
+        snap('github:o/c', open: 0),
+      ];
+      final teams = [
+        const Team(
+          id: 't1',
+          name: 'Platform',
+          repoKeys: {'github:o/a', 'github:o/b'},
+        ),
+        const Team(id: 't2', name: 'Quiet', repoKeys: {'github:o/c'}),
+      ];
+      final result = IssueStats.perTeam(snapshots, teams);
+      expect(result, hasLength(1));
+      expect(result.single.teamId, 't1');
+      expect(result.single.openCount, 8);
+      expect(result.single.staleCount, 3);
+    });
+  });
+}

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:kode_radar/activity_service.dart';
 import 'package:kode_radar/ci_run_history.dart';
 import 'package:kode_radar/cycle_time.dart';
+import 'package:kode_radar/issue_service.dart';
 import 'package:kode_radar/metric_snapshot.dart';
 import 'package:kode_radar/person.dart';
 import 'package:kode_radar/team.dart';
@@ -17,6 +18,7 @@ import 'package:kode_radar/views/donut_view.dart';
 import 'package:kode_radar/views/freshness_view.dart';
 import 'package:kode_radar/views/health_gauge_view.dart';
 import 'package:kode_radar/views/heatmap_view.dart';
+import 'package:kode_radar/views/issues_view.dart';
 import 'package:kode_radar/views/provider_split_view.dart';
 import 'package:kode_radar/views/pulse_view.dart';
 import 'package:kode_radar/views/quadrant_view.dart';
@@ -150,6 +152,23 @@ InsightsData _sampleData() {
           url: 'https://github.com/o/alpha/pull/$i',
         ),
     ],
+    issueSnapshots: [
+      const RepoIssues(
+        repoKey: 'github:o/alpha',
+        repoDisplay: 'o/alpha',
+        openCount: 12,
+        staleCount: 4,
+        oldestAgeDays: 90,
+      ),
+      const RepoIssues(
+        repoKey: 'github:o/beta',
+        repoDisplay: 'o/beta',
+        openCount: 100,
+        staleCount: 30,
+        oldestAgeDays: 200,
+      ),
+    ],
+    issuesFailedRepos: 1,
     loadedAt: DateTime.utc(2026, 3, 1, 13),
   );
 }
@@ -175,6 +194,7 @@ void main() {
     'CiTrends': (d) => CiTrendsView(data: d),
     'CycleTime': (d) => CycleTimeView(data: d),
     'TrendDigest': (d) => TrendDigestView(data: d),
+    'Issues': (d) => IssuesView(data: d),
     'Treemap': (d) => TreemapView(data: d),
     'AgeHistogram': (d) => AgeHistogramView(data: d),
     'Heatmap': (d) => HeatmapView(data: d),


### PR DESCRIPTION
## What

Adds **issue awareness**: a new "Issues" Insights view that surfaces where open (and stale) issue backlogs are piling up — **per-repo and per-team open-issue counts, ranked most-stale first** — so a manager watching several teams (and many OSS projects) can spot the backlogs that need triage.

## How
- **`lib/issue_service.dart`** (pure + fetch) — `RepoIssues` (openCount, staleCount, oldestAgeDays) + `IssueStats.rankRepos/perTeam`. Fetches via **GitHub GraphQL** for exact, issues-only counts: `issues(states:OPEN).totalCount` excludes PRs, a `search(is:issue is:open created:<cutoff)` field gives the exact **stale** count, and `orderBy CREATED_AT ASC` yields the **true oldest** issue — so there's no cap / PR-mixing guesswork. `computeAll` returns an `IssuesResult` (snapshots + `failedRepos`) and never throws.
- **`lib/views/issues_view.dart`** — the "Issues" view (per-repo + per-team, stale-first), which distinguishes a genuine "no open issues" from a partial/failed fetch.
- **Wiring** — `InsightsData` gains `issueSnapshots` + `issuesFailedRepos`; the Insights hub fetches issues concurrently with the other passes and registers the view.

## Notes / scope
- **GitHub-only** for now — ADO work items are project-scoped WIQL queries (a planned follow-up), so ADO repos contribute no issue data.
- Current-state snapshot — **no new DB table** (issues aren't accumulated history).
- Attention-category / feed-event / issue-trend integration are noted follow-ups; this is the first coherent increment.

## Review gate
Ran **code-review** (no significant issues) and **rubber-duck** before opening. Rubber-duck flagged the original REST `/issues` approach (100-item cap intermixes PRs → counts/oldest could mislead) and that failures rendered as "No issues"; I reworked the fetch to **GraphQL** (exact issues-only counts, no cap) and added the `IssuesResult` failure signal + partial-coverage UI, plus deterministic sort tie-breakers.

## Testing
`dart format` clean, `flutter analyze --fatal-infos` clean, **476 tests pass** (+13 new: GraphQL parser incl. malformed/zero/absent-stale, stale-cutoff date, rank/per-team aggregation, view smoke).
