### PR TITLE
Add releases & security digest insight

### DIFF
--- a/lib/release_service.dart
+++ b/lib/release_service.dart
@@ -105,11 +105,12 @@ class SecurityStats {
 /// lately" and "what's newly vulnerable".
 ///
 /// GitHub-only: Azure DevOps has no releases-list / Dependabot equivalent here.
-/// Releases use the public releases API (works for any watched repo); Dependabot
-/// alerts are owner-scoped, so repos the user doesn't administer typically 403
-/// — that's counted as "unavailable", not a failure. Parsers are pure static
-/// methods for unit-testing; [computeAll] wires the network fetch, mirroring
-/// [IssueService].
+/// Each repo is fetched with its configured token (like every other service).
+/// The releases API is public, so it's readable for any repo the token can see
+/// — including ones the user doesn't own — whereas Dependabot alerts are
+/// owner-scoped, so repos the user doesn't administer typically 403; that's
+/// counted as "unavailable", not a failure. Parsers are pure static methods for
+/// unit-testing; [computeAll] wires the network fetch, mirroring [IssueService].
 class ReleaseService {
   ReleaseService._();
 

--- a/lib/release_service.dart
+++ b/lib/release_service.dart
@@ -282,8 +282,10 @@ class ReleaseService {
       final results = await _runBounded(tasks, concurrency);
       final releases = <ReleaseItem>[];
       final security = <RepoSecurity>[];
+      // A malformed stored entry means neither source could be fetched, so it
+      // counts toward both coverage gaps.
       var releasesFailed = setupFailed;
-      var securityUnavailable = 0;
+      var securityUnavailable = setupFailed;
       for (final r in results) {
         if (r.releases == null) {
           releasesFailed++;

--- a/lib/release_service.dart
+++ b/lib/release_service.dart
@@ -1,0 +1,421 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'repo_detail_service.dart';
+import 'repo_discovery_service.dart';
+import 'repo_store.dart';
+import 'token_store.dart';
+
+/// A published release, tagged with its repo, for the cross-repo "what shipped"
+/// digest.
+class ReleaseItem {
+  const ReleaseItem({
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.tag,
+    this.name,
+    this.author,
+    this.publishedAt,
+    this.url,
+  });
+
+  final String repoKey;
+  final String repoDisplay;
+  final String tag;
+  final String? name;
+  final String? author;
+  final DateTime? publishedAt;
+  final String? url;
+}
+
+/// Open-vulnerability (Dependabot alert) counts for a repo, by severity.
+class RepoSecurity {
+  const RepoSecurity({
+    required this.repoKey,
+    required this.repoDisplay,
+    required this.critical,
+    required this.high,
+    required this.medium,
+    required this.low,
+    this.capped = false,
+  });
+
+  final String repoKey;
+  final String repoDisplay;
+  final int critical;
+  final int high;
+  final int medium;
+  final int low;
+
+  /// True when the alerts page was full, so counts are a floor (there may be
+  /// more open alerts than shown).
+  final bool capped;
+
+  int get total => critical + high + medium + low;
+
+  bool get isEmpty => total == 0;
+}
+
+/// The cross-repo release + security snapshot, with source-health signals so
+/// the UI can tell "nothing shipped / all clear" apart from failed fetches.
+class ReleaseSecurityResult {
+  const ReleaseSecurityResult({
+    this.releases = const [],
+    this.security = const [],
+    this.releasesFailedRepos = 0,
+    this.securityUnavailableRepos = 0,
+  });
+
+  final List<ReleaseItem> releases;
+  final List<RepoSecurity> security;
+
+  /// GitHub repos whose releases fetch failed (auth/network/malformed).
+  final int releasesFailedRepos;
+
+  /// GitHub repos whose Dependabot alerts weren't readable (commonly 403 for
+  /// repos the user doesn't administer — expected for watched OSS, not an
+  /// error). Surfaced so the security section can explain partial coverage.
+  final int securityUnavailableRepos;
+}
+
+/// Pure roll-ups for the security section.
+class SecurityStats {
+  const SecurityStats._();
+
+  /// Repos with open alerts, worst-severity first (a single critical outranks
+  /// any number of highs, etc.), then most-total, then name.
+  static List<RepoSecurity> rankRepos(Iterable<RepoSecurity> repos) {
+    final result = repos.where((r) => !r.isEmpty).toList();
+    result.sort((a, b) {
+      // Compare severities in order so a strictly-worse severity always wins.
+      if (a.critical != b.critical) return b.critical.compareTo(a.critical);
+      if (a.high != b.high) return b.high.compareTo(a.high);
+      if (a.medium != b.medium) return b.medium.compareTo(a.medium);
+      if (a.low != b.low) return b.low.compareTo(a.low);
+      return a.repoDisplay.toLowerCase().compareTo(b.repoDisplay.toLowerCase());
+    });
+    return result;
+  }
+}
+
+/// Fetches recent releases and open Dependabot alerts across the monitored
+/// GitHub repos, so the "Releases & security" insight can answer "what shipped
+/// lately" and "what's newly vulnerable".
+///
+/// GitHub-only: Azure DevOps has no releases-list / Dependabot equivalent here.
+/// Releases use the public releases API (works for any watched repo); Dependabot
+/// alerts are owner-scoped, so repos the user doesn't administer typically 403
+/// — that's counted as "unavailable", not a failure. Parsers are pure static
+/// methods for unit-testing; [computeAll] wires the network fetch, mirroring
+/// [IssueService].
+class ReleaseService {
+  ReleaseService._();
+
+  static const Duration _requestTimeout = Duration(seconds: 20);
+
+  /// Only releases published within this window are surfaced in the digest.
+  static const Duration releaseWindow = Duration(days: 90);
+
+  static const int _releasePageSize = 30;
+  static const int _alertPageSize = 100;
+
+  // ---- Pure parsers --------------------------------------------------------
+
+  /// Normalizes a GitHub `/releases` list into [ReleaseItem]s tagged with the
+  /// repo, keeping only releases published within [window] of [now]. Reuses the
+  /// shared release normalizer, then filters/attaches identity.
+  static List<ReleaseItem> releasesFromGithub(
+    dynamic body, {
+    required String repoKey,
+    required String repoDisplay,
+    required DateTime now,
+    Duration window = releaseWindow,
+  }) {
+    if (body is! List) return const [];
+    final cutoff = now.subtract(window);
+    final result = <ReleaseItem>[];
+    for (final release in RepoDetailService.parseGithubReleases(body)) {
+      final published = release.publishedAt;
+      // Drop drafts/undated and anything older than the window.
+      if (published == null || published.isBefore(cutoff)) continue;
+      result.add(
+        ReleaseItem(
+          repoKey: repoKey,
+          repoDisplay: repoDisplay,
+          tag: release.tag,
+          name: release.name,
+          author: release.author,
+          publishedAt: published,
+          url: release.url,
+        ),
+      );
+    }
+    return result;
+  }
+
+  /// Counts open Dependabot alerts by severity from a GitHub
+  /// `/dependabot/alerts` list. Only `state == open` alerts are counted; the
+  /// severity comes from `security_advisory.severity` (falling back to
+  /// `security_vulnerability.severity`). Returns null when the body isn't a
+  /// list (e.g. a 403/404 object), so the caller can mark it unavailable.
+  static RepoSecurity? securityFromGithubAlerts(
+    dynamic body, {
+    required String repoKey,
+    required String repoDisplay,
+  }) {
+    if (body is! List) return null;
+    var critical = 0, high = 0, medium = 0, low = 0;
+    for (final alert in body) {
+      if (alert is! Map) continue;
+      final state = alert['state'];
+      // Require an explicit "open" state (a missing/non-string state isn't
+      // assumed open).
+      if (state is! String || state.toLowerCase() != 'open') continue;
+      switch (_severityOf(alert)) {
+        case 'critical':
+          critical++;
+        case 'high':
+          high++;
+        case 'medium':
+          medium++;
+        case 'low':
+          low++;
+      }
+    }
+    return RepoSecurity(
+      repoKey: repoKey,
+      repoDisplay: repoDisplay,
+      critical: critical,
+      high: high,
+      medium: medium,
+      low: low,
+      capped: body.length >= _alertPageSize,
+    );
+  }
+
+  static String? _severityOf(Map alert) {
+    final advisory = alert['security_advisory'];
+    final fromAdvisory = advisory is Map ? advisory['severity'] : null;
+    if (fromAdvisory is String) return fromAdvisory.toLowerCase();
+    final vuln = alert['security_vulnerability'];
+    final fromVuln = vuln is Map ? vuln['severity'] : null;
+    if (fromVuln is String) return fromVuln.toLowerCase();
+    return null;
+  }
+
+  static String? _str(Map map, String key) {
+    final v = map[key];
+    return v is String && v.isNotEmpty ? v : null;
+  }
+
+  /// All releases sorted newest published first (nulls last), across repos.
+  static List<ReleaseItem> sortReleases(List<ReleaseItem> releases) {
+    final sorted = [...releases];
+    sorted.sort((a, b) {
+      final ap = a.publishedAt;
+      final bp = b.publishedAt;
+      if (ap == null && bp == null) {
+        return a.repoDisplay.toLowerCase().compareTo(
+          b.repoDisplay.toLowerCase(),
+        );
+      }
+      if (ap == null) return 1;
+      if (bp == null) return -1;
+      return bp.compareTo(ap);
+    });
+    return sorted;
+  }
+
+  // ---- Network -------------------------------------------------------------
+
+  /// Fetches releases + Dependabot alerts for every monitored GitHub repo.
+  /// Never throws — top-level setup failures return an empty result. Bounded to
+  /// [concurrency] repos in flight (each repo does its two GETs sequentially).
+  static Future<ReleaseSecurityResult> computeAll({
+    http.Client? client,
+    int concurrency = 5,
+    Set<String>? onlyRepoKeys,
+    DateTime? now,
+  }) async {
+    final httpClient = client ?? http.Client();
+    final at = now ?? DateTime.now();
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final githubRepos =
+          prefs.getStringList(RepoStore.githubKey) ?? const <String>[];
+
+      final tasks = <Future<_RepoResult> Function()>[];
+      var setupFailed = 0;
+      for (final raw in githubRepos) {
+        try {
+          final decoded = jsonDecode(raw);
+          if (decoded is! Map) {
+            setupFailed++;
+            continue;
+          }
+          final owner = _str(decoded, 'owner');
+          final name = _str(decoded, 'repoName');
+          if (owner == null || name == null) {
+            setupFailed++;
+            continue;
+          }
+          final repoKey = RepoDiscoveryService.githubKey(owner, name);
+          if (onlyRepoKeys != null && !onlyRepoKeys.contains(repoKey)) continue;
+          final tokenId = _str(decoded, 'tokenId');
+          tasks.add(
+            () => _fetchGithub(
+              httpClient,
+              owner: owner,
+              name: name,
+              repoKey: repoKey,
+              tokenId: tokenId,
+              now: at,
+            ),
+          );
+        } catch (_) {
+          setupFailed++;
+        }
+      }
+
+      final results = await _runBounded(tasks, concurrency);
+      final releases = <ReleaseItem>[];
+      final security = <RepoSecurity>[];
+      var releasesFailed = setupFailed;
+      var securityUnavailable = 0;
+      for (final r in results) {
+        if (r.releases == null) {
+          releasesFailed++;
+        } else {
+          releases.addAll(r.releases!);
+        }
+        if (r.security == null) {
+          securityUnavailable++;
+        } else if (!r.security!.isEmpty) {
+          security.add(r.security!);
+        }
+      }
+      return ReleaseSecurityResult(
+        releases: sortReleases(releases),
+        security: SecurityStats.rankRepos(security),
+        releasesFailedRepos: releasesFailed,
+        securityUnavailableRepos: securityUnavailable,
+      );
+    } catch (_) {
+      return const ReleaseSecurityResult();
+    } finally {
+      if (client == null) httpClient.close();
+    }
+  }
+
+  static Future<_RepoResult> _fetchGithub(
+    http.Client httpClient, {
+    required String owner,
+    required String name,
+    required String repoKey,
+    String? tokenId,
+    required DateTime now,
+  }) async {
+    String? secret;
+    try {
+      secret = (await TokenStore.resolveGithubSecret(
+        owner,
+        tokenId: tokenId,
+      ))?.trim();
+    } catch (_) {
+      // Isolate a token-resolution failure to this repo (both sources counted
+      // unavailable) rather than aborting the whole batch.
+      return const _RepoResult(releases: null, security: null);
+    }
+    if (secret == null || secret.isEmpty) {
+      return const _RepoResult(releases: null, security: null);
+    }
+    final headers = {
+      'Authorization': 'Bearer $secret',
+      'Accept': 'application/vnd.github+json',
+    };
+    final display = '$owner/$name';
+
+    List<ReleaseItem>? releases;
+    try {
+      final response = await httpClient
+          .get(
+            Uri.https('api.github.com', '/repos/$owner/$name/releases', {
+              'per_page': '$_releasePageSize',
+            }),
+            headers: headers,
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode == 200) {
+        final decoded = jsonDecode(response.body);
+        // A 200 whose body isn't a list is malformed — treat as a failure
+        // (null) rather than a successful empty result.
+        if (decoded is List) {
+          releases = releasesFromGithub(
+            decoded,
+            repoKey: repoKey,
+            repoDisplay: display,
+            now: now,
+          );
+        }
+      }
+    } catch (_) {
+      releases = null;
+    }
+
+    RepoSecurity? security;
+    try {
+      final response = await httpClient
+          .get(
+            Uri.https(
+              'api.github.com',
+              '/repos/$owner/$name/dependabot/alerts',
+              {'state': 'open', 'per_page': '$_alertPageSize'},
+            ),
+            headers: headers,
+          )
+          .timeout(_requestTimeout);
+      if (response.statusCode == 200) {
+        security = securityFromGithubAlerts(
+          jsonDecode(response.body),
+          repoKey: repoKey,
+          repoDisplay: display,
+        );
+      }
+      // Any non-200 (403 no access / 404 alerts disabled) → unavailable (null).
+    } catch (_) {
+      security = null;
+    }
+
+    return _RepoResult(releases: releases, security: security);
+  }
+
+  static Future<List<T>> _runBounded<T>(
+    List<Future<T> Function()> tasks,
+    int concurrency,
+  ) async {
+    if (tasks.isEmpty) return <T>[];
+    final results = <T>[];
+    var next = 0;
+    Future<void> worker() async {
+      while (true) {
+        final i = next++;
+        if (i >= tasks.length) break;
+        results.add(await tasks[i]());
+      }
+    }
+
+    final workerCount = concurrency.clamp(1, tasks.length);
+    await Future.wait(List.generate(workerCount, (_) => worker()));
+    return results;
+  }
+}
+
+/// One repo's fetch outcome. A null field means that source failed / was
+/// unavailable for the repo (distinct from a successful empty result).
+class _RepoResult {
+  const _RepoResult({required this.releases, required this.security});
+  final List<ReleaseItem>? releases;
+  final RepoSecurity? security;
+}

--- a/lib/release_service.dart
+++ b/lib/release_service.dart
@@ -85,7 +85,7 @@ class SecurityStats {
   const SecurityStats._();
 
   /// Repos with open alerts, worst-severity first (a single critical outranks
-  /// any number of highs, etc.), then most-total, then name.
+  /// any number of highs, etc.), then by display name.
   static List<RepoSecurity> rankRepos(Iterable<RepoSecurity> repos) {
     final result = repos.where((r) => !r.isEmpty).toList();
     result.sort((a, b) {

--- a/lib/views/insights_hub_page.dart
+++ b/lib/views/insights_hub_page.dart
@@ -8,6 +8,7 @@ import '../cycle_time_store.dart';
 import '../issue_service.dart';
 import '../metric_store.dart';
 import '../people_service.dart';
+import '../release_service.dart';
 import '../team_service.dart';
 import '../team_store.dart';
 import 'age_histogram_view.dart';
@@ -24,6 +25,7 @@ import 'issues_view.dart';
 import 'provider_split_view.dart';
 import 'pulse_view.dart';
 import 'quadrant_view.dart';
+import 'releases_view.dart';
 import 'repo_table_view.dart';
 import 'review_load_view.dart';
 import 'stacked_area_view.dart';
@@ -111,6 +113,12 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
       builder: (d) => IssuesView(data: d),
     ),
     ViewInfo(
+      title: 'Releases & security',
+      blurb: 'What shipped · open Dependabot alerts',
+      icon: Icons.new_releases_outlined,
+      builder: (d) => ReleasesView(data: d),
+    ),
+    ViewInfo(
       title: 'Treemap',
       blurb: 'Repos sized by activity',
       icon: Icons.dashboard,
@@ -192,12 +200,19 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
     });
     try {
       // Run the network passes concurrently (repo activity, People, merged-PR
-      // cycle time, and open issues) so none serializes behind the others.
-      final (activities, people, cycleFetched, issuesResult) = await (
+      // cycle time, open issues, releases + security) so none serializes.
+      final (
+        activities,
+        people,
+        cycleFetched,
+        issuesResult,
+        releaseResult,
+      ) = await (
         ActivityService.computeAll(client: AppHttp.client),
         PeopleService.computeAll(client: AppHttp.client),
         CycleTimeService.computeAll(client: AppHttp.client),
         IssueService.computeAll(client: AppHttp.client),
+        ReleaseService.computeAll(client: AppHttp.client),
       ).wait;
       // Record a trend snapshot from this load too (deduped ~1/day), matching
       // Radar/Teams/Digest, so opening Insights also advances trend history.
@@ -226,6 +241,10 @@ class _InsightsHubPageState extends State<InsightsHubPage> {
           cycleSamples: cycleSamples,
           issueSnapshots: issuesResult.snapshots,
           issuesFailedRepos: issuesResult.failedRepos,
+          releases: releaseResult.releases,
+          security: releaseResult.security,
+          releasesFailedRepos: releaseResult.releasesFailedRepos,
+          securityUnavailableRepos: releaseResult.securityUnavailableRepos,
           loadedAt: DateTime.now(),
         );
         _loading = false;

--- a/lib/views/releases_view.dart
+++ b/lib/views/releases_view.dart
@@ -44,7 +44,7 @@ class ReleasesView extends StatelessWidget {
                   _Muted(
                     text: unavailable > 0
                         ? 'No open alerts in the repos that could be read.'
-                        : 'No open Dependabot alerts. \u2728',
+                        : 'No open Dependabot alerts.',
                   )
                 else
                   for (final s in security) _SecurityTile(repo: s),

--- a/lib/views/releases_view.dart
+++ b/lib/views/releases_view.dart
@@ -27,12 +27,7 @@ class ReleasesView extends StatelessWidget {
       child: hasNothing
           ? ViewEmpty(
               message: (unavailable > 0 || releasesFailed > 0)
-                  ? 'Nothing to show yet.\nReleases couldn\u2019t be fetched '
-                        'for $releasesFailed '
-                        '${releasesFailed == 1 ? 'repo' : 'repos'}; Dependabot '
-                        'alerts weren\u2019t available for $unavailable '
-                        '${unavailable == 1 ? 'repo' : 'repos'}. Check your '
-                        'connection and tokens, then refresh.'
+                  ? _coverageMessage(releasesFailed, unavailable)
                   : 'No recent releases or open alerts.\nReleases from the last '
                         '${ReleaseService.releaseWindow.inDays} days and open '
                         'Dependabot alerts show here (GitHub only).',
@@ -43,7 +38,7 @@ class ReleasesView extends StatelessWidget {
                 _SectionLabel(
                   label:
                       'Open security alerts'
-                      '${unavailable > 0 ? ' · $unavailable unavailable' : ''}',
+                      '${unavailable > 0 ? ' · $unavailable ${_repos(unavailable)} unavailable' : ''}',
                 ),
                 if (security.isEmpty)
                   _Muted(
@@ -58,7 +53,7 @@ class ReleasesView extends StatelessWidget {
                   label:
                       'Recent releases · last '
                       '${ReleaseService.releaseWindow.inDays}d'
-                      '${releasesFailed > 0 ? ' · $releasesFailed unavailable' : ''}',
+                      '${releasesFailed > 0 ? ' · $releasesFailed ${_repos(releasesFailed)} unavailable' : ''}',
                 ),
                 if (releases.isEmpty)
                   _Muted(
@@ -72,6 +67,27 @@ class ReleasesView extends StatelessWidget {
             ),
     );
   }
+
+  static String _repos(int n) => n == 1 ? 'repo' : 'repos';
+
+  /// Empty-state coverage note that mentions only the source(s) that actually
+  /// have a gap (so it never says "0 repos"), plus the likely causes.
+  static String _coverageMessage(int releasesFailed, int unavailable) {
+    final parts = <String>[
+      if (releasesFailed > 0)
+        'releases couldn\u2019t be fetched for $releasesFailed '
+            '${_repos(releasesFailed)}',
+      if (unavailable > 0)
+        'Dependabot alerts weren\u2019t available for $unavailable '
+            '${_repos(unavailable)}',
+    ];
+    return 'Nothing to show yet.\n${_sentenceCase(parts.join('; '))}. '
+        'Check your connection, tokens, and (for alerts) repo permissions, '
+        'then refresh.';
+  }
+
+  static String _sentenceCase(String s) =>
+      s.isEmpty ? s : '${s[0].toUpperCase()}${s.substring(1)}';
 }
 
 const Color _critical = Color(0xFFB71C1C);

--- a/lib/views/releases_view.dart
+++ b/lib/views/releases_view.dart
@@ -1,0 +1,278 @@
+import 'package:flutter/material.dart';
+
+import '../release_service.dart';
+import 'views_common.dart';
+
+/// Two manager/OSS-watcher questions in one place: **what shipped** (recent
+/// releases across every monitored GitHub repo, newest first) and **what's
+/// vulnerable** (repos with open Dependabot alerts, worst severity first).
+/// GitHub-only; Dependabot alerts are owner-scoped so watched repos you don't
+/// administer are noted as unavailable rather than shown as clear.
+class ReleasesView extends StatelessWidget {
+  const ReleasesView({super.key, required this.data});
+
+  final InsightsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final releases = data.releases;
+    final security = data.security;
+    final unavailable = data.securityUnavailableRepos;
+    final releasesFailed = data.releasesFailedRepos;
+    final hasNothing = releases.isEmpty && security.isEmpty;
+
+    return ViewScaffold(
+      title: 'Releases & security',
+      loadedAt: data.loadedAt,
+      child: hasNothing
+          ? ViewEmpty(
+              message: (unavailable > 0 || releasesFailed > 0)
+                  ? 'Nothing to show yet.\nReleases couldn\u2019t be fetched '
+                        'for $releasesFailed '
+                        '${releasesFailed == 1 ? 'repo' : 'repos'}; Dependabot '
+                        'alerts weren\u2019t available for $unavailable '
+                        '${unavailable == 1 ? 'repo' : 'repos'}. Check your '
+                        'connection and tokens, then refresh.'
+                  : 'No recent releases or open alerts.\nReleases from the last '
+                        '${ReleaseService.releaseWindow.inDays} days and open '
+                        'Dependabot alerts show here (GitHub only).',
+            )
+          : ListView(
+              padding: const EdgeInsets.all(12),
+              children: [
+                _SectionLabel(
+                  label:
+                      'Open security alerts'
+                      '${unavailable > 0 ? ' · $unavailable unavailable' : ''}',
+                ),
+                if (security.isEmpty)
+                  _Muted(
+                    text: unavailable > 0
+                        ? 'No open alerts in the repos that could be read.'
+                        : 'No open Dependabot alerts. \u2728',
+                  )
+                else
+                  for (final s in security) _SecurityTile(repo: s),
+                const SizedBox(height: 16),
+                _SectionLabel(
+                  label:
+                      'Recent releases · last '
+                      '${ReleaseService.releaseWindow.inDays}d'
+                      '${releasesFailed > 0 ? ' · $releasesFailed unavailable' : ''}',
+                ),
+                if (releases.isEmpty)
+                  _Muted(
+                    text: releasesFailed > 0
+                        ? 'No releases in the repos that could be read.'
+                        : 'No releases in range.',
+                  )
+                else
+                  for (final r in releases) _ReleaseTile(release: r),
+              ],
+            ),
+    );
+  }
+}
+
+const Color _critical = Color(0xFFB71C1C);
+const Color _high = Color(0xFFD32F2F);
+const Color _medium = Color(0xFFEF6C00);
+const Color _low = Color(0xFF9E9E9E);
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
+      child: Text(
+        label.toUpperCase(),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.6,
+        ),
+      ),
+    );
+  }
+}
+
+class _Muted extends StatelessWidget {
+  const _Muted({required this.text});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
+      child: Text(
+        text,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+class _SecurityTile extends StatelessWidget {
+  const _SecurityTile({required this.repo});
+  final RepoSecurity repo;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final chips = <Widget>[
+      if (repo.critical > 0)
+        _SevChip(label: 'C', count: repo.critical, color: _critical),
+      if (repo.high > 0) _SevChip(label: 'H', count: repo.high, color: _high),
+      if (repo.medium > 0)
+        _SevChip(label: 'M', count: repo.medium, color: _medium),
+      if (repo.low > 0) _SevChip(label: 'L', count: repo.low, color: _low),
+    ];
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            Icon(
+              Icons.gpp_maybe_outlined,
+              size: 18,
+              color: repo.critical > 0 || repo.high > 0 ? _high : _medium,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                repo.repoDisplay,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Wrap(spacing: 4, children: chips),
+            if (repo.capped)
+              Padding(
+                padding: const EdgeInsets.only(left: 4),
+                child: Text(
+                  '100+',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SevChip extends StatelessWidget {
+  const _SevChip({
+    required this.label,
+    required this.count,
+    required this.color,
+  });
+
+  final String label;
+  final int count;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        '$label $count',
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}
+
+class _ReleaseTile extends StatelessWidget {
+  const _ReleaseTile({required this.release});
+  final ReleaseItem release;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final title = release.name != null && release.name != release.tag
+        ? '${release.tag} · ${release.name}'
+        : release.tag;
+    final published = release.publishedAt;
+    final meta = [
+      release.repoDisplay,
+      if (published != null) relativeTime(published),
+      if (release.author != null) release.author!,
+    ].join(' · ');
+    final url = release.url;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      margin: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: url == null ? null : () => openUrl(url),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              Icon(
+                Icons.new_releases_outlined,
+                size: 18,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    Text(
+                      meta,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (url != null)
+                Icon(
+                  Icons.open_in_new,
+                  size: 16,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/views_common.dart
+++ b/lib/views/views_common.dart
@@ -7,6 +7,7 @@ import '../cycle_time.dart';
 import '../issue_service.dart';
 import '../metric_snapshot.dart';
 import '../person.dart';
+import '../release_service.dart';
 import '../team.dart';
 import '../team_service.dart';
 
@@ -26,6 +27,10 @@ class InsightsData {
     List<MergedPrSample> cycleSamples = const [],
     List<RepoIssues> issueSnapshots = const [],
     this.issuesFailedRepos = 0,
+    List<ReleaseItem> releases = const [],
+    List<RepoSecurity> security = const [],
+    this.releasesFailedRepos = 0,
+    this.securityUnavailableRepos = 0,
     required this.loadedAt,
   }) : activities = List.unmodifiable(activities),
        history = Map.unmodifiable({
@@ -39,7 +44,9 @@ class InsightsData {
        people = List.unmodifiable(people),
        ciRunSamples = List.unmodifiable(ciRunSamples),
        cycleSamples = List.unmodifiable(cycleSamples),
-       issueSnapshots = List.unmodifiable(issueSnapshots);
+       issueSnapshots = List.unmodifiable(issueSnapshots),
+       releases = List.unmodifiable(releases),
+       security = List.unmodifiable(security);
 
   final List<RepoActivity> activities;
   final Map<String, List<MetricSnapshot>> history;
@@ -61,6 +68,20 @@ class InsightsData {
   /// How many monitored GitHub repos' issue fetches failed this load, so the
   /// Issues view can show partial-coverage instead of a false "no issues".
   final int issuesFailedRepos;
+
+  /// Recent releases across monitored GitHub repos (newest first).
+  final List<ReleaseItem> releases;
+
+  /// Repos with open Dependabot alerts (worst-severity first).
+  final List<RepoSecurity> security;
+
+  /// GitHub repos whose releases fetch failed, so the releases section can note
+  /// partial coverage instead of a false "nothing shipped".
+  final int releasesFailedRepos;
+
+  /// GitHub repos whose Dependabot alerts weren't readable (commonly repos the
+  /// user doesn't administer), so the security view can note partial coverage.
+  final int securityUnavailableRepos;
   final DateTime loadedAt;
 
   /// Repos whose fetch succeeded (errored repos would read as healthy zeros).

--- a/test/release_service_test.dart
+++ b/test/release_service_test.dart
@@ -1,0 +1,202 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kode_radar/release_service.dart';
+import 'package:kode_radar/repo_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final now = DateTime.utc(2026, 3, 1);
+
+  group('releasesFromGithub', () {
+    test('keeps in-window dated releases, tagged with the repo', () {
+      final body = jsonDecode('''
+      [
+        {"tag_name":"v2.0","name":"Two","published_at":"2026-02-20T00:00:00Z",
+         "author":{"login":"alice"},"html_url":"https://gh/r/v2"},
+        {"tag_name":"v1.0","name":"One","published_at":"2025-10-01T00:00:00Z"}
+      ]
+      ''');
+      final items = ReleaseService.releasesFromGithub(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+        now: now,
+      );
+      // v1.0 is >90 days old → dropped.
+      expect(items, hasLength(1));
+      expect(items.single.tag, 'v2.0');
+      expect(items.single.repoKey, 'github:o/r');
+      expect(items.single.author, 'alice');
+      expect(items.single.publishedAt, DateTime.utc(2026, 2, 20));
+    });
+
+    test('drops undated (draft) releases and non-list bodies', () {
+      final withDraft = jsonDecode('''
+      [
+        {"tag_name":"v3.0"},
+        {"tag_name":"v2.9","published_at":"2026-02-25T00:00:00Z"}
+      ]
+      ''');
+      final items = ReleaseService.releasesFromGithub(
+        withDraft,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+        now: now,
+      );
+      expect(items.map((r) => r.tag), ['v2.9']);
+      expect(
+        ReleaseService.releasesFromGithub(
+          jsonDecode('{"message":"Not Found"}'),
+          repoKey: 'github:o/r',
+          repoDisplay: 'o/r',
+          now: now,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('sortReleases orders newest first, nulls last', () {
+      final items = [
+        const ReleaseItem(
+          repoKey: 'github:o/a',
+          repoDisplay: 'o/a',
+          tag: 'old',
+        ), // null published
+        ReleaseItem(
+          repoKey: 'github:o/b',
+          repoDisplay: 'o/b',
+          tag: 'newer',
+          publishedAt: DateTime.utc(2026, 2, 28),
+        ),
+        ReleaseItem(
+          repoKey: 'github:o/c',
+          repoDisplay: 'o/c',
+          tag: 'newest',
+          publishedAt: DateTime.utc(2026, 3, 1),
+        ),
+      ];
+      final sorted = ReleaseService.sortReleases(items);
+      expect(sorted.map((r) => r.tag), ['newest', 'newer', 'old']);
+    });
+  });
+
+  group('securityFromGithubAlerts', () {
+    test('counts open alerts by severity, ignoring closed/stateless', () {
+      final body = jsonDecode('''
+      [
+        {"state":"open","security_advisory":{"severity":"critical"}},
+        {"state":"open","security_advisory":{"severity":"high"}},
+        {"state":"open","security_advisory":{"severity":"HIGH"}},
+        {"state":"fixed","security_advisory":{"severity":"critical"}},
+        {"state":"open","security_vulnerability":{"severity":"medium"}},
+        {"security_advisory":{"severity":"high"}},
+        {"state":"open"}
+      ]
+      ''');
+      final s = ReleaseService.securityFromGithubAlerts(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      )!;
+      expect(s.critical, 1);
+      expect(s.high, 2, reason: 'the stateless alert is not assumed open');
+      expect(s.medium, 1);
+      expect(s.low, 0);
+      expect(s.total, 4);
+      expect(s.capped, isFalse);
+    });
+
+    test('a full alerts page marks the counts capped', () {
+      final body = [
+        for (var i = 0; i < 100; i++)
+          {
+            'state': 'open',
+            'security_advisory': {'severity': 'low'},
+          },
+      ];
+      final s = ReleaseService.securityFromGithubAlerts(
+        body,
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      )!;
+      expect(s.low, 100);
+      expect(s.capped, isTrue);
+    });
+
+    test('non-list body (e.g. 403 object) → null (unavailable)', () {
+      final s = ReleaseService.securityFromGithubAlerts(
+        jsonDecode('{"message":"Dependabot alerts are disabled"}'),
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      );
+      expect(s, isNull);
+    });
+
+    test('empty list → a zero (all-clear) snapshot, not null', () {
+      final s = ReleaseService.securityFromGithubAlerts(
+        jsonDecode('[]'),
+        repoKey: 'github:o/r',
+        repoDisplay: 'o/r',
+      );
+      expect(s, isNotNull);
+      expect(s!.isEmpty, isTrue);
+    });
+  });
+
+  group('SecurityStats.rankRepos', () {
+    RepoSecurity sec(
+      String key, {
+      int critical = 0,
+      int high = 0,
+      int medium = 0,
+      int low = 0,
+    }) => RepoSecurity(
+      repoKey: key,
+      repoDisplay: key,
+      critical: critical,
+      high: high,
+      medium: medium,
+      low: low,
+    );
+
+    test('drops clear repos and sorts worst-severity first', () {
+      final ranked = SecurityStats.rankRepos([
+        sec('github:o/clean'),
+        sec('github:o/low', low: 9),
+        sec('github:o/crit', critical: 1),
+        sec('github:o/high', high: 3),
+      ]);
+      expect(ranked.map((r) => r.repoKey), [
+        'github:o/crit', // any critical outranks
+        'github:o/high',
+        'github:o/low',
+      ]);
+    });
+
+    test('a single critical outranks many highs', () {
+      final ranked = SecurityStats.rankRepos([
+        sec('github:o/manyhigh', high: 100),
+        sec('github:o/onecrit', critical: 1),
+      ]);
+      expect(ranked.first.repoKey, 'github:o/onecrit');
+    });
+  });
+
+  group('computeAll', () {
+    test(
+      'malformed monitored entries count toward releasesFailedRepos',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          RepoStore.githubKey: <String>['not json', '{"owner":"o"}'],
+        });
+        final result = await ReleaseService.computeAll(now: now);
+        expect(result.releases, isEmpty);
+        expect(result.security, isEmpty);
+        expect(result.releasesFailedRepos, 2);
+      },
+    );
+  });
+}

--- a/test/release_service_test.dart
+++ b/test/release_service_test.dart
@@ -196,6 +196,7 @@ void main() {
         expect(result.releases, isEmpty);
         expect(result.security, isEmpty);
         expect(result.releasesFailedRepos, 2);
+        expect(result.securityUnavailableRepos, 2);
       },
     );
   });

--- a/test/views_smoke_test.dart
+++ b/test/views_smoke_test.dart
@@ -6,6 +6,7 @@ import 'package:kode_radar/cycle_time.dart';
 import 'package:kode_radar/issue_service.dart';
 import 'package:kode_radar/metric_snapshot.dart';
 import 'package:kode_radar/person.dart';
+import 'package:kode_radar/release_service.dart';
 import 'package:kode_radar/team.dart';
 import 'package:kode_radar/team_service.dart';
 import 'package:kode_radar/views/age_histogram_view.dart';
@@ -22,6 +23,7 @@ import 'package:kode_radar/views/issues_view.dart';
 import 'package:kode_radar/views/provider_split_view.dart';
 import 'package:kode_radar/views/pulse_view.dart';
 import 'package:kode_radar/views/quadrant_view.dart';
+import 'package:kode_radar/views/releases_view.dart';
 import 'package:kode_radar/views/repo_table_view.dart';
 import 'package:kode_radar/views/review_load_view.dart';
 import 'package:kode_radar/views/stacked_area_view.dart';
@@ -169,6 +171,33 @@ InsightsData _sampleData() {
       ),
     ],
     issuesFailedRepos: 1,
+    releases: [
+      ReleaseItem(
+        repoKey: 'github:o/alpha',
+        repoDisplay: 'o/alpha',
+        tag: 'v2.1',
+        name: 'Sprint 12',
+        author: 'alice',
+        publishedAt: DateTime.utc(2026, 2, 26),
+        url: 'https://github.com/o/alpha/releases/v2.1',
+      ),
+      const ReleaseItem(
+        repoKey: 'github:o/beta',
+        repoDisplay: 'o/beta',
+        tag: 'v0.9',
+      ),
+    ],
+    security: const [
+      RepoSecurity(
+        repoKey: 'github:o/alpha',
+        repoDisplay: 'o/alpha',
+        critical: 1,
+        high: 2,
+        medium: 3,
+        low: 0,
+      ),
+    ],
+    securityUnavailableRepos: 2,
     loadedAt: DateTime.utc(2026, 3, 1, 13),
   );
 }
@@ -195,6 +224,7 @@ void main() {
     'CycleTime': (d) => CycleTimeView(data: d),
     'TrendDigest': (d) => TrendDigestView(data: d),
     'Issues': (d) => IssuesView(data: d),
+    'ReleasesSecurity': (d) => ReleasesView(data: d),
     'Treemap': (d) => TreemapView(data: d),
     'AgeHistogram': (d) => AgeHistogramView(data: d),
     'Heatmap': (d) => HeatmapView(data: d),


### PR DESCRIPTION
## What

Adds a **"Releases & security" Insights view** that answers two manager / OSS-watcher questions in one place: **what shipped** (recent releases across every monitored GitHub repo, newest first) and **what's vulnerable** (open Dependabot alert counts by severity, worst first).

## How
- **`lib/release_service.dart`** (pure + fetch) — `ReleaseItem` / `RepoSecurity` models + parsers:
  - `releasesFromGithub` reuses `RepoDetailService.parseGithubReleases`, then drops drafts/undated and anything older than a **90-day window**, tagging each with its repo.
  - `securityFromGithubAlerts` counts only **explicitly-open** alerts by `security_advisory.severity` (fallback `security_vulnerability.severity`), and marks the count **capped** at the 100-item page limit.
  - `SecurityStats.rankRepos` compares severities **in order**, so a single critical outranks any number of highs.
  - `computeAll` fetches releases + Dependabot alerts per repo, returning source-health counters (`releasesFailedRepos`, `securityUnavailableRepos`); never throws and isolates per-repo token/fetch failures.
- **`lib/views/releases_view.dart`** — the two-section view; distinguishes all-clear from partial coverage with neutral wording and shows **"100+"** when capped.
- **Wiring** — `InsightsData` gains `releases` / `security` / `releasesFailedRepos` / `securityUnavailableRepos`; the hub fetches this as a 5th concurrent pass.

## Notes / scope
- **GitHub-only** — Azure DevOps has no releases-list / Dependabot equivalent here (a follow-up).
- **Dependabot alerts are owner-scoped**, so watched repos you don't administer are counted **"unavailable"** rather than shown as clear.
- Current-state snapshot — **no new DB table**.

## Review gate
Ran **code-review** (no significant issues; I applied its defensive note to isolate token-resolution failures per repo) and **rubber-duck**, whose findings I addressed: expose the 100-alert cap (`capped` → "100+"), surface `releasesFailedRepos` in the UI, order severities lexicographically (1 critical > N highs), require an explicit `open` state, treat a non-list 200 as a failure, widen the release page to 30, and use neutral "unavailable" wording (no incorrect "admin-only" diagnosis).

## Testing
`dart format` clean, `flutter analyze --fatal-infos` clean, **489 tests pass** (+13 new: release window/sort/null handling, Dependabot severity/open-state/cap counting, worst-severity ranking incl. 1-critical-vs-many-highs, malformed-entry failure counting, view smoke).
